### PR TITLE
ESD-16399: Ensure paths are escaped when constructing URI

### DIFF
--- a/management/management.go
+++ b/management/management.go
@@ -246,11 +246,18 @@ func New(domain string, options ...Option) (*Management, error) {
 // URI returns the absolute URL of the Management API with any path segments
 // appended to the end.
 func (m *Management) URI(path ...string) string {
-	return (&url.URL{
+	var escapedPath []string
+	for _, unescapedPath := range path {
+		escapedPath = append(escapedPath, url.PathEscape(unescapedPath))
+	}
+
+	absoluteURL := &url.URL{
 		Scheme: m.url.Scheme,
 		Host:   m.url.Host,
-		Path:   m.basePath + "/" + strings.Join(path, "/"),
-	}).String()
+		Path:   m.basePath + "/" + strings.Join(escapedPath, "/"),
+	}
+
+	return absoluteURL.String()
 }
 
 // NewRequest returns a new HTTP request. If the payload is not nil it will be


### PR DESCRIPTION
## Description

In this PR we are making sure to escape input paths when constructing a URI so we don't end up with invalid characters within the constructed URI like for example forward slashes. 


## References

<!--- 
Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow post
- Support forum thread
- Related pull requests/issues from other repos

If there are no references, simply delete this section.
-->


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [ ] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [ ] I have reviewed my own code beforehand.
- [ ] I have added documentation for new/changed functionality in this PR.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [ ] The correct base branch is being used, if not `main`.
