### PR TITLE
Add fields required to support self-managed certificates

### DIFF
--- a/management/custom_domain.go
+++ b/management/custom_domain.go
@@ -22,6 +22,15 @@ type CustomDomain struct {
 	// "disabled", "pending", "pending_verification" or "ready"
 	Status *string `json:"status,omitempty"`
 
+	// The origin domain name that the CNAME or reverse proxy should be pointed
+	// to.
+	OriginDomainName *string `json:"origin_domain_name,omitempty"`
+
+	// For self-managed certificates, when the verification completes for the
+	// first time, this field will be set to the value the reverse proxy should
+	// send in the cname-api-key header field.
+	CNAMEAPIKey *string `json:"cname_api_key,omitempty"`
+
 	// The custom domain verification method. The only allowed value is "txt".
 	VerificationMethod *string `json:"verification_method,omitempty"`
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3540,6 +3540,14 @@ func (c *CreateEnrollmentTicket) String() string {
 	return Stringify(c)
 }
 
+// GetCNAMEAPIKey returns the CNAMEAPIKey field if it's non-nil, zero value otherwise.
+func (c *CustomDomain) GetCNAMEAPIKey() string {
+	if c == nil || c.CNAMEAPIKey == nil {
+		return ""
+	}
+	return *c.CNAMEAPIKey
+}
+
 // GetCustomClientIPHeader returns the CustomClientIPHeader field if it's non-nil, zero value otherwise.
 func (c *CustomDomain) GetCustomClientIPHeader() string {
 	if c == nil || c.CustomClientIPHeader == nil {
@@ -3562,6 +3570,14 @@ func (c *CustomDomain) GetID() string {
 		return ""
 	}
 	return *c.ID
+}
+
+// GetOriginDomainName returns the OriginDomainName field if it's non-nil, zero value otherwise.
+func (c *CustomDomain) GetOriginDomainName() string {
+	if c == nil || c.OriginDomainName == nil {
+		return ""
+	}
+	return *c.OriginDomainName
 }
 
 // GetPrimary returns the Primary field if it's non-nil, zero value otherwise.


### PR DESCRIPTION
## Description

When programmatically managing self-managed certificates, i.e. by requesting the `/verify` endpoint in code, the caller needs needs to know the values of the origin domain name and the `cname-api-key` header to set up the reverse proxy correctly. This change simply adds those two fields to the `CustomDomain` struct.

## References

* auth0/terraform-provider-auth0#118

## Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

## Checklist

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
