### PR TITLE
Add support for tenant `session_cookie` property

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5607,6 +5607,14 @@ func (t *Tenant) GetSandboxVersion() string {
 	return *t.SandboxVersion
 }
 
+// GetSessionCookie returns the SessionCookie field.
+func (t *Tenant) GetSessionCookie() *TenantSessionCookie {
+	if t == nil {
+		return nil
+	}
+	return t.SessionCookie
+}
+
 // GetSessionLifetime returns the SessionLifetime field if it's non-nil, zero value otherwise.
 func (t *Tenant) GetSessionLifetime() float64 {
 	if t == nil || t.SessionLifetime == nil {
@@ -5842,6 +5850,19 @@ func (t *TenantGuardianMFAPage) GetHTML() string {
 
 // String returns a string representation of TenantGuardianMFAPage.
 func (t *TenantGuardianMFAPage) String() string {
+	return Stringify(t)
+}
+
+// GetMode returns the Mode field if it's non-nil, zero value otherwise.
+func (t *TenantSessionCookie) GetMode() string {
+	if t == nil || t.Mode == nil {
+		return ""
+	}
+	return *t.Mode
+}
+
+// String returns a string representation of TenantSessionCookie.
+func (t *TenantSessionCookie) String() string {
 	return Stringify(t)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -7129,6 +7129,13 @@ func TestTenant_GetSandboxVersion(tt *testing.T) {
 	t.GetSandboxVersion()
 }
 
+func TestTenant_GetSessionCookie(tt *testing.T) {
+	t := &Tenant{}
+	t.GetSessionCookie()
+	t = nil
+	t.GetSessionCookie()
+}
+
 func TestTenant_GetSessionLifetime(tt *testing.T) {
 	var zeroValue float64
 	t := &Tenant{SessionLifetime: &zeroValue}
@@ -7429,6 +7436,24 @@ func TestTenantGuardianMFAPage_GetHTML(tt *testing.T) {
 func TestTenantGuardianMFAPage_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &TenantGuardianMFAPage{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestTenantSessionCookie_GetMode(tt *testing.T) {
+	var zeroValue string
+	t := &TenantSessionCookie{Mode: &zeroValue}
+	t.GetMode()
+	t = &TenantSessionCookie{}
+	t.GetMode()
+	t = nil
+	t.GetMode()
+}
+
+func TestTenantSessionCookie_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &TenantSessionCookie{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/management/tenant.go
+++ b/management/tenant.go
@@ -302,6 +302,7 @@ type TenantDeviceFlow struct {
 }
 
 type TenantSessionCookie struct {
+	// Behavior of the tenant's session cookie, accepts either 'persistent' or 'non-persistent'
 	Mode *string `json:"mode,omitempty"`
 }
 

--- a/management/tenant.go
+++ b/management/tenant.go
@@ -301,8 +301,8 @@ type TenantDeviceFlow struct {
 	Mask *string `json:"mask,omitempty"`
 }
 
+// TenantSessionCookie manages behavior of the tenant's session cookie, accepts either 'persistent' or 'non-persistent'
 type TenantSessionCookie struct {
-	// Behavior of the tenant's session cookie, accepts either 'persistent' or 'non-persistent'
 	Mode *string `json:"mode,omitempty"`
 }
 

--- a/management/tenant.go
+++ b/management/tenant.go
@@ -75,6 +75,8 @@ type Tenant struct {
 
 	// Supported locales for the UI
 	EnabledLocales []interface{} `json:"enabled_locales,omitempty"`
+
+	SessionCookie *TenantSessionCookie `json:"session_cookie,omitempty"`
 }
 
 // MarshalJSON is a custom serializer for the Tenant type.
@@ -297,6 +299,10 @@ type TenantDeviceFlow struct {
 	// The mask used to format the generated User Code to a friendly, readable
 	// format with possible spaces or hyphens
 	Mask *string `json:"mask,omitempty"`
+}
+
+type TenantSessionCookie struct {
+	Mode *string `json:"mode,omitempty"`
 }
 
 // TenantManager manages Auth0 Tenant resources.

--- a/management/tenant.go
+++ b/management/tenant.go
@@ -301,7 +301,7 @@ type TenantDeviceFlow struct {
 	Mask *string `json:"mask,omitempty"`
 }
 
-// TenantSessionCookie manages behavior of the tenant's session cookie, accepts either 'persistent' or 'non-persistent'
+// TenantSessionCookie manages behavior of the tenant's session cookie, accepts either 'persistent' or 'non-persistent'.
 type TenantSessionCookie struct {
 	Mode *string `json:"mode,omitempty"`
 }

--- a/management/tenant_test.go
+++ b/management/tenant_test.go
@@ -31,6 +31,9 @@ func TestTenantManager(t *testing.T) {
 		DefaultRedirectionURI: auth0.String("https://example.com/login"),
 		SessionLifetime:       auth0.Float64(1080),
 		IdleSessionLifetime:   auth0.Float64(720.2), // will be rounded off
+		SessionCookie: &TenantSessionCookie{
+			Mode: auth0.String("non-persistent"),
+		},
 	}
 	err = m.Tenant.Update(newTenantSettings)
 	assert.NoError(t, err)
@@ -43,6 +46,7 @@ func TestTenantManager(t *testing.T) {
 	assert.Equal(t, newTenantSettings.GetSessionLifetime(), actualTenantSettings.GetSessionLifetime())
 	assert.Equal(t, newTenantSettings.GetSupportEmail(), actualTenantSettings.GetSupportEmail())
 	assert.Equal(t, newTenantSettings.GetSupportURL(), actualTenantSettings.GetSupportURL())
+	assert.Equal(t, newTenantSettings.SessionCookie.GetMode(), actualTenantSettings.SessionCookie.GetMode())
 }
 
 func TestTenant_MarshalJSON(t *testing.T) {

--- a/management/testdata/recordings/TestTenantManager.yaml
+++ b/management/testdata/recordings/TestTenantManager.yaml
@@ -25,7 +25,7 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"friendly_name":"My Example Tenant","support_email":"support@example.com","support_url":"https://support.example.com","session_lifetime":1080,"idle_session_lifetime":720,"default_redirection_uri":"https://example.com/login"}
+      {"friendly_name":"My Example Tenant","support_email":"support@example.com","support_url":"https://support.example.com","session_lifetime":1080,"idle_session_lifetime":720,"default_redirection_uri":"https://example.com/login","session_cookie":{"mode":"non-persistent"}}
     form: {}
     headers:
       Content-Type:
@@ -38,7 +38,7 @@ interactions:
     body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{"enabled":true,"html":"<html>Change
       Password</html>"},"default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error
       Page</html>","url":"https://mycompany.org/error","show_log_link":false},"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":false,"universal_login":false,"use_scope_descriptions_for_consent":false,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My
-      Example Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":720,"picture_url":"https://mycompany.org/logo.png","sandbox_version":"12","session_lifetime":1080,"support_email":"support@example.com","support_url":"https://support.example.com","universal_login":{"colors":{"primary":"#ea5323","page_background":{"type":"linear-gradient","start":"#000000","end":"#ffffff","angle_deg":35}}}}'
+      Example Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":720,"picture_url":"https://mycompany.org/logo.png","sandbox_version":"12","session_cookie":{"mode":"non-persistent"},"session_lifetime":1080,"support_email":"support@example.com","support_url":"https://support.example.com","universal_login":{"colors":{"primary":"#ea5323","page_background":{"type":"linear-gradient","start":"#000000","end":"#ffffff","angle_deg":35}}}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -60,7 +60,7 @@ interactions:
     body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{"enabled":true,"html":"<html>Change
       Password</html>"},"default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error
       Page</html>","url":"https://mycompany.org/error","show_log_link":false},"flags":{"allow_changing_enable_sso":false,"change_pwd_flow_v1":false,"disable_impersonation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":false,"universal_login":false,"use_scope_descriptions_for_consent":false,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My
-      Example Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":720,"picture_url":"https://mycompany.org/logo.png","sandbox_version":"12","session_lifetime":1080,"support_email":"support@example.com","support_url":"https://support.example.com","universal_login":{"colors":{"primary":"#ea5323","page_background":{"type":"linear-gradient","start":"#000000","end":"#ffffff","angle_deg":35}}},"sandbox_versions_available":["12"]}'
+      Example Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":720,"picture_url":"https://mycompany.org/logo.png","sandbox_version":"12","session_cookie":{"mode":"non-persistent"},"session_lifetime":1080,"support_email":"support@example.com","support_url":"https://support.example.com","universal_login":{"colors":{"primary":"#ea5323","page_background":{"type":"linear-gradient","start":"#000000","end":"#ffffff","angle_deg":35}}},"sandbox_versions_available":["12"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8


### PR DESCRIPTION
## Description

Adding the `session_cookie` tenant property to enable the modification of session cookie behavior. This was originally requested in this [Terraform provider issue](https://github.com/auth0/terraform-provider-auth0/issues/55).  

This property is an object that contains a single `mode` property that accepts two string values: `"persistent"` and `"non-persistent"`.

## References

- Original requesting issue: https://github.com/auth0/terraform-provider-auth0/issues/55
- [PATCH tenant settings endpoint documentation](https://auth0.com/docs/api/management/v2#!/Tenants/patch_settings)

## Testing

Tested manually and also added test case to existing `TestTenantManager` test.

- [x] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
