### PR TITLE
[DXCDT-44] Add attack protection endpoints

### DIFF
--- a/management/attack_protection.go
+++ b/management/attack_protection.go
@@ -1,0 +1,177 @@
+package management
+
+import (
+	"net/http"
+)
+
+// AttackProtectionManager manages Auth0 Attack Protection settings.
+//
+// See: https://auth0.com/docs/secure/attack-protection
+type AttackProtectionManager struct {
+	*Management
+}
+
+func newAttackProtectionManager(m *Management) *AttackProtectionManager {
+	return &AttackProtectionManager{m}
+}
+
+// BreachedPasswordDetection protects applications from
+// bad actors logging in with stolen credentials.
+//
+// See: https://auth0.com/docs/secure/attack-protection/breached-password-detection
+type BreachedPasswordDetection struct {
+	Enabled                    *bool     `json:"enabled,omitempty"`
+	Shields                    *[]string `json:"shields,omitempty"`
+	AdminNotificationFrequency *[]string `json:"admin_notification_frequency,omitempty"`
+	Method                     *string   `json:"method,omitempty"`
+}
+
+// GetBreachedPasswordDetection retrieves breached password detection settings.
+//
+// Required scope: `read:attack_protection`
+//
+// See: https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_breached_password_detection
+func (m *AttackProtectionManager) GetBreachedPasswordDetection(
+	opts ...RequestOption,
+) (*BreachedPasswordDetection, error) {
+	var breachedPasswordDetection BreachedPasswordDetection
+	err := m.Request(
+		http.MethodGet,
+		m.URI("attack-protection", "breached-password-detection"),
+		&breachedPasswordDetection,
+		opts...,
+	)
+
+	return &breachedPasswordDetection, err
+}
+
+// UpdateBreachedPasswordDetection updates the breached password detection settings.
+//
+// Required scope: `read:attack_protection`
+//
+// See: https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_breached_password_detection
+func (m *AttackProtectionManager) UpdateBreachedPasswordDetection(
+	breachedPasswordDetection *BreachedPasswordDetection,
+	opts ...RequestOption,
+) error {
+	return m.Request(
+		http.MethodPatch,
+		m.URI("attack-protection", "breached-password-detection"),
+		breachedPasswordDetection,
+		opts...,
+	)
+}
+
+// BruteForceProtection safeguards against a single
+// IP address attacking a single user account.
+//
+// See: https://auth0.com/docs/secure/attack-protection/brute-force-protection
+type BruteForceProtection struct {
+	Enabled     *bool     `json:"enabled,omitempty"`
+	Shields     *[]string `json:"shields,omitempty"`
+	AllowList   *[]string `json:"allow_list,omitempty"`
+	Mode        *string   `json:"mode,omitempty"`
+	MaxAttempts *int      `json:"max_attempts,omitempty"`
+}
+
+// GetBruteForceProtection retrieves the brute force configuration.
+//
+// Required scope: `read:attack_protection`
+//
+// See: https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_brute_force_protection
+func (m *AttackProtectionManager) GetBruteForceProtection(
+	opts ...RequestOption,
+) (*BruteForceProtection, error) {
+	var bruteForceProtection BruteForceProtection
+	err := m.Request(
+		http.MethodGet,
+		m.URI("attack-protection", "brute-force-protection"),
+		&bruteForceProtection,
+		opts...,
+	)
+
+	return &bruteForceProtection, err
+}
+
+// UpdateBruteForceProtection updates the brute force configuration.
+//
+// Required scope: `read:attack_protection`
+//
+// See: https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_brute_force_protection
+func (m *AttackProtectionManager) UpdateBruteForceProtection(
+	bruteForceProtection *BruteForceProtection,
+	opts ...RequestOption,
+) error {
+	return m.Request(
+		http.MethodPatch,
+		m.URI("attack-protection", "brute-force-protection"),
+		bruteForceProtection,
+		opts...,
+	)
+}
+
+// SuspiciousIPThrottling blocks traffic from any IP address
+// that rapidly attempts too many logins or signups.
+//
+// See: https://auth0.com/docs/secure/attack-protection/suspicious-ip-throttling
+type SuspiciousIPThrottling struct {
+	Enabled   *bool     `json:"enabled,omitempty"`
+	Shields   *[]string `json:"shields,omitempty"`
+	AllowList *[]string `json:"allow_list,omitempty"`
+	Stage     *Stage    `json:"stage,omitempty"`
+}
+
+// Stage is used to customize thresholds for limiting
+// suspicious traffic in login and sign up flows.
+type Stage struct {
+	PreLogin            *PreLogin            `json:"pre-login,omitempty"`
+	PreUserRegistration *PreUserRegistration `json:"pre-user-registration,omitempty"`
+}
+
+// PreLogin is used to customize thresholds for login flow.
+type PreLogin struct {
+	MaxAttempts *int `json:"max_attempts,omitempty"`
+	Rate        *int `json:"rate,omitempty"`
+}
+
+// PreUserRegistration is used to customize thresholds for sign up flow.
+type PreUserRegistration struct {
+	MaxAttempts *int `json:"max_attempts,omitempty"`
+	Rate        *int `json:"rate,omitempty"`
+}
+
+// GetSuspiciousIPThrottling retrieves the suspicious IP throttling configuration.
+//
+// Required scope: `read:attack_protection`
+//
+// See: https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_suspicious_ip_throttling
+func (m *AttackProtectionManager) GetSuspiciousIPThrottling(
+	opts ...RequestOption,
+) (*SuspiciousIPThrottling, error) {
+	var suspiciousIPThrottling SuspiciousIPThrottling
+	err := m.Request(
+		http.MethodGet,
+		m.URI("attack-protection", "suspicious-ip-throttling"),
+		&suspiciousIPThrottling,
+		opts...,
+	)
+
+	return &suspiciousIPThrottling, err
+}
+
+// UpdateSuspiciousIPThrottling updates the suspicious IP throttling configuration.
+//
+// Required scope: `read:attack_protection`
+//
+// See: https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_suspicious_ip_throttling
+func (m *AttackProtectionManager) UpdateSuspiciousIPThrottling(
+	suspiciousIPThrottling *SuspiciousIPThrottling,
+	opts ...RequestOption,
+) error {
+	return m.Request(
+		http.MethodPatch,
+		m.URI("attack-protection", "suspicious-ip-throttling"),
+		suspiciousIPThrottling,
+		opts...,
+	)
+}

