### PR TITLE
Add `ShowAsButton` option

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -98,6 +98,9 @@ type Connection struct {
 
 	// Provisioning Ticket URL is Ticket URL for Active Directory/LDAP, etc.
 	ProvisioningTicketURL *string `json:"provisioning_ticket_url,omitempty"`
+
+	// Display connection as a button.
+	ShowAsButton *bool `json:"show_as_button,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1023,6 +1023,14 @@ func (c *Connection) GetProvisioningTicketURL() string {
 	return *c.ProvisioningTicketURL
 }
 
+// GetShowAsButton returns the ShowAsButton field if it's non-nil, zero value otherwise.
+func (c *Connection) GetShowAsButton() bool {
+	if c == nil || c.ShowAsButton == nil {
+		return false
+	}
+	return *c.ShowAsButton
+}
+
 // GetStrategy returns the Strategy field if it's non-nil, zero value otherwise.
 func (c *Connection) GetStrategy() string {
 	if c == nil || c.Strategy == nil {


### PR DESCRIPTION
## Description

Add a new `show_as_button` option to be able to show a connection as a button.

Migrated from https://github.com/go-auth0/auth0/pull/257.

<!--- 
Describe the purpose of this PR along with any background information and the impacts of the proposed change. 
For the benefit of the community, please do not assume prior context.

Provide details that support your chosen implementation, including: 
- breaking changes
- alternatives considered
- changes to the API
- demos (screenshots, videos) if you find that useful
- etc.
-->


## References

<!--- 
Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow post
- Support forum thread
- Related pull requests/issues from other repos

If there are no references, simply delete this section.
-->


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [ ] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [ ] I have added documentation for new/changed functionality in this PR.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
