### PR TITLE
Add profileData key to UserIdentity

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -178,13 +178,14 @@ type UserIdentityLink struct {
 
 // UserIdentity holds values that validate a User's identity.
 type UserIdentity struct {
-	Connection        *string `json:"connection,omitempty"`
-	UserID            *string `json:"-"`
-	Provider          *string `json:"provider,omitempty"`
-	IsSocial          *bool   `json:"isSocial,omitempty"`
-	AccessToken       *string `json:"access_token,omitempty"`
-	AccessTokenSecret *string `json:"access_token_secret,omitempty"`
-	RefreshToken      *string `json:"refresh_token,omitempty"`
+	Connection        *string                 `json:"connection,omitempty"`
+	UserID            *string                 `json:"-"`
+	Provider          *string                 `json:"provider,omitempty"`
+	IsSocial          *bool                   `json:"isSocial,omitempty"`
+	AccessToken       *string                 `json:"access_token,omitempty"`
+	AccessTokenSecret *string                 `json:"access_token_secret,omitempty"`
+	RefreshToken      *string                 `json:"refresh_token,omitempty"`
+	ProfileData       *map[string]interface{} `json:"profileData,omitempty"`
 }
 
 // UnmarshalJSON is a custom deserializer for the UserIdentity type.

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -400,5 +400,15 @@ func TestUserIdentity(t *testing.T) {
 			}
 			expect.Expect(t, u.GetUserID(), expected.GetUserID())
 		}
+
+		profileData := map[string]interface{}{"picture": "some-picture.jpeg"}
+		b := `{"profileData": {"picture": "some-picture.jpeg"}}`
+		expected := &UserIdentity{ProfileData: &profileData}
+		var u UserIdentity
+		err := json.Unmarshal([]byte(b), &u)
+		if err != nil {
+			t.Error(err)
+		}
+		expect.Expect(t, u.ProfileData, expected.ProfileData)
 	})
 }

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/internal/testing/expect"
 )
@@ -387,28 +389,22 @@ func TestUserIdentity(t *testing.T) {
 	})
 
 	t.Run("UnmarshalJSON", func(t *testing.T) {
-		for b, expected := range map[string]*UserIdentity{
+		for expectedAsString, expected := range map[string]*UserIdentity{
 			`{}`:                {UserID: nil},
 			`{"user_id":1}`:     {UserID: auth0.String("1")},
 			`{"user_id":"1"}`:   {UserID: auth0.String("1")},
 			`{"user_id":"foo"}`: {UserID: auth0.String("foo")},
+			`{"profileData": {"picture": "some-picture.jpeg"}}`: {
+				ProfileData: &map[string]interface{}{
+					"picture": "some-picture.jpeg",
+				},
+			},
 		} {
-			var u UserIdentity
-			err := json.Unmarshal([]byte(b), &u)
-			if err != nil {
+			var actual *UserIdentity
+			if err := json.Unmarshal([]byte(expectedAsString), &actual); err != nil {
 				t.Error(err)
 			}
-			expect.Expect(t, u.GetUserID(), expected.GetUserID())
+			assert.Equal(t, expected, actual)
 		}
-
-		profileData := map[string]interface{}{"picture": "some-picture.jpeg"}
-		b := `{"profileData": {"picture": "some-picture.jpeg"}}`
-		expected := &UserIdentity{ProfileData: &profileData}
-		var u UserIdentity
-		err := json.Unmarshal([]byte(b), &u)
-		if err != nil {
-			t.Error(err)
-		}
-		expect.Expect(t, u.ProfileData, expected.ProfileData)
 	})
 }


### PR DESCRIPTION
## Description

The key `profileData` is present in social Identities (see below), but is not in the `UserIdentity` struct. This means that this SDK cannot be used to retrieve social profile data.
Here's an example of the key within an account with two identities:
```
...
  "identities": [
    {
      "connection": "Initial-Connection",
      "user_id": "123xyz",
      "provider": "auth0",
      "isSocial": false
    },
    {
      "connection": "google-oauth2",
      "user_id": "abc123",
      "provider": "google-oauth2",
      "isSocial": true,
      "profileData": {
         "family_name": "some name",
         "picture": "https://cdn.googleusercontent.com/user/abc123"
      }
    }
  ],
...
```
This PR adds a `profileData` field to `UserIdentity` with type `*map[string]interface{}` so arbitrary schemas of social providers can be deserialized.

## References

This PR was motivated by this thread on the community forum: https://community.auth0.com/t/identity-profiledata-field-not-in-management-api-useridentity/78948


## Testing

- [x] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [ ] I have added documentation for new/changed functionality in this PR.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
