### PR TITLE
Request function in management.go return the http.response also

### DIFF
--- a/management/organization.go
+++ b/management/organization.go
@@ -1,5 +1,7 @@
 package management
 
+import "net/http"
+
 // Organization is used to allow B2B customers to better manage
 // their partners and customers, and to customize the ways that
 // end-users access their applications.
@@ -280,9 +282,9 @@ func (m *OrganizationManager) Invitations(id string, opts ...RequestOption) (i *
 // CreateInvitation creates invitations to an organization.
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/post_invitations
-func (m *OrganizationManager) CreateInvitation(id string, i *OrganizationInvitation, opts ...RequestOption) (err error) {
-	err = m.Request("POST", m.URI("organizations", id, "invitations"), &i, opts...)
-	return
+func (m *OrganizationManager) CreateInvitation(id string, i *OrganizationInvitation, opts ...RequestOption) (res *http.Response, err error) {
+	res, err = m.Invite_Request("POST", m.URI("organizations", id, "invitations"), &i, opts...)
+	return res, nil
 }
 
 // Invitation retrieves an invitation to an organization.

--- a/management/organization_test.go
+++ b/management/organization_test.go
@@ -167,7 +167,8 @@ func TestOrganizationManager_CreateInvitation(t *testing.T) {
 		ClientID: client.ClientID,
 	}
 
-	err := m.Organization.CreateInvitation(org.GetID(), orgInvite)
+	res, err := m.Organization.CreateInvitation(org.GetID(), orgInvite)
+	assert.NotEmpty(t, res)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, orgInvite.GetID())
 }
@@ -322,9 +323,9 @@ func givenAnOrganizationInvitation(t *testing.T, orgID string) *OrganizationInvi
 		ClientID: client.ClientID,
 	}
 
-	err := m.Organization.CreateInvitation(orgID, orgInvite)
+	res, err := m.Organization.CreateInvitation(orgID, orgInvite)
 	require.NoError(t, err)
-
+	assert.NotEmpty(t, res)
 	return orgInvite
 }
 


### PR DESCRIPTION
## Description

For now the request function in management.go did not return the http response which is required for implementing many features.

In this PR I have created a alternate http request function ( Invite_Request ) which basically return the http response of CreateInvitaion back.

I want our request fucntion in the management.go to return http.response

![image](https://user-images.githubusercontent.com/106047034/171560526-8da7feed-1be2-48b1-a84e-ecfb31a3e6ed.png)



## References

My team needed this so I made the changes however we could create a issue and discuss it over there.


## Testing


Testing remains intact. It could be tested as it has done before the changes. No changes requrired in test file.



## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [ ] I have added documentation for new/changed functionality in this PR.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [ ] The correct base branch is being used, if not `main`.
