### PR TITLE
Add ability to pass a custom audience when using client credentials

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -143,14 +143,29 @@ func Wrap(base *http.Client, tokenSource oauth2.TokenSource, options ...Option) 
 
 // OAuth2ClientCredentials sets the oauth2 client credentials.
 func OAuth2ClientCredentials(ctx context.Context, uri, clientID, clientSecret string) oauth2.TokenSource {
-	return (&clientcredentials.Config{
+	audience := uri + "/api/v2/"
+	return OAuth2ClientCredentialsAndAudience(ctx, uri, clientID, clientSecret, audience)
+}
+
+// OAuth2ClientCredentialsAndAudience sets the oauth2
+// client credentials with a custom audience.
+func OAuth2ClientCredentialsAndAudience(
+	ctx context.Context,
+	uri,
+	clientID,
+	clientSecret,
+	audience string,
+) oauth2.TokenSource {
+	cfg := &clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		TokenURL:     uri + "/oauth/token",
 		EndpointParams: url.Values{
-			"audience": {uri + "/api/v2/"},
+			"audience": []string{audience},
 		},
-	}).TokenSource(ctx)
+	}
+
+	return cfg.TokenSource(ctx)
 }
 
 // StaticToken sets a static token to be used for oauth2.

--- a/management/management_option.go
+++ b/management/management_option.go
@@ -42,6 +42,20 @@ func WithClientCredentials(clientID, clientSecret string) Option {
 	}
 }
 
+// WithClientCredentialsAndAudience configures management to authenticate using the client
+// credentials authentication flow and a custom audience.
+func WithClientCredentialsAndAudience(clientID, clientSecret, audience string) Option {
+	return func(m *Management) {
+		m.tokenSource = client.OAuth2ClientCredentialsAndAudience(
+			m.ctx,
+			m.url.String(),
+			clientID,
+			clientSecret,
+			audience,
+		)
+	}
+}
+
 // WithStaticToken configures management to authenticate using a static
 // authentication token.
 func WithStaticToken(token string) Option {


### PR DESCRIPTION
## Description

In this PR we add  the ability to pass a custom audience when using client credentials. This is especially useful when using custom domains that are not publicly accessible. 

<!--- 
Describe the purpose of this PR along with any background information and the impacts of the proposed change. 
For the benefit of the community, please do not assume prior context.

Provide details that support your chosen implementation, including: 
- breaking changes
- alternatives considered
- changes to the API
- demos (screenshots, videos) if you find that useful
- etc.
-->


## References

<!--- 
Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow post
- Support forum thread
- Related pull requests/issues from other repos

If there are no references, simply delete this section.
-->


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [x] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
