### PR TITLE
Adding PKCE enablement field to OAuth2 connection options

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -645,7 +645,8 @@ type ConnectionOptionsOAuth2 struct {
 	LogoURL            *string   `json:"icon_url,omitempty"`
 	// Scripts for the connection
 	// Allowed keys are: "fetchUserProfile"
-	Scripts map[string]interface{} `json:"scripts,omitempty"`
+	Scripts     map[string]interface{} `json:"scripts,omitempty"`
+	PKCEEnabled *bool                  `json:"pkce_enabled,omitempty"`
 }
 
 // Scopes returns the scopes for ConnectionOptionsOAuth2.

--- a/management/connection.go
+++ b/management/connection.go
@@ -643,10 +643,10 @@ type ConnectionOptionsOAuth2 struct {
 	SetUserAttributes  *string   `json:"set_user_root_attributes,omitempty"`
 	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`
 	LogoURL            *string   `json:"icon_url,omitempty"`
+	PKCEEnabled        *bool     `json:"pkce_enabled,omitempty"`
 	// Scripts for the connection
 	// Allowed keys are: "fetchUserProfile"
-	Scripts     map[string]interface{} `json:"scripts,omitempty"`
-	PKCEEnabled *bool                  `json:"pkce_enabled,omitempty"`
+	Scripts map[string]interface{} `json:"scripts,omitempty"`
 }
 
 // Scopes returns the scopes for ConnectionOptionsOAuth2.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2763,6 +2763,14 @@ func (c *ConnectionOptionsOAuth2) GetNonPersistentAttrs() []string {
 	return *c.NonPersistentAttrs
 }
 
+// GetPKCEEnabled returns the PKCEEnabled field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOAuth2) GetPKCEEnabled() bool {
+	if c == nil || c.PKCEEnabled == nil {
+		return false
+	}
+	return *c.PKCEEnabled
+}
+
 // GetScope returns the Scope field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsOAuth2) GetScope() string {
 	if c == nil || c.Scope == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -3495,6 +3495,16 @@ func TestConnectionOptionsOAuth2_GetNonPersistentAttrs(tt *testing.T) {
 	c.GetNonPersistentAttrs()
 }
 
+func TestConnectionOptionsOAuth2_GetPKCEEnabled(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsOAuth2{PKCEEnabled: &zeroValue}
+	c.GetPKCEEnabled()
+	c = &ConnectionOptionsOAuth2{}
+	c.GetPKCEEnabled()
+	c = nil
+	c.GetPKCEEnabled()
+}
+
 func TestConnectionOptionsOAuth2_GetScope(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsOAuth2{Scope: &zeroValue}


### PR DESCRIPTION
## Description

Adding the `pkce_enabled` field for OAuth2 connection options which controls the enablement of Proof Key for Code Exchange (PKCE).


## References

- [Authorization Code Flow with Proof Key for Code Exchange (PKCE)](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-proof-key-for-code-exchange-pkce)
- [Original requesting Github issue](https://github.com/auth0/terraform-provider-auth0/issues/49)


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [x] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
