### PR TITLE
Add support for webauthn_platform_first_factor_prompt flag in the prompt

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5107,6 +5107,14 @@ func (p *Prompt) GetIdentifierFirst() bool {
 	return *p.IdentifierFirst
 }
 
+// GetWebAuthnPlatformFirstFactor returns the WebAuthnPlatformFirstFactor field if it's non-nil, zero value otherwise.
+func (p *Prompt) GetWebAuthnPlatformFirstFactor() bool {
+	if p == nil || p.WebAuthnPlatformFirstFactor == nil {
+		return false
+	}
+	return *p.WebAuthnPlatformFirstFactor
+}
+
 // String returns a string representation of Prompt.
 func (p *Prompt) String() string {
 	return Stringify(p)

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -6507,6 +6507,16 @@ func TestPrompt_GetIdentifierFirst(tt *testing.T) {
 	p.GetIdentifierFirst()
 }
 
+func TestPrompt_GetWebAuthnPlatformFirstFactor(tt *testing.T) {
+	var zeroValue bool
+	p := &Prompt{WebAuthnPlatformFirstFactor: &zeroValue}
+	p.GetWebAuthnPlatformFirstFactor()
+	p = &Prompt{}
+	p.GetWebAuthnPlatformFirstFactor()
+	p = nil
+	p.GetWebAuthnPlatformFirstFactor()
+}
+
 func TestPrompt_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &Prompt{}

--- a/management/prompt.go
+++ b/management/prompt.go
@@ -9,6 +9,9 @@ type Prompt struct {
 
 	// IdentifierFirst determines if the login screen prompts for just the identifier, identifier and password first.
 	IdentifierFirst *bool `json:"identifier_first,omitempty"`
+
+	// WebAuthnPlatformFirstFactor determines if the login screen uses identifier and biometrics first.
+	WebAuthnPlatformFirstFactor *bool `json:"webauthn_platform_first_factor,omitempty"`
 }
 
 // PromptManager is used for managing a Prompt.

--- a/management/prompt_test.go
+++ b/management/prompt_test.go
@@ -14,36 +14,41 @@ func TestPrompt(t *testing.T) {
 
 	t.Cleanup(func() {
 		err := m.Prompt.Update(&Prompt{
-			UniversalLoginExperience: "classic",
-			IdentifierFirst:          auth0.Bool(false),
+			UniversalLoginExperience:    "classic",
+			IdentifierFirst:             auth0.Bool(false),
+			WebAuthnPlatformFirstFactor: auth0.Bool(false),
 		})
 		require.NoError(t, err)
 	})
 
-	t.Run("Update to the new identifier first experience", func(t *testing.T) {
+	t.Run("Update to the new identifier first experience with biometrics", func(t *testing.T) {
 		err := m.Prompt.Update(&Prompt{
-			UniversalLoginExperience: "new",
-			IdentifierFirst:          auth0.Bool(true),
+			UniversalLoginExperience:    "new",
+			IdentifierFirst:             auth0.Bool(true),
+			WebAuthnPlatformFirstFactor: auth0.Bool(true),
 		})
 		assert.NoError(t, err)
 
 		ps, err := m.Prompt.Read()
 		assert.NoError(t, err)
 		assert.Equal(t, "new", ps.UniversalLoginExperience)
-		assert.Equal(t, true, ps.GetIdentifierFirst())
+		assert.True(t, ps.GetIdentifierFirst())
+		assert.True(t, ps.GetWebAuthnPlatformFirstFactor())
 	})
 
-	t.Run("Update to the classic non identifier first experience", func(t *testing.T) {
+	t.Run("Update to the classic non identifier first experience without biometrics", func(t *testing.T) {
 		err := m.Prompt.Update(&Prompt{
-			UniversalLoginExperience: "classic",
-			IdentifierFirst:          auth0.Bool(false),
+			UniversalLoginExperience:    "classic",
+			IdentifierFirst:             auth0.Bool(false),
+			WebAuthnPlatformFirstFactor: auth0.Bool(false),
 		})
 		assert.NoError(t, err)
 
 		ps, err := m.Prompt.Read()
 		assert.NoError(t, err)
 		assert.Equal(t, "classic", ps.UniversalLoginExperience)
-		assert.Equal(t, false, ps.GetIdentifierFirst())
+		assert.False(t, ps.GetIdentifierFirst())
+		assert.False(t, ps.GetWebAuthnPlatformFirstFactor())
 	})
 }
 

--- a/management/testdata/recordings/TestPrompt.yaml
+++ b/management/testdata/recordings/TestPrompt.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"universal_login_experience":"new","identifier_first":true}
+      {"universal_login_experience":"new","identifier_first":true,"webauthn_platform_first_factor":true}
     form: {}
     headers:
       Content-Type:
@@ -13,7 +13,7 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts
     method: PATCH
   response:
-    body: '{"universal_login_experience":"new","identifier_first":true}'
+    body: '{"universal_login_experience":"new","identifier_first":true,"webauthn_platform_first_factor":true}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -32,7 +32,7 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts
     method: GET
   response:
-    body: '{"universal_login_experience":"new","identifier_first":true}'
+    body: '{"universal_login_experience":"new","identifier_first":true,"webauthn_platform_first_factor":true}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -41,7 +41,7 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"universal_login_experience":"classic","identifier_first":false}
+      {"universal_login_experience":"classic","identifier_first":false,"webauthn_platform_first_factor":false}
     form: {}
     headers:
       Content-Type:
@@ -51,7 +51,7 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts
     method: PATCH
   response:
-    body: '{"universal_login_experience":"classic","identifier_first":false}'
+    body: '{"universal_login_experience":"classic","identifier_first":false,"webauthn_platform_first_factor":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -70,7 +70,7 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts
     method: GET
   response:
-    body: '{"universal_login_experience":"classic","identifier_first":false}'
+    body: '{"universal_login_experience":"classic","identifier_first":false,"webauthn_platform_first_factor":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -79,7 +79,7 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"universal_login_experience":"classic","identifier_first":false}
+      {"universal_login_experience":"classic","identifier_first":false,"webauthn_platform_first_factor":false}
     form: {}
     headers:
       Content-Type:
@@ -89,7 +89,7 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts
     method: PATCH
   response:
-    body: '{"universal_login_experience":"classic","identifier_first":false}'
+    body: '{"universal_login_experience":"classic","identifier_first":false,"webauthn_platform_first_factor":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8


### PR DESCRIPTION
## Description
This PR adds support for the `webauthn_platform_first_factor_prompt` boolean flag in the prompt. This is required for proper support of it in the [Auth0 Terraform provider](https://github.com/auth0/terraform-provider-auth0/issues/102).

<!--- 
Describe the purpose of this PR along with any background information and the impacts of the proposed change. 
For the benefit of the community, please do not assume prior context.

Provide details that support your chosen implementation, including: 
- breaking changes
- alternatives considered
- changes to the API
- demos (screenshots, videos) if you find that useful
- etc.
-->


## References

https://github.com/auth0/terraform-provider-auth0/issues/102


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [x] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
