### PR TITLE
Add support for checkpoint based pagination

### DIFF
--- a/management/management.go
+++ b/management/management.go
@@ -378,10 +378,11 @@ func (m *managementError) Status() int {
 // Specific implementations embed this struct, therefore its direct use is not
 // useful. Rather it has been made public in order to aid documentation.
 type List struct {
-	Start  int `json:"start"`
-	Limit  int `json:"limit"`
-	Length int `json:"length"`
-	Total  int `json:"total"`
+	Start  int    `json:"start"`
+	Limit  int    `json:"limit"`
+	Length int    `json:"length"`
+	Total  int    `json:"total"`
+	Next   string `json:"next"`
 }
 
 // HasNext returns true if the list has more results.
@@ -468,6 +469,24 @@ func IncludeTotals(include bool) RequestOption {
 	return newRequestOption(func(r *http.Request) {
 		q := r.URL.Query()
 		q.Set("include_totals", strconv.FormatBool(include))
+		r.URL.RawQuery = q.Encode()
+	})
+}
+
+// From configures a request to start from the specified checkpoint.
+func From(checkpoint string) RequestOption {
+	return newRequestOption(func(r *http.Request) {
+		q := r.URL.Query()
+		q.Set("from", checkpoint)
+		r.URL.RawQuery = q.Encode()
+	})
+}
+
+// Take configures a request to limit the amount of items in the result for a checkpoint based request.
+func Take(items int) RequestOption {
+	return newRequestOption(func(r *http.Request) {
+		q := r.URL.Query()
+		q.Set("take", strconv.FormatInt(int64(items), 10))
 		r.URL.RawQuery = q.Encode()
 	})
 }

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -99,6 +99,21 @@ func TestOptionTotals(t *testing.T) {
 	assert.Equal(t, "true", includeTotals)
 }
 
+func TestOptionFrom(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/", nil)
+
+	From("abc").apply(r)
+	Take(10).apply(r)
+
+	v := r.URL.Query()
+
+	from := v.Get("from")
+	assert.Equal(t, "abc", from)
+
+	take := v.Get("take")
+	assert.Equal(t, "10", take)
+}
+
 func TestOptionParameter(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/", nil)
 


### PR DESCRIPTION
## Description

This PR adds support for the `from` and `take` query params that Auth0 allows for cursor/checkpoint based pagination.
My organization needs this in order to build a more robust pagination solution that doesn't risk skipping items, and it is currently difficult to accomplish using the sdk.

## References

This is the the only pagination query params not currently supported and it is [well documented by the official documentation](https://auth0.com/docs/api/management/v2/#!/Organizations/get_organizations).

## Testing

This can be easily tested by just using the take and from functions before firing off a request to retrieve for example organizations.  I tested it myself with our own internal api, as well as added a small unit test.

- [x] This change adds test coverage for new/changed/fixed functionality


## Checklist

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
