### PR TITLE
feat: add missing fields to the user struct

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -6253,6 +6253,14 @@ func (u *User) GetFamilyName() string {
 	return *u.FamilyName
 }
 
+// GetFirstName returns the FirstName field if it's non-nil, zero value otherwise.
+func (u *User) GetFirstName() string {
+	if u == nil || u.FirstName == nil {
+		return ""
+	}
+	return *u.FirstName
+}
+
 // GetGivenName returns the GivenName field if it's non-nil, zero value otherwise.
 func (u *User) GetGivenName() string {
 	if u == nil || u.GivenName == nil {
@@ -6283,6 +6291,14 @@ func (u *User) GetLastLogin() time.Time {
 		return time.Time{}
 	}
 	return *u.LastLogin
+}
+
+// GetLastName returns the LastName field if it's non-nil, zero value otherwise.
+func (u *User) GetLastName() string {
+	if u == nil || u.LastName == nil {
+		return ""
+	}
+	return *u.LastName
 }
 
 // GetLocation returns the Location field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -7949,6 +7949,16 @@ func TestUser_GetFamilyName(tt *testing.T) {
 	u.GetFamilyName()
 }
 
+func TestUser_GetFirstName(tt *testing.T) {
+	var zeroValue string
+	u := &User{FirstName: &zeroValue}
+	u.GetFirstName()
+	u = &User{}
+	u.GetFirstName()
+	u = nil
+	u.GetFirstName()
+}
+
 func TestUser_GetGivenName(tt *testing.T) {
 	var zeroValue string
 	u := &User{GivenName: &zeroValue}
@@ -7987,6 +7997,16 @@ func TestUser_GetLastLogin(tt *testing.T) {
 	u.GetLastLogin()
 	u = nil
 	u.GetLastLogin()
+}
+
+func TestUser_GetLastName(tt *testing.T) {
+	var zeroValue string
+	u := &User{LastName: &zeroValue}
+	u.GetLastName()
+	u = &User{}
+	u.GetLastName()
+	u = nil
+	u.GetLastName()
 }
 
 func TestUser_GetLocation(tt *testing.T) {

--- a/management/user.go
+++ b/management/user.go
@@ -30,6 +30,12 @@ type User struct {
 	// The users' family name.
 	FamilyName *string `json:"family_name,omitempty"`
 
+	// The users' first name.
+	FirstName *string `json:"first_name,omitempty"`
+
+	// The users' last name.
+	LastName *string `json:"last_name,omitempty"`
+
 	// The users' username. Only valid if the connection requires a username.
 	Username *string `json:"username,omitempty"`
 

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -365,6 +365,8 @@ func givenAUser(t *testing.T) *User {
 		Username:      auth0.String(fmt.Sprintf("test-user%d", rand.Intn(999))),
 		GivenName:     auth0.String("Chuck"),
 		FamilyName:    auth0.String("Sanchez"),
+		FirstName:     auth0.String("Chuck"),
+		LastName:      auth0.String("Sanchez"),
 		Nickname:      auth0.String("Chucky"),
 		UserMetadata:  &userMetadata,
 		EmailVerified: auth0.Bool(true),


### PR DESCRIPTION
There are missing fields in the User struct.

`first_name` and `last_name`

In the API docs, you can see those fields but not in the go sdk. 



