### PR TITLE
Added missing field ClientId to Ticket for ChangePassword and VerifyE…

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ tenant that has been authorized to call the Management API. You can easily set o
 [API Explorer Application](https://auth0.com/docs/tokens/management-api-access-tokens/create-and-authorize-a-machine-to-machine-application)
 in your tenant.
 
-Then simply create a local `.env` file with the following settings:
+Then simply create a local `.env` file in the `management` folder with the following settings:
 
 * `AUTH0_DOMAIN`: The **Domain** of the M2M app
 * `AUTH0_CLIENT_ID`: The **Client ID** of the M2M app

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5632,6 +5632,14 @@ func (t *TenantUniversalLoginColors) String() string {
 	return Stringify(t)
 }
 
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (t *Ticket) GetClientID() string {
+	if t == nil || t.ClientID == nil {
+		return ""
+	}
+	return *t.ClientID
+}
+
 // GetConnectionID returns the ConnectionID field if it's non-nil, zero value otherwise.
 func (t *Ticket) GetConnectionID() string {
 	if t == nil || t.ConnectionID == nil {

--- a/management/management.go
+++ b/management/management.go
@@ -65,7 +65,7 @@ func WithStaticToken(token string) Option {
 // WithInsecure configures management to not use an authentication token and
 // use HTTP instead of HTTPS.
 //
-// This options is available for testing purposes and should not be used in
+// This option is available for testing purposes and should not be used in
 // production.
 func WithInsecure() Option {
 	return func(m *Management) {

--- a/management/ticket.go
+++ b/management/ticket.go
@@ -14,6 +14,13 @@ type Ticket struct {
 	// applied.
 	TTLSec *int `json:"ttl_sec,omitempty"`
 
+	// ID of the client. If provided for tenants using New Universal Login experience,
+	// the user will be prompted to redirect to the default login route of the
+	// corresponding application once the ticket is used.
+	//
+	// Conflicts with: ResultURL
+	ClientID *string `json:"client_id,omitempty"`
+
 	// The connection that provides the identity for which the password is to be
 	// changed. If sending this parameter, the email is also required and the
 	// UserID is invalid.


### PR DESCRIPTION
## Description
Password change and verify email tickets need client id to redirect to the application clientid represents. This applies for Universal login.
This change adds the clientid to the ticket which wasn't present, hence enables redirection for the tickets.

## References
https://community.auth0.com/t/password-change-ticket-missing-clientid/48439

## Testing

Some tests fail because I've not set something up for them. I've just run the tests for ticket.go
Cannot test the redirection to application page after the password change/verify so haven't added any new tests.

- [] This change adds test coverage for new/changed/fixed functionality

<details>
  <summary>Test output for ticket.go PASSED</summary>
  
```
Running tool: /home/pavan/.gvm/gos/go1.17.5/bin/go test -timeout 30s -run ^TestTicket$ github.com/auth0/go-auth0/management

=== RUN   TestTicket
2022/02/18 08:05:28
POST /api/v2/users HTTP/1.1
Host: pavan-test-12345678987654321.us.auth0.com
User-Agent: Go-Auth0-SDK/latest
Content-Length: 149
Content-Type: application/json
Accept-Encoding: gzip

{"connection":"Username-Password-Authentication","email":"chuck@chucknorris.com","username":"chuck","password":"I have a password and its a secret"}

2022/02/18 08:05:30
HTTP/2.0 201 Created
Connection: close
Alt-Svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
Cache-Control: no-cache
Cf-Cache-Status: DYNAMIC
Cf-Ray: 6df3dcc6bba4c940-HYD
Content-Type: application/json; charset=utf-8
Date: Fri, 18 Feb 2022 02:35:30 GMT
Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
Ot-Baggage-Auth0-Request-Id: 6df3dcc6bba4c940
Ot-Tracer-Sampled: true
Ot-Tracer-Spanid: 019ffb462b5052dc
Ot-Tracer-Traceid: 18a50d2644d0596a
Server: cloudflare
Strict-Transport-Security: max-age=31536000
Vary: origin,accept-encoding
X-Content-Type-Options: nosniff
X-Ratelimit-Limit: 10
X-Ratelimit-Remaining: 9
X-Ratelimit-Reset: 1645151731

{"created_at":"2022-02-18T02:35:30.146Z","email":"chuck@chucknorris.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"620f05f24ec0b900709d9c6c","provider":"auth0","isSocial":false}],"name":"chuck@chucknorris.com","nickname":"chuck","picture":"https://s.gravatar.com/avatar/cf4c15514a33fbef56cbdedce8e225d1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fch.png","updated_at":"2022-02-18T02:35:30.146Z","user_id":"auth0|620f05f24ec0b900709d9c6c","username":"chuck"}

=== RUN   TestTicket/VerifyEmail
2022/02/18 08:05:30
POST /api/v2/tickets/email-verification HTTP/1.1
Host: pavan-test-12345678987654321.us.auth0.com
User-Agent: Go-Auth0-SDK/latest
Content-Length: 108
Content-Type: application/json
Accept-Encoding: gzip

{"result_url":"https://example.com/verify-email","user_id":"auth0|620f05f24ec0b900709d9c6c","ttl_sec":3600}

2022/02/18 08:05:30
HTTP/2.0 201 Created
Connection: close
Alt-Svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
Cache-Control: no-cache
Cf-Cache-Status: DYNAMIC
Cf-Ray: 6df3dccacdd0c940-HYD
Content-Type: application/json; charset=utf-8
Date: Fri, 18 Feb 2022 02:35:30 GMT
Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
Ot-Baggage-Auth0-Request-Id: 6df3dccacdd0c940
Ot-Tracer-Sampled: true
Ot-Tracer-Spanid: 478f6d7b497196b8
Ot-Tracer-Traceid: 562a5c6f529fc8b4
Server: cloudflare
Strict-Transport-Security: max-age=31536000
Vary: origin,accept-encoding
X-Content-Type-Options: nosniff
X-Ratelimit-Limit: 10
X-Ratelimit-Remaining: 9
X-Ratelimit-Reset: 1645151732

{"ticket":"https://pavan-test-12345678987654321.us.auth0.com/u/email-verification?ticket=BrZlCz8zoreyJe963OVmP67ybSR9p1kI#"}

    /home/pavan/src/github.com/1pavanb/go-auth0/management/ticket_test.go:38: {
          "result_url": "https://example.com/verify-email",
          "user_id": "auth0|620f05f24ec0b900709d9c6c",
          "ttl_sec": 3600,
          "ticket": "https://pavan-test-12345678987654321.us.auth0.com/u/email-verification?ticket=BrZlCz8zoreyJe963OVmP67ybSR9p1kI#"
        }
=== RUN   TestTicket/ChangePassword
2022/02/18 08:05:30
POST /api/v2/tickets/password-change HTTP/1.1
Host: pavan-test-12345678987654321.us.auth0.com
User-Agent: Go-Auth0-SDK/latest
Content-Length: 171
Content-Type: application/json
Accept-Encoding: gzip

{"result_url":"https://example.com/change-password","user_id":"auth0|620f05f24ec0b900709d9c6c","ttl_sec":3600,"mark_email_as_verified":true,"includeEmailInRedirect":true}

2022/02/18 08:05:31
HTTP/2.0 201 Created
Connection: close
Alt-Svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
Cache-Control: no-cache
Cf-Cache-Status: DYNAMIC
Cf-Ray: 6df3dccdff09c940-HYD
Content-Type: application/json; charset=utf-8
Date: Fri, 18 Feb 2022 02:35:31 GMT
Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
Ot-Baggage-Auth0-Request-Id: 6df3dccdff09c940
Ot-Tracer-Sampled: true
Ot-Tracer-Spanid: 75ae07bf277d1bea
Ot-Tracer-Traceid: 0defd8045875dca2
Server: cloudflare
Strict-Transport-Security: max-age=31536000
Vary: origin,accept-encoding
X-Content-Type-Options: nosniff
X-Ratelimit-Limit: 10
X-Ratelimit-Remaining: 9
X-Ratelimit-Reset: 1645151732

{"ticket":"https://pavan-test-12345678987654321.us.auth0.com/lo/reset?ticket=Wg9W5kQpRdqHvcz7VzE57pQxqU5o0cQd#"}

    /home/pavan/src/github.com/1pavanb/go-auth0/management/ticket_test.go:55: {
          "result_url": "https://example.com/change-password",
          "user_id": "auth0|620f05f24ec0b900709d9c6c",
          "ttl_sec": 3600,
          "ticket": "https://pavan-test-12345678987654321.us.auth0.com/lo/reset?ticket=Wg9W5kQpRdqHvcz7VzE57pQxqU5o0cQd#",
          "mark_email_as_verified": true,
          "includeEmailInRedirect": true
        }
2022/02/18 08:05:31
DELETE /api/v2/users/auth0%7C620f05f24ec0b900709d9c6c HTTP/1.1
Host: pavan-test-12345678987654321.us.auth0.com
User-Agent: Go-Auth0-SDK/latest
Content-Type: application/json
Accept-Encoding: gzip


2022/02/18 08:05:31
HTTP/2.0 204 No Content
Alt-Svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
Cache-Control: no-cache
Cf-Cache-Status: DYNAMIC
Cf-Ray: 6df3dcd118a9c940-HYD
Content-Type: application/json; charset=utf-8
Date: Fri, 18 Feb 2022 02:35:31 GMT
Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
Ot-Baggage-Auth0-Request-Id: 6df3dcd118a9c940
Ot-Tracer-Sampled: true
Ot-Tracer-Spanid: 4ceb84f27fd27970
Ot-Tracer-Traceid: 413d696a7476c2fa
Server: cloudflare
Strict-Transport-Security: max-age=31536000
Vary: origin,accept-encoding
X-Content-Type-Options: nosniff
X-Ratelimit-Limit: 10
X-Ratelimit-Remaining: 9
X-Ratelimit-Reset: 1645151733



--- PASS: TestTicket (3.56s)
    --- PASS: TestTicket/VerifyEmail (0.51s)
    --- PASS: TestTicket/ChangePassword (0.51s)
PASS
ok      github.com/auth0/go-auth0/management    3.561s


> Test run finished at 2/18/2022, 8:05:31 AM <

```
</details>

## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