--- a/management/attack_protection_test.go
+++ b/management/attack_protection_test.go
@@ -1,0 +1,99 @@
+package management
+
+import (
+	"testing"
+
+	"github.com/auth0/go-auth0"
+)
+
+func TestAttackProtection(t *testing.T) {
+	t.Run("Get breached password detection settings", func(t *testing.T) {
+		breachedPasswordDetection, err := m.AttackProtection.GetBreachedPasswordDetection()
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", breachedPasswordDetection)
+	})
+
+	t.Run("Update breached password detection settings", func(t *testing.T) {
+		breachedPasswordDetection := &BreachedPasswordDetection{
+			Enabled: auth0.Bool(true),
+			Method:  auth0.String("standard"),
+		}
+
+		err := m.AttackProtection.UpdateBreachedPasswordDetection(breachedPasswordDetection)
+		if err != nil {
+			t.Error(err)
+		}
+
+		breachedPasswordDetection, err = m.AttackProtection.GetBreachedPasswordDetection()
+		if err != nil {
+			t.Error(err)
+		}
+
+		t.Logf("%+v\n", breachedPasswordDetection)
+	})
+
+	t.Run("Get the brute force configuration", func(t *testing.T) {
+		bruteForceProtection, err := m.AttackProtection.GetBruteForceProtection()
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", bruteForceProtection)
+	})
+
+	t.Run("Update the brute force configuration", func(t *testing.T) {
+		bruteForceProtection := &BruteForceProtection{
+			Enabled:     auth0.Bool(true),
+			MaxAttempts: auth0.Int(10),
+		}
+
+		err := m.AttackProtection.UpdateBruteForceProtection(bruteForceProtection)
+		if err != nil {
+			t.Error(err)
+		}
+
+		bruteForceProtection, err = m.AttackProtection.GetBruteForceProtection()
+		if err != nil {
+			t.Error(err)
+		}
+
+		t.Logf("%+v\n", bruteForceProtection)
+	})
+
+	t.Run("Get the suspicious IP throttling configuration", func(t *testing.T) {
+		suspiciousIPThrottling, err := m.AttackProtection.GetSuspiciousIPThrottling()
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", suspiciousIPThrottling)
+	})
+
+	t.Run("Update the suspicious IP throttling configuration", func(t *testing.T) {
+		suspiciousIPThrottling := &SuspiciousIPThrottling{
+			Enabled: auth0.Bool(true),
+			Stage: &Stage{
+				PreLogin: &PreLogin{
+					MaxAttempts: auth0.Int(100),
+					Rate:        auth0.Int(864000),
+				},
+				PreUserRegistration: &PreUserRegistration{
+					MaxAttempts: auth0.Int(50),
+					Rate:        auth0.Int(1200),
+				},
+			},
+		}
+
+		err := m.AttackProtection.UpdateSuspiciousIPThrottling(suspiciousIPThrottling)
+		if err != nil {
+			t.Error(err)
+		}
+
+		suspiciousIPThrottling, err = m.AttackProtection.GetSuspiciousIPThrottling()
+		if err != nil {
+			t.Error(err)
+		}
+
+		t.Logf("%+v\n", suspiciousIPThrottling)
+	})
+}

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -570,6 +570,88 @@ func (b *BrandingUniversalLogin) String() string {
 	return Stringify(b)
 }
 
