### PR TITLE
[DXCDT-61] Fix json tags on AllowList for Attack Protection structs

### DIFF
--- a/management/attack_protection.go
+++ b/management/attack_protection.go
@@ -69,7 +69,7 @@ func (m *AttackProtectionManager) UpdateBreachedPasswordDetection(
 type BruteForceProtection struct {
 	Enabled     *bool     `json:"enabled,omitempty"`
 	Shields     *[]string `json:"shields,omitempty"`
-	AllowList   *[]string `json:"allow_list,omitempty"`
+	AllowList   *[]string `json:"allowlist,omitempty"`
 	Mode        *string   `json:"mode,omitempty"`
 	MaxAttempts *int      `json:"max_attempts,omitempty"`
 }
@@ -117,7 +117,7 @@ func (m *AttackProtectionManager) UpdateBruteForceProtection(
 type SuspiciousIPThrottling struct {
 	Enabled   *bool     `json:"enabled,omitempty"`
 	Shields   *[]string `json:"shields,omitempty"`
-	AllowList *[]string `json:"allow_list,omitempty"`
+	AllowList *[]string `json:"allowlist,omitempty"`
 	Stage     *Stage    `json:"stage,omitempty"`
 }
 


### PR DESCRIPTION
## Description

This fixes a small typo on the json tag for the allow list property. 

```json
"allowlist": [
    "143.204.0.105",
    "2600:9000:208f:ca00:d:f5f5:b40:93a1"
],
```

## References

<!--- 
Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow post
- Support forum thread
- Related pull requests/issues from other repos

If there are no references, simply delete this section.
-->


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [ ] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
