### PR TITLE
Adding `IncludeEmailInRedirect` field for email templates

### DIFF
--- a/management/email_template.go
+++ b/management/email_template.go
@@ -30,6 +30,11 @@ type EmailTemplate struct {
 
 	// Whether or not the template is enabled.
 	Enabled *bool `json:"enabled,omitempty"`
+
+	// Whether the `reset_email` and `verify_email` templates should include the user's
+	// email address as the email parameter in the returnUrl (true) or whether no email
+	// address should be included in the redirect (false). Defaults to true.
+	IncludeEmailInRedirect *bool `json:"includeEmailInRedirect,omitempty"`
 }
 
 // EmailTemplateManager manages Auth0 EmailTemplate resources.

--- a/management/email_template_test.go
+++ b/management/email_template_test.go
@@ -14,13 +14,14 @@ func TestEmailTemplateManager_Create(t *testing.T) {
 	setupHTTPRecordings(t)
 
 	template := &EmailTemplate{
-		Template:  auth0.String("verify_email"),
-		Body:      auth0.String("<html><body><h1>Verify your email</h1></body></html>"),
-		From:      auth0.String("me@example.com"),
-		ResultURL: auth0.String("https://www.example.com/verify-email"),
-		Subject:   auth0.String("Verify your email"),
-		Syntax:    auth0.String("liquid"),
-		Enabled:   auth0.Bool(true),
+		Template:               auth0.String("verify_email"),
+		Body:                   auth0.String("<html><body><h1>Verify your email</h1></body></html>"),
+		From:                   auth0.String("me@example.com"),
+		ResultURL:              auth0.String("https://www.example.com/verify-email"),
+		Subject:                auth0.String("Verify your email"),
+		Syntax:                 auth0.String("liquid"),
+		Enabled:                auth0.Bool(true),
+		IncludeEmailInRedirect: auth0.Bool(true),
 	}
 
 	err := m.EmailTemplate.Create(template)
@@ -52,10 +53,12 @@ func TestEmailTemplateManager_Update(t *testing.T) {
 	template := givenAnEmailTemplate(t)
 
 	expectedBody := "<html><body><h1>Let's get you verified!</h1></body></html>"
+	expectedIncludeEmailInRedirect := false
 	err := m.EmailTemplate.Update(
 		template.GetTemplate(),
 		&EmailTemplate{
-			Body: &expectedBody,
+			Body:                   &expectedBody,
+			IncludeEmailInRedirect: &expectedIncludeEmailInRedirect,
 		},
 	)
 	assert.NoError(t, err)
@@ -63,6 +66,7 @@ func TestEmailTemplateManager_Update(t *testing.T) {
 	actualTemplate, err := m.EmailTemplate.Read(template.GetTemplate())
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBody, actualTemplate.GetBody())
+	assert.Equal(t, expectedIncludeEmailInRedirect, actualTemplate.GetIncludeEmailInRedirect())
 }
 
 func TestEmailTemplateManager_Replace(t *testing.T) {
@@ -71,25 +75,37 @@ func TestEmailTemplateManager_Replace(t *testing.T) {
 	givenAnEmailProvider(t)
 	template := givenAnEmailTemplate(t)
 
+	template.Template = auth0.String("verify_email")
 	template.Subject = auth0.String("Let's get you verified!")
 	template.Body = auth0.String("<html><body><h1>Let's get you verified!</h1></body></html>")
 	template.From = auth0.String("someone@example.com")
+	template.IncludeEmailInRedirect = auth0.Bool(true)
 
 	err := m.EmailTemplate.Replace(template.GetTemplate(), template)
 	assert.NoError(t, err)
+
+	actualTemplate, err := m.EmailTemplate.Read(template.GetTemplate())
+	assert.NoError(t, err)
+
+	assert.Equal(t, actualTemplate.GetBody(), template.GetBody())
+	assert.Equal(t, actualTemplate.GetSubject(), template.GetSubject())
+	assert.Equal(t, actualTemplate.GetFrom(), template.GetFrom())
+	assert.Equal(t, actualTemplate.GetTemplate(), template.GetTemplate())
+	assert.Equal(t, actualTemplate.GetIncludeEmailInRedirect(), template.GetIncludeEmailInRedirect())
 }
 
 func givenAnEmailTemplate(t *testing.T) *EmailTemplate {
 	t.Helper()
 
 	template := &EmailTemplate{
-		Template:  auth0.String("verify_email"),
-		Body:      auth0.String("<html><body><h1>Verify your email</h1></body></html>"),
-		From:      auth0.String("me@example.com"),
-		ResultURL: auth0.String("https://www.example.com/verify-email"),
-		Subject:   auth0.String("Verify your email"),
-		Syntax:    auth0.String("liquid"),
-		Enabled:   auth0.Bool(true),
+		Template:               auth0.String("verify_email"),
+		Body:                   auth0.String("<html><body><h1>Verify your email</h1></body></html>"),
+		From:                   auth0.String("me@example.com"),
+		ResultURL:              auth0.String("https://www.example.com/verify-email"),
+		Subject:                auth0.String("Verify your email"),
+		Syntax:                 auth0.String("liquid"),
+		Enabled:                auth0.Bool(true),
+		IncludeEmailInRedirect: auth0.Bool(true),
 	}
 
 	err := m.EmailTemplate.Create(template)

--- a/management/email_template_test.go
+++ b/management/email_template_test.go
@@ -72,6 +72,9 @@ func TestEmailTemplateManager_Update(t *testing.T) {
 func TestEmailTemplateManager_Replace(t *testing.T) {
 	setupHTTPRecordings(t)
 
+	err := m.Email.Delete()
+	assert.NoError(t, err)
+
 	givenAnEmailProvider(t)
 	template := givenAnEmailTemplate(t)
 
@@ -81,7 +84,7 @@ func TestEmailTemplateManager_Replace(t *testing.T) {
 	template.From = auth0.String("someone@example.com")
 	template.IncludeEmailInRedirect = auth0.Bool(true)
 
-	err := m.EmailTemplate.Replace(template.GetTemplate(), template)
+	err = m.EmailTemplate.Replace(template.GetTemplate(), template)
 	assert.NoError(t, err)
 
 	actualTemplate, err := m.EmailTemplate.Read(template.GetTemplate())

--- a/management/email_template_test.go
+++ b/management/email_template_test.go
@@ -72,9 +72,6 @@ func TestEmailTemplateManager_Update(t *testing.T) {
 func TestEmailTemplateManager_Replace(t *testing.T) {
 	setupHTTPRecordings(t)
 
-	err := m.Email.Delete()
-	assert.NoError(t, err)
-
 	givenAnEmailProvider(t)
 	template := givenAnEmailTemplate(t)
 
@@ -84,7 +81,7 @@ func TestEmailTemplateManager_Replace(t *testing.T) {
 	template.From = auth0.String("someone@example.com")
 	template.IncludeEmailInRedirect = auth0.Bool(true)
 
-	err = m.EmailTemplate.Replace(template.GetTemplate(), template)
+	err := m.EmailTemplate.Replace(template.GetTemplate(), template)
 	assert.NoError(t, err)
 
 	actualTemplate, err := m.EmailTemplate.Read(template.GetTemplate())

--- a/management/email_test.go
+++ b/management/email_test.go
@@ -91,6 +91,9 @@ func TestEmailManager_Delete(t *testing.T) {
 func givenAnEmailProvider(t *testing.T) *Email {
 	t.Helper()
 
+	err := m.Email.Delete() // Delete any existing email providers, otherwise most subsequent operations will fail
+	require.NoError(t, err)
+
 	emailProvider := &Email{
 		Name:               auth0.String("smtp"),
 		Enabled:            auth0.Bool(true),
@@ -103,7 +106,7 @@ func givenAnEmailProvider(t *testing.T) *Email {
 		},
 	}
 
-	err := m.Email.Create(emailProvider)
+	err = m.Email.Create(emailProvider)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/management/email_test.go
+++ b/management/email_test.go
@@ -91,9 +91,6 @@ func TestEmailManager_Delete(t *testing.T) {
 func givenAnEmailProvider(t *testing.T) *Email {
 	t.Helper()
 
-	err := m.Email.Delete() // Delete any existing email providers, otherwise most subsequent operations will fail
-	require.NoError(t, err)
-
 	emailProvider := &Email{
 		Name:               auth0.String("smtp"),
 		Enabled:            auth0.Bool(true),
@@ -106,8 +103,12 @@ func givenAnEmailProvider(t *testing.T) *Email {
 		},
 	}
 
-	err = m.Email.Create(emailProvider)
-	require.NoError(t, err)
+	err := m.Email.Create(emailProvider)
+	if err != nil {
+		if err.(Error).Status() != http.StatusConflict {
+			t.Error(err)
+		}
+	}
 
 	t.Cleanup(func() {
 		cleanupEmailProvider(t)

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3886,6 +3886,14 @@ func (e *EmailTemplate) GetFrom() string {
 	return *e.From
 }
 
+// GetIncludeEmailInRedirect returns the IncludeEmailInRedirect field if it's non-nil, zero value otherwise.
+func (e *EmailTemplate) GetIncludeEmailInRedirect() bool {
+	if e == nil || e.IncludeEmailInRedirect == nil {
+		return false
+	}
+	return *e.IncludeEmailInRedirect
+}
+
 // GetResultURL returns the ResultURL field if it's non-nil, zero value otherwise.
 func (e *EmailTemplate) GetResultURL() string {
 	if e == nil || e.ResultURL == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -4907,6 +4907,16 @@ func TestEmailTemplate_GetFrom(tt *testing.T) {
 	e.GetFrom()
 }
 
+func TestEmailTemplate_GetIncludeEmailInRedirect(tt *testing.T) {
+	var zeroValue bool
+	e := &EmailTemplate{IncludeEmailInRedirect: &zeroValue}
+	e.GetIncludeEmailInRedirect()
+	e = &EmailTemplate{}
+	e.GetIncludeEmailInRedirect()
+	e = nil
+	e.GetIncludeEmailInRedirect()
+}
+
 func TestEmailTemplate_GetResultURL(tt *testing.T) {
 	var zeroValue string
 	e := &EmailTemplate{ResultURL: &zeroValue}

--- a/management/testdata/recordings/TestEmailManager_Delete.yaml
+++ b/management/testdata/recordings/TestEmailManager_Delete.yaml
@@ -2,24 +2,6 @@
 version: 1
 interactions:
 - request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go-Auth0-SDK/latest
-    url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    status: 204 No Content
-    code: 204
-    duration: 1ms
-- request:
     body: |
       {"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user","smtp_pass":"pass"}}
     form: {}

--- a/management/testdata/recordings/TestEmailManager_Delete.yaml
+++ b/management/testdata/recordings/TestEmailManager_Delete.yaml
@@ -2,6 +2,24 @@
 version: 1
 interactions:
 - request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 204 No Content
+    code: 204
+    duration: 1ms
+- request:
     body: |
       {"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user","smtp_pass":"pass"}}
     form: {}

--- a/management/testdata/recordings/TestEmailManager_Read.yaml
+++ b/management/testdata/recordings/TestEmailManager_Read.yaml
@@ -2,6 +2,24 @@
 version: 1
 interactions:
 - request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 204 No Content
+    code: 204
+    duration: 1ms
+- request:
     body: |
       {"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user","smtp_pass":"pass"}}
     form: {}

--- a/management/testdata/recordings/TestEmailManager_Update.yaml
+++ b/management/testdata/recordings/TestEmailManager_Update.yaml
@@ -2,6 +2,24 @@
 version: 1
 interactions:
 - request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 204 No Content
+    code: 204
+    duration: 1ms
+- request:
     body: |
       {"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user","smtp_pass":"pass"}}
     form: {}

--- a/management/testdata/recordings/TestEmailTemplateManager_Create.yaml
+++ b/management/testdata/recordings/TestEmailTemplateManager_Create.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"template":"verify_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eVerify your email\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"me@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Verify your email","syntax":"liquid","enabled":true}
+      {"template":"verify_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eVerify your email\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"me@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Verify your email","syntax":"liquid","enabled":true,"includeEmailInRedirect":true}
     form: {}
     headers:
       Content-Type:
@@ -33,8 +33,8 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates/verify_email
     method: PATCH
   response:
-    body: '{"template":"verify_email","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Let''s
-      get you verified!","syntax":"liquid","enabled":false}'
+    body: '{"syntax":"liquid","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","subject":"Let''s
+      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":true,"resultUrl":"https://www.example.com/verify-email","enabled":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8

--- a/management/testdata/recordings/TestEmailTemplateManager_Read.yaml
+++ b/management/testdata/recordings/TestEmailTemplateManager_Read.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"template":"verify_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eVerify your email\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"me@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Verify your email","syntax":"liquid","enabled":true}
+      {"template":"verify_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eVerify your email\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"me@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Verify your email","syntax":"liquid","enabled":true,"includeEmailInRedirect":true}
     form: {}
     headers:
       Content-Type:
@@ -33,8 +33,8 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates/verify_email
     method: GET
   response:
-    body: '{"template":"verify_email","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Let''s
-      get you verified!","syntax":"liquid","enabled":false}'
+    body: '{"syntax":"liquid","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","subject":"Let''s
+      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":false,"resultUrl":"https://www.example.com/verify-email","enabled":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -53,8 +53,8 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates/verify_email
     method: PATCH
   response:
-    body: '{"template":"verify_email","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Let''s
-      get you verified!","syntax":"liquid","enabled":false}'
+    body: '{"syntax":"liquid","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","subject":"Let''s
+      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":false,"resultUrl":"https://www.example.com/verify-email","enabled":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8

--- a/management/testdata/recordings/TestEmailTemplateManager_Read.yaml
+++ b/management/testdata/recordings/TestEmailTemplateManager_Read.yaml
@@ -34,7 +34,7 @@ interactions:
     method: GET
   response:
     body: '{"syntax":"liquid","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","subject":"Let''s
-      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":false,"resultUrl":"https://www.example.com/verify-email","enabled":false}'
+      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":true,"resultUrl":"https://www.example.com/verify-email","enabled":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -54,7 +54,7 @@ interactions:
     method: PATCH
   response:
     body: '{"syntax":"liquid","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","subject":"Let''s
-      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":false,"resultUrl":"https://www.example.com/verify-email","enabled":false}'
+      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":true,"resultUrl":"https://www.example.com/verify-email","enabled":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8

--- a/management/testdata/recordings/TestEmailTemplateManager_Replace.yaml
+++ b/management/testdata/recordings/TestEmailTemplateManager_Replace.yaml
@@ -2,24 +2,6 @@
 version: 1
 interactions:
 - request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go-Auth0-SDK/latest
-    url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    status: 204 No Content
-    code: 204
-    duration: 1ms
-- request:
     body: |
       {"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user","smtp_pass":"pass"}}
     form: {}

--- a/management/testdata/recordings/TestEmailTemplateManager_Replace.yaml
+++ b/management/testdata/recordings/TestEmailTemplateManager_Replace.yaml
@@ -13,88 +13,11 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
     method: POST
   response:
-    body: '{"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user"}}'
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    status: 201 Created
-    code: 201
-    duration: 1ms
-- request:
-    body: |
-      {"template":"verify_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eVerify your email\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"me@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Verify your email","syntax":"liquid","enabled":true}
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go-Auth0-SDK/latest
-    url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates
-    method: POST
-  response:
-    body: '{"statusCode":409,"error":"Conflict","message":"Template verify_email already
-      exists."}'
+    body: '{"statusCode":409,"error":"Conflict","message":"An email provider is already
+      configured: mandrill","errorCode":"email_provider_conflict"}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
     status: 409 Conflict
     code: 409
-    duration: 1ms
-- request:
-    body: |
-      {"template":"verify_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eLet's get you verified!\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"someone@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Let's get you verified!","syntax":"liquid","enabled":true}
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go-Auth0-SDK/latest
-    url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates/verify_email
-    method: PUT
-  response:
-    body: '{"template":"verify_email","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Let''s
-      get you verified!","syntax":"liquid","enabled":true}'
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    status: 200 OK
-    code: 200
-    duration: 1ms
-- request:
-    body: |
-      {"enabled":false}
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go-Auth0-SDK/latest
-    url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates/verify_email
-    method: PATCH
-  response:
-    body: '{"template":"verify_email","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Let''s
-      get you verified!","syntax":"liquid","enabled":false}'
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    status: 200 OK
-    code: 200
-    duration: 1ms
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go-Auth0-SDK/latest
-    url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    status: 204 No Content
-    code: 204
     duration: 1ms

--- a/management/testdata/recordings/TestEmailTemplateManager_Replace.yaml
+++ b/management/testdata/recordings/TestEmailTemplateManager_Replace.yaml
@@ -2,6 +2,24 @@
 version: 1
 interactions:
 - request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 204 No Content
+    code: 204
+    duration: 1ms
+- request:
     body: |
       {"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user","smtp_pass":"pass"}}
     form: {}
@@ -13,11 +31,108 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
     method: POST
   response:
-    body: '{"statusCode":409,"error":"Conflict","message":"An email provider is already
-      configured: mandrill","errorCode":"email_provider_conflict"}'
+    body: '{"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user"}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 201 Created
+    code: 201
+    duration: 1ms
+- request:
+    body: |
+      {"template":"verify_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eVerify your email\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"me@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Verify your email","syntax":"liquid","enabled":true,"includeEmailInRedirect":true}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates
+    method: POST
+  response:
+    body: '{"statusCode":409,"error":"Conflict","message":"Template verify_email already
+      exists."}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
     status: 409 Conflict
     code: 409
+    duration: 1ms
+- request:
+    body: |
+      {"template":"verify_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eLet's get you verified!\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"someone@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Let's get you verified!","syntax":"liquid","enabled":true,"includeEmailInRedirect":true}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates/verify_email
+    method: PUT
+  response:
+    body: '{"syntax":"liquid","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","subject":"Let''s
+      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":true,"resultUrl":"https://www.example.com/verify-email","enabled":true}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates/verify_email
+    method: GET
+  response:
+    body: '{"syntax":"liquid","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","subject":"Let''s
+      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":true,"resultUrl":"https://www.example.com/verify-email","enabled":true}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      {"enabled":false}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates/verify_email
+    method: PATCH
+  response:
+    body: '{"syntax":"liquid","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","subject":"Let''s
+      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":true,"resultUrl":"https://www.example.com/verify-email","enabled":false}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 204 No Content
+    code: 204
     duration: 1ms

--- a/management/testdata/recordings/TestEmailTemplateManager_Update.yaml
+++ b/management/testdata/recordings/TestEmailTemplateManager_Update.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"template":"verify_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eVerify your email\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"me@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Verify your email","syntax":"liquid","enabled":true}
+      {"template":"verify_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eVerify your email\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"me@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Verify your email","syntax":"liquid","enabled":true,"includeEmailInRedirect":true}
     form: {}
     headers:
       Content-Type:
@@ -23,7 +23,7 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eLet's get you verified!\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e"}
+      {"body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eLet's get you verified!\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","includeEmailInRedirect":false}
     form: {}
     headers:
       Content-Type:
@@ -33,8 +33,8 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates/verify_email
     method: PATCH
   response:
-    body: '{"template":"verify_email","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Let''s
-      get you verified!","syntax":"liquid","enabled":false}'
+    body: '{"syntax":"liquid","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","subject":"Let''s
+      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":false,"resultUrl":"https://www.example.com/verify-email","enabled":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -53,8 +53,8 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates/verify_email
     method: GET
   response:
-    body: '{"template":"verify_email","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Let''s
-      get you verified!","syntax":"liquid","enabled":false}'
+    body: '{"syntax":"liquid","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","subject":"Let''s
+      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":false,"resultUrl":"https://www.example.com/verify-email","enabled":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -73,8 +73,8 @@ interactions:
     url: https://go-auth0-dev.eu.auth0.com/api/v2/email-templates/verify_email
     method: PATCH
   response:
-    body: '{"template":"verify_email","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","resultUrl":"https://www.example.com/verify-email","subject":"Let''s
-      get you verified!","syntax":"liquid","enabled":false}'
+    body: '{"syntax":"liquid","body":"<html><body><h1>Let''s get you verified!</h1></body></html>","from":"someone@example.com","subject":"Let''s
+      get you verified!","urlLifetimeInSeconds":432000,"template":"verify_email","includeEmailInRedirect":false,"resultUrl":"https://www.example.com/verify-email","enabled":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8


### PR DESCRIPTION
## Description

This PR adds the `includeEmailInRedirect` boolean field for email templates. This comes per a [request in the Terraform provider](https://github.com/auth0/terraform-provider-auth0/issues/34).

**Additionally,** included are some minor testing changes to the email templates testing to improve assertions and repeatability. These testing changes are only somewhat related to the core change here, but somewhat messy to separate while ensuring testing on this feature; willing to separate if requested.

## References

- [Update email templates endpoint documentation](https://auth0.com/docs/api/management/v2#!/Email_Templates/put_email_templates_by_templateName)
- [Original request](https://github.com/auth0/terraform-provider-auth0/issues/3)


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [x] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
