### PR TITLE
[DXCDT-110] [DXCDT-113] Refactor email, email_template tests

### DIFF
--- a/management/email_template_test.go
+++ b/management/email_template_test.go
@@ -4,29 +4,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/auth0/go-auth0"
 )
 
-func TestEmailTemplate(t *testing.T) {
-	e := &Email{
-		Name:               auth0.String("smtp"),
-		Enabled:            auth0.Bool(true),
-		DefaultFromAddress: auth0.String("no-reply@example.com"),
-		Credentials: &EmailCredentials{
-			SMTPHost: auth0.String("smtp.example.com"),
-			SMTPPort: auth0.Int(587),
-			SMTPUser: auth0.String("user"),
-			SMTPPass: auth0.String("pass"),
-		},
-	}
-
-	err := m.Email.Create(e)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer m.Email.Delete()
-
-	et := &EmailTemplate{
+func TestEmailTemplateManager_Create(t *testing.T) {
+	template := &EmailTemplate{
 		Template:  auth0.String("verify_email"),
 		Body:      auth0.String("<html><body><h1>Verify your email</h1></body></html>"),
 		From:      auth0.String("me@example.com"),
@@ -36,51 +21,85 @@ func TestEmailTemplate(t *testing.T) {
 		Enabled:   auth0.Bool(true),
 	}
 
-	t.Run("Create", func(t *testing.T) {
-		err = m.EmailTemplate.Create(et)
-		if err != nil {
-			if err, ok := err.(Error); ok && err.Status() != http.StatusConflict {
-				t.Fatal(err)
-			}
-		}
-		t.Logf("%v\n", et)
-	})
-
-	t.Run("Read", func(t *testing.T) {
-		et, err = m.EmailTemplate.Read(auth0.StringValue(et.Template))
-		if err != nil {
+	err := m.EmailTemplate.Create(template)
+	if err != nil {
+		if err, ok := err.(Error); ok && err.Status() != http.StatusConflict {
 			t.Error(err)
 		}
-		t.Logf("%v\n", et)
-	})
+	}
 
-	t.Run("Update", func(t *testing.T) {
-		err = m.EmailTemplate.Update(auth0.StringValue(et.Template), &EmailTemplate{
-			Body: auth0.String("<html><body><h1>Let's get you verified!</h1></body></html>"),
-		})
-		if err != nil {
+	defer cleanupEmailTemplate(t, template.GetTemplate())
+}
+
+func TestEmailTemplateManager_Read(t *testing.T) {
+	expectedTemplate := givenAnEmailTemplate(t)
+	defer cleanupEmailTemplate(t, expectedTemplate.GetTemplate())
+
+	actualTemplate, err := m.EmailTemplate.Read(expectedTemplate.GetTemplate())
+
+	assert.NoError(t, err)
+	assert.ObjectsAreEqual(expectedTemplate, actualTemplate)
+}
+
+func TestEmailTemplateManager_Update(t *testing.T) {
+	template := givenAnEmailTemplate(t)
+	defer cleanupEmailTemplate(t, template.GetTemplate())
+
+	expectedBody := "<html><body><h1>Let's get you verified!</h1></body></html>"
+	err := m.EmailTemplate.Update(
+		template.GetTemplate(),
+		&EmailTemplate{
+			Body: &expectedBody,
+		},
+	)
+	assert.NoError(t, err)
+
+	actualTemplate, err := m.EmailTemplate.Read(template.GetTemplate())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBody, actualTemplate.GetBody())
+}
+
+func TestEmailTemplateManager_Replace(t *testing.T) {
+	givenAnEmailProvider(t)
+	defer cleanupEmailProvider(t)
+
+	template := givenAnEmailTemplate(t)
+	defer cleanupEmailTemplate(t, template.GetTemplate())
+
+	template.Subject = auth0.String("Let's get you verified!")
+	template.Body = auth0.String("<html><body><h1>Let's get you verified!</h1></body></html>")
+	template.From = auth0.String("someone@example.com")
+
+	err := m.EmailTemplate.Replace(template.GetTemplate(), template)
+	assert.NoError(t, err)
+}
+
+func givenAnEmailTemplate(t *testing.T) *EmailTemplate {
+	t.Helper()
+
+	template := &EmailTemplate{
+		Template:  auth0.String("verify_email"),
+		Body:      auth0.String("<html><body><h1>Verify your email</h1></body></html>"),
+		From:      auth0.String("me@example.com"),
+		ResultURL: auth0.String("https://www.example.com/verify-email"),
+		Subject:   auth0.String("Verify your email"),
+		Syntax:    auth0.String("liquid"),
+		Enabled:   auth0.Bool(true),
+	}
+
+	err := m.EmailTemplate.Create(template)
+	if err != nil {
+		if err, ok := err.(Error); ok && err.Status() != http.StatusConflict {
 			t.Error(err)
 		}
-		t.Logf("%v\n", et)
-	})
+	}
 
-	t.Run("Replace", func(t *testing.T) {
-		et.Subject = auth0.String("Let's get you verified!")
-		et.Body = auth0.String("<html><body><h1>Let's get you verified!</h1></body></html>")
-		et.From = auth0.String("someone@example.com")
+	return template
+}
 
-		err = m.EmailTemplate.Replace(auth0.StringValue(et.Template), et)
-		if err != nil {
-			t.Error(err)
-		}
-		t.Logf("%v\n", et)
-	})
+func cleanupEmailTemplate(t *testing.T, templateName string) {
+	t.Helper()
 
-	t.Run("Delete", func(t *testing.T) {
-		et.Enabled = auth0.Bool(false)
-		err = m.EmailTemplate.Update(auth0.StringValue(et.Template), et)
-		if err != nil {
-			t.Error(err)
-		}
-	})
+	err := m.EmailTemplate.Update(templateName, &EmailTemplate{Enabled: auth0.Bool(false)})
+	require.NoError(t, err)
 }

--- a/management/email_test.go
+++ b/management/email_test.go
@@ -1,14 +1,17 @@
 package management
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/auth0/go-auth0"
-	"github.com/auth0/go-auth0/internal/testing/expect"
 )
 
-func TestEmail(t *testing.T) {
-	e := &Email{
+func TestEmailManager_Create(t *testing.T) {
+	emailProvider := &Email{
 		Name:               auth0.String("smtp"),
 		Enabled:            auth0.Bool(true),
 		DefaultFromAddress: auth0.String("no-reply@example.com"),
@@ -20,44 +23,83 @@ func TestEmail(t *testing.T) {
 		},
 	}
 
-	var err error
+	err := m.Email.Create(emailProvider)
+	assert.NoError(t, err)
 
-	t.Run("Create", func(t *testing.T) {
-		err = m.Email.Create(e)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Logf("%v\n", e)
-	})
+	defer cleanupEmailProvider(t)
+}
 
-	t.Run("Read", func(t *testing.T) {
-		e, err = m.Email.Read()
-		if err != nil {
-			t.Error(err)
-		}
-		expect.Expect(t, e.GetName(), "smtp")
-		expect.Expect(t, e.GetEnabled(), true)
-		expect.Expect(t, e.GetDefaultFromAddress(), "no-reply@example.com")
-		expect.Expect(t, e.GetCredentials().GetSMTPUser(), "user")
-		expect.Expect(t, e.GetCredentials().GetSMTPPass(), "") // passwords are not returned from Auth0
-		t.Logf("%v\n", e)
-	})
+func TestEmailManager_Read(t *testing.T) {
+	expectedEmailProvider := givenAnEmailProvider(t)
+	defer cleanupEmailProvider(t)
 
-	t.Run("Update", func(t *testing.T) {
-		e.Enabled = auth0.Bool(false)
-		e.DefaultFromAddress = auth0.String("info@example.com")
+	actualEmailProvider, err := m.Email.Read()
 
-		err = m.Email.Update(e)
-		if err != nil {
-			t.Error(err)
-		}
-		t.Logf("%v\n", e)
-	})
+	assert.NoError(t, err)
+	assert.Equal(t, expectedEmailProvider.GetName(), actualEmailProvider.GetName())
+	assert.Equal(t, expectedEmailProvider.GetEnabled(), actualEmailProvider.GetEnabled())
+	assert.Equal(t, expectedEmailProvider.GetDefaultFromAddress(), actualEmailProvider.GetDefaultFromAddress())
+	assert.Equal(
+		t,
+		expectedEmailProvider.GetCredentials().GetSMTPUser(),
+		actualEmailProvider.GetCredentials().GetSMTPUser(),
+	)
+	assert.Equal(
+		t,
+		"",
+		actualEmailProvider.GetCredentials().GetSMTPPass(),
+	) // Passwords are not returned from the Auth0 API.
+}
 
-	t.Run("Delete", func(t *testing.T) {
-		err = m.Email.Delete()
-		if err != nil {
-			t.Error(err)
-		}
-	})
+func TestEmailManager_Update(t *testing.T) {
+	emailProvider := givenAnEmailProvider(t)
+	defer cleanupEmailProvider(t)
+
+	emailProvider.Enabled = auth0.Bool(false)
+	emailProvider.DefaultFromAddress = auth0.String("info@example.com")
+
+	err := m.Email.Update(emailProvider)
+	assert.NoError(t, err)
+
+	actualEmailProvider, err := m.Email.Read()
+	assert.NoError(t, err)
+
+	assert.False(t, actualEmailProvider.GetEnabled())
+	assert.Equal(t, "info@example.com", actualEmailProvider.GetDefaultFromAddress())
+}
+
+func TestEmailManager_Delete(t *testing.T) {
+	givenAnEmailProvider(t)
+
+	err := m.Email.Delete()
+	assert.NoError(t, err)
+
+	_, err = m.Email.Read()
+	assert.Error(t, err)
+	assert.Implements(t, (*Error)(nil), err)
+	assert.Equal(t, http.StatusNotFound, err.(Error).Status())
+}
+
+func givenAnEmailProvider(t *testing.T) *Email {
+	emailProvider := &Email{
+		Name:               auth0.String("smtp"),
+		Enabled:            auth0.Bool(true),
+		DefaultFromAddress: auth0.String("no-reply@example.com"),
+		Credentials: &EmailCredentials{
+			SMTPHost: auth0.String("smtp.example.com"),
+			SMTPPort: auth0.Int(587),
+			SMTPUser: auth0.String("user"),
+			SMTPPass: auth0.String("pass"),
+		},
+	}
+
+	err := m.Email.Create(emailProvider)
+	require.NoError(t, err)
+
+	return emailProvider
+}
+
+func cleanupEmailProvider(t *testing.T) {
+	err := m.Email.Delete()
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Description

Refactor email, email_template tests so they can be ran in any order and they clean up the test tenant after running.

<!--- 
Describe the purpose of this PR along with any background information and the impacts of the proposed change. 
For the benefit of the community, please do not assume prior context.

Provide details that support your chosen implementation, including: 
- breaking changes
- alternatives considered
- changes to the API
- demos (screenshots, videos) if you find that useful
- etc.
-->


## References

<!--- 
Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow post
- Support forum thread
- Related pull requests/issues from other repos

If there are no references, simply delete this section.
-->


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [x] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