+// GetAdminNotificationFrequency returns the AdminNotificationFrequency field if it's non-nil, zero value otherwise.
+func (b *BreachedPasswordDetection) GetAdminNotificationFrequency() []string {
+	if b == nil || b.AdminNotificationFrequency == nil {
+		return nil
+	}
+	return *b.AdminNotificationFrequency
+}
+
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (b *BreachedPasswordDetection) GetEnabled() bool {
+	if b == nil || b.Enabled == nil {
+		return false
+	}
+	return *b.Enabled
+}
+
+// GetMethod returns the Method field if it's non-nil, zero value otherwise.
+func (b *BreachedPasswordDetection) GetMethod() string {
+	if b == nil || b.Method == nil {
+		return ""
+	}
+	return *b.Method
+}
+
+// GetShields returns the Shields field if it's non-nil, zero value otherwise.
+func (b *BreachedPasswordDetection) GetShields() []string {
+	if b == nil || b.Shields == nil {
+		return nil
+	}
+	return *b.Shields
+}
+
+// String returns a string representation of BreachedPasswordDetection.
+func (b *BreachedPasswordDetection) String() string {
+	return Stringify(b)
+}
+
+// GetAllowList returns the AllowList field if it's non-nil, zero value otherwise.
+func (b *BruteForceProtection) GetAllowList() []string {
+	if b == nil || b.AllowList == nil {
+		return nil
+	}
+	return *b.AllowList
+}
+
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (b *BruteForceProtection) GetEnabled() bool {
+	if b == nil || b.Enabled == nil {
+		return false
+	}
+	return *b.Enabled
+}
+
+// GetMaxAttempts returns the MaxAttempts field if it's non-nil, zero value otherwise.
+func (b *BruteForceProtection) GetMaxAttempts() int {
+	if b == nil || b.MaxAttempts == nil {
+		return 0
+	}
+	return *b.MaxAttempts
+}
+
+// GetMode returns the Mode field if it's non-nil, zero value otherwise.
+func (b *BruteForceProtection) GetMode() string {
+	if b == nil || b.Mode == nil {
+		return ""
+	}
+	return *b.Mode
+}
+
+// GetShields returns the Shields field if it's non-nil, zero value otherwise.
+func (b *BruteForceProtection) GetShields() []string {
+	if b == nil || b.Shields == nil {
+		return nil
+	}
+	return *b.Shields
+}
+
+// String returns a string representation of BruteForceProtection.
+func (b *BruteForceProtection) String() string {
+	return Stringify(b)
+}
+
 // GetAppType returns the AppType field if it's non-nil, zero value otherwise.
 func (c *Client) GetAppType() string {
 	if c == nil || c.AppType == nil {
@@ -4910,6 +4992,48 @@ func (p *PhoneMessageTypes) String() string {
 	return Stringify(p)
 }
 
+// GetMaxAttempts returns the MaxAttempts field if it's non-nil, zero value otherwise.
+func (p *PreLogin) GetMaxAttempts() int {
+	if p == nil || p.MaxAttempts == nil {
+		return 0
+	}
+	return *p.MaxAttempts
+}
+
+// GetRate returns the Rate field if it's non-nil, zero value otherwise.
+func (p *PreLogin) GetRate() int {
+	if p == nil || p.Rate == nil {
+		return 0
+	}
+	return *p.Rate
+}
+
+// String returns a string representation of PreLogin.
+func (p *PreLogin) String() string {
+	return Stringify(p)
+}
+
+// GetMaxAttempts returns the MaxAttempts field if it's non-nil, zero value otherwise.
+func (p *PreUserRegistration) GetMaxAttempts() int {
+	if p == nil || p.MaxAttempts == nil {
+		return 0
+	}
+	return *p.MaxAttempts
+}
+
+// GetRate returns the Rate field if it's non-nil, zero value otherwise.
+func (p *PreUserRegistration) GetRate() int {
+	if p == nil || p.Rate == nil {
+		return 0
+	}
+	return *p.Rate
+}
+
+// String returns a string representation of PreUserRegistration.
+func (p *PreUserRegistration) String() string {
+	return Stringify(p)
+}
+
 // GetIdentifierFirst returns the IdentifierFirst field if it's non-nil, zero value otherwise.
 func (p *Prompt) GetIdentifierFirst() bool {
 	if p == nil || p.IdentifierFirst == nil {
@@ -5253,6 +5377,64 @@ func (s *SigningKey) GetThumbprint() string {
 
 // String returns a string representation of SigningKey.
 func (s *SigningKey) String() string {
+	return Stringify(s)
+}
+
+// GetPreLogin returns the PreLogin field.
+func (s *Stage) GetPreLogin() *PreLogin {
+	if s == nil {
+		return nil
+	}
+	return s.PreLogin
+}
+
+// GetPreUserRegistration returns the PreUserRegistration field.
+func (s *Stage) GetPreUserRegistration() *PreUserRegistration {
+	if s == nil {
+		return nil
+	}
+	return s.PreUserRegistration
+}
+
+// String returns a string representation of Stage.
+func (s *Stage) String() string {
+	return Stringify(s)
+}
+
+// GetAllowList returns the AllowList field if it's non-nil, zero value otherwise.
+func (s *SuspiciousIPThrottling) GetAllowList() []string {
+	if s == nil || s.AllowList == nil {
+		return nil
+	}
+	return *s.AllowList
+}
+
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (s *SuspiciousIPThrottling) GetEnabled() bool {
+	if s == nil || s.Enabled == nil {
+		return false
+	}
+	return *s.Enabled
+}
+
+// GetShields returns the Shields field if it's non-nil, zero value otherwise.
+func (s *SuspiciousIPThrottling) GetShields() []string {
+	if s == nil || s.Shields == nil {
+		return nil
+	}
+	return *s.Shields
+}
+
+// GetStage returns the Stage field.
+func (s *SuspiciousIPThrottling) GetStage() *Stage {
+	if s == nil {
+		return nil
+	}
+	return s.Stage
+}
+
+// String returns a string representation of SuspiciousIPThrottling.
+func (s *SuspiciousIPThrottling) String() string {
 	return Stringify(s)
 }
 

--- a/management/management.go
+++ b/management/management.go
@@ -166,6 +166,9 @@ type Management struct {
 	// Organization manages Auth0 Organizations.
 	Organization *OrganizationManager
 
+	// AttackProtection manages Auth0 Attack Protection.
+	AttackProtection *AttackProtectionManager
+
 	url         *url.URL
 	basePath    string
 	userAgent   string
@@ -235,6 +238,7 @@ func New(domain string, options ...Option) (*Management, error) {
 	m.Anomaly = newAnomalyManager(m)
 	m.Action = newActionManager(m)
 	m.Organization = newOrganizationManager(m)
+	m.AttackProtection = newAttackProtectionManager(m)
 
 	return m, nil
 }


### PR DESCRIPTION
## Description

In this PR we are adding support for the Attack Protection endpoints found at https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_breached_password_detection. 

**Note**: The tests we are adding follow the style of all the other tests within this repo. 


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [x] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
