### PR TITLE
[DXCDT-190] Add more connection strategies that default to OAuth2

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -47,6 +47,42 @@ const (
 	ConnectionStrategySAML = "samlp"
 	// ConnectionStrategyGoogleApps constant.
 	ConnectionStrategyGoogleApps = "google-apps"
+	// ConnectionStrategyDropbox constant.
+	ConnectionStrategyDropbox = "dropbox"
+	// ConnectionStrategyBitBucket constant.
+	ConnectionStrategyBitBucket = "bitbucket"
+	// ConnectionStrategyPaypal constant.
+	ConnectionStrategyPaypal = "paypal"
+	// ConnectionStrategyTwitter constant.
+	ConnectionStrategyTwitter = "twitter"
+	// ConnectionStrategyAmazon constant.
+	ConnectionStrategyAmazon = "amazon"
+	// ConnectionStrategyYahoo constant.
+	ConnectionStrategyYahoo = "yahoo"
+	// ConnectionStrategyBox constant.
+	ConnectionStrategyBox = "box"
+	// ConnectionStrategyWordpress constant.
+	ConnectionStrategyWordpress = "wordpress"
+	// ConnectionStrategyDiscord constant.
+	ConnectionStrategyDiscord = "discord"
+	// ConnectionStrategyImgur constant.
+	ConnectionStrategyImgur = "imgur"
+	// ConnectionStrategySpotify constant.
+	ConnectionStrategySpotify = "spotify"
+	// ConnectionStrategyShopify constant.
+	ConnectionStrategyShopify = "shopify"
+	// ConnectionStrategyFigma constant.
+	ConnectionStrategyFigma = "figma"
+	// ConnectionStrategySlack constant.
+	ConnectionStrategySlack = "slack-oauth-2"
+	// ConnectionStrategyDigitalOcean constant.
+	ConnectionStrategyDigitalOcean = "digitalocean"
+	// ConnectionStrategyTwitch constant.
+	ConnectionStrategyTwitch = "twitch"
+	// ConnectionStrategyVimeo constant.
+	ConnectionStrategyVimeo = "vimeo"
+	// ConnectionStrategyCustom constant.
+	ConnectionStrategyCustom = "custom"
 )
 
 // Connection is the relationship between Auth0 and a source of users.
@@ -167,7 +203,25 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 			v = &ConnectionOptionsSMS{}
 		case ConnectionStrategyOIDC:
 			v = &ConnectionOptionsOIDC{}
-		case ConnectionStrategyOAuth2:
+		case ConnectionStrategyOAuth2,
+			ConnectionStrategyDropbox,
+			ConnectionStrategyBitBucket,
+			ConnectionStrategyPaypal,
+			ConnectionStrategyTwitter,
+			ConnectionStrategyAmazon,
+			ConnectionStrategyYahoo,
+			ConnectionStrategyBox,
+			ConnectionStrategyWordpress,
+			ConnectionStrategyDiscord,
+			ConnectionStrategyImgur,
+			ConnectionStrategySpotify,
+			ConnectionStrategyShopify,
+			ConnectionStrategyFigma,
+			ConnectionStrategySlack,
+			ConnectionStrategyDigitalOcean,
+			ConnectionStrategyTwitch,
+			ConnectionStrategyVimeo,
+			ConnectionStrategyCustom:
 			v = &ConnectionOptionsOAuth2{}
 		case ConnectionStrategyAD:
 			v = &ConnectionOptionsAD{}


### PR DESCRIPTION
## Description

Add more connection strategies that default to OAuth2.


## References

<!--- 
Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow post
- Support forum thread
- Related pull requests/issues from other repos

If there are no references, simply delete this section.
-->


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [ ] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
