### PR TITLE
Adding disable sign out field to SAMLP connection options

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -762,6 +762,7 @@ type ConnectionOptionsSAML struct {
 	DomainAliases      []interface{}                      `json:"domain_aliases,omitempty"`
 	SignInEndpoint     *string                            `json:"signInEndpoint,omitempty"`
 	SignOutEndpoint    *string                            `json:"signOutEndpoint,omitempty"`
+	DisableSignOut     *bool                              `json:"disableSignout,omitempty"`
 	SignatureAlgorithm *string                            `json:"signatureAlgorithm,omitempty"`
 	DigestAglorithm    *string                            `json:"digestAlgorithm,omitempty"`
 	MetadataXML        *string                            `json:"metadataXml,omitempty"`

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3007,6 +3007,14 @@ func (c *ConnectionOptionsSAML) GetDigestAglorithm() string {
 	return *c.DigestAglorithm
 }
 
+// GetDisableSignOut returns the DisableSignOut field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetDisableSignOut() bool {
+	if c == nil || c.DisableSignOut == nil {
+		return false
+	}
+	return *c.DisableSignOut
+}
+
 // GetEntityID returns the EntityID field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSAML) GetEntityID() string {
 	if c == nil || c.EntityID == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -3807,6 +3807,16 @@ func TestConnectionOptionsSAML_GetDigestAglorithm(tt *testing.T) {
 	c.GetDigestAglorithm()
 }
 
+func TestConnectionOptionsSAML_GetDisableSignOut(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsSAML{DisableSignOut: &zeroValue}
+	c.GetDisableSignOut()
+	c = &ConnectionOptionsSAML{}
+	c.GetDisableSignOut()
+	c = nil
+	c.GetDisableSignOut()
+}
+
 func TestConnectionOptionsSAML_GetEntityID(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsSAML{EntityID: &zeroValue}


### PR DESCRIPTION
## Description

As noted in [this Terraform provider issue](https://github.com/auth0/terraform-provider-auth0/issues/161), the `disableSignout` field is absent from SAMLP connection options, but is very much a real configuration. This PR adds this field in to then enable for the Terraform provider.


## References

[Original issue](https://github.com/auth0/terraform-provider-auth0/issues/161)

## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [x] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [ ] I have reviewed my own code beforehand.
- [ ] I have added documentation for new/changed functionality in this PR.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [ ] The correct base branch is being used, if not `main`.
