### PR TITLE
DXCDT-218: Allow empty fields through pointers

### DIFF
--- a/management/actions.go
+++ b/management/actions.go
@@ -23,7 +23,7 @@ type ActionTrigger struct {
 
 // ActionTriggerList is a list of ActionTriggers.
 type ActionTriggerList struct {
-	Triggers []*ActionTrigger `json:"triggers"`
+	Triggers *[]ActionTrigger `json:"triggers"`
 }
 
 // ActionDependency is used to allow the use of packages from the npm registry.
@@ -74,25 +74,25 @@ type Action struct {
 	// ID of the action
 	ID *string `json:"id,omitempty"`
 	// The name of an action
-	Name *string `json:"name"`
+	Name *string `json:"name,omitempty"`
 	// List of triggers that this action supports. At this time, an action can
 	// only target a single trigger at a time.
-	SupportedTriggers []*ActionTrigger `json:"supported_triggers"`
+	SupportedTriggers *[]ActionTrigger `json:"supported_triggers,omitempty"`
 	// The source code of the action.
 	Code *string `json:"code,omitempty"`
 	// List of third party npm modules, and their versions, that this action
 	// depends on.
-	Dependencies []*ActionDependency `json:"dependencies,omitempty"`
+	Dependencies *[]ActionDependency `json:"dependencies,omitempty"`
 	// The Node runtime. For example `node16`, defaults to `node12`
 	Runtime *string `json:"runtime,omitempty"`
 	// List of secrets that are included in an action or a version of an action.
-	Secrets []*ActionSecret `json:"secrets,omitempty"`
+	Secrets *[]ActionSecret `json:"secrets,omitempty"`
 	// Version of the action that is currently deployed.
 	DeployedVersion *ActionVersion `json:"deployed_version,omitempty"`
 	// The build status of this action.
 	Status *string `json:"status,omitempty"`
 	// True if all of an Action's contents have been deployed.
-	AllChangesDeployed bool `json:"all_changes_deployed,omitempty"`
+	AllChangesDeployed *bool `json:"all_changes_deployed,omitempty"`
 	// The time when this action was built successfully.
 	BuiltAt *time.Time `json:"built_at,omitempty"`
 	// The time when this action was created.
@@ -104,7 +104,7 @@ type Action struct {
 // ActionList is a list of Actions.
 type ActionList struct {
 	List
-	Actions []*Action `json:"actions"`
+	Actions *[]Action `json:"actions"`
 }
 
 // ActionVersion is used to manage Actions version history.
@@ -113,12 +113,12 @@ type ActionList struct {
 type ActionVersion struct {
 	ID           *string             `json:"id,omitempty"`
 	Code         *string             `json:"code"`
-	Dependencies []*ActionDependency `json:"dependencies,omitempty"`
+	Dependencies *[]ActionDependency `json:"dependencies,omitempty"`
 	Deployed     bool                `json:"deployed"`
 	Status       *string             `json:"status,omitempty"`
-	Number       int                 `json:"number,omitempty"`
+	Number       *int                `json:"number,omitempty"`
 
-	Errors []*ActionVersionError `json:"errors,omitempty"`
+	Errors *[]ActionVersionError `json:"errors,omitempty"`
 	Action *Action               `json:"action,omitempty"`
 
 	BuiltAt   *time.Time `json:"built_at,omitempty"`
@@ -129,7 +129,7 @@ type ActionVersion struct {
 // ActionVersionList is a list of ActionVersions.
 type ActionVersionList struct {
 	List
-	Versions []*ActionVersion `json:"versions"`
+	Versions []ActionVersion `json:"versions"`
 }
 
 const (
@@ -154,7 +154,7 @@ type ActionBinding struct {
 
 	Ref     *ActionBindingReference `json:"ref,omitempty"`
 	Action  *Action                 `json:"action,omitempty"`
-	Secrets []*ActionSecret         `json:"secrets,omitempty"`
+	Secrets *[]ActionSecret         `json:"secrets,omitempty"`
 
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
@@ -163,11 +163,11 @@ type ActionBinding struct {
 // ActionBindingList is a list of ActionBindings.
 type ActionBindingList struct {
 	List
-	Bindings []*ActionBinding `json:"bindings"`
+	Bindings *[]ActionBinding `json:"bindings"`
 }
 
 type actionBindingsPerTrigger struct {
-	Bindings []*ActionBinding `json:"bindings"`
+	Bindings *[]ActionBinding `json:"bindings"`
 }
 
 // ActionTestPayload is used for testing Actions prior to being deployed.
@@ -181,8 +181,8 @@ type actionTestRequest struct {
 
 // ActionExecutionResult holds the results of an ActionExecution.
 type ActionExecutionResult struct {
-	ActionName *string                `json:"action_name,omitempty"`
-	Error      map[string]interface{} `json:"error,omitempty"`
+	ActionName *string                 `json:"action_name,omitempty"`
+	Error      *map[string]interface{} `json:"error,omitempty"`
 
 	StartedAt *time.Time `json:"started_at,omitempty"`
 	EndedAt   *time.Time `json:"ended_at,omitempty"`
@@ -194,7 +194,7 @@ type ActionExecution struct {
 	ID        *string                  `json:"id"`
 	TriggerID *string                  `json:"trigger_id"`
 	Status    *string                  `json:"status"`
-	Results   []*ActionExecutionResult `json:"results"`
+	Results   *[]ActionExecutionResult `json:"results"`
 
 	CreatedAt *time.Time `json:"created_at"`
 	UpdatedAt *time.Time `json:"updated_at"`
@@ -282,7 +282,7 @@ func (m *ActionManager) Versions(id string, opts ...RequestOption) (c *ActionVer
 // UpdateBindings of a trigger.
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Actions/patch_bindings
-func (m *ActionManager) UpdateBindings(triggerID string, b []*ActionBinding, opts ...RequestOption) error {
+func (m *ActionManager) UpdateBindings(triggerID string, b *[]ActionBinding, opts ...RequestOption) error {
 	bl := &actionBindingsPerTrigger{
 		Bindings: b,
 	}

--- a/management/actions_test.go
+++ b/management/actions_test.go
@@ -17,20 +17,20 @@ func TestActionManager_Create(t *testing.T) {
 	expectedAction := &Action{
 		Name: auth0.Stringf("Test Action (%s)", time.Now().Format(time.StampMilli)),
 		Code: auth0.String("exports.onExecutePostLogin = async (event, api) =\u003e {}"),
-		SupportedTriggers: []*ActionTrigger{
+		SupportedTriggers: &[]ActionTrigger{
 			{
 				ID:      auth0.String(ActionTriggerPostLogin),
 				Version: auth0.String("v2"),
 			},
 		},
-		Dependencies: []*ActionDependency{
+		Dependencies: &[]ActionDependency{
 			{
 				Name:        auth0.String("lodash"),
 				Version:     auth0.String("4.0.0"),
 				RegistryURL: auth0.String("https://www.npmjs.com/package/lodash"),
 			},
 		},
-		Secrets: []*ActionSecret{
+		Secrets: &[]ActionSecret{
 			{
 				Name:  auth0.String("mySecretName"),
 				Value: auth0.String("mySecretValue"),
@@ -103,7 +103,8 @@ func TestActionManager_List(t *testing.T) {
 	actionList, err := m.Action.List(Parameter("actionName", expectedAction.GetName()))
 
 	assert.NoError(t, err)
-	assert.Equal(t, expectedAction.GetID(), actionList.Actions[0].GetID())
+
+	assert.Equal(t, expectedAction.GetID(), actionList.GetActions()[0].GetID())
 }
 
 func TestActionManager_Triggers(t *testing.T) {
@@ -181,11 +182,11 @@ func TestActionManager_Bindings(t *testing.T) {
 	_, err := m.Action.Deploy(action.GetID())
 	require.NoError(t, err)
 
-	emptyBinding := make([]*ActionBinding, 0)
-	err = m.Action.UpdateBindings(ActionTriggerPostLogin, emptyBinding)
+	emptyBinding := make([]ActionBinding, 0)
+	err = m.Action.UpdateBindings(ActionTriggerPostLogin, &emptyBinding)
 	assert.NoError(t, err)
 
-	binding := []*ActionBinding{
+	binding := []ActionBinding{
 		{
 			Ref: &ActionBindingReference{
 				Type:  auth0.String(ActionBindingReferenceByName),
@@ -195,16 +196,16 @@ func TestActionManager_Bindings(t *testing.T) {
 		},
 	}
 
-	err = m.Action.UpdateBindings(ActionTriggerPostLogin, binding)
+	err = m.Action.UpdateBindings(ActionTriggerPostLogin, &binding)
 	assert.NoError(t, err)
 
 	bindingList, err := m.Action.Bindings(ActionTriggerPostLogin)
 
 	assert.NoError(t, err)
-	assert.Len(t, bindingList.Bindings, 1)
+	assert.Len(t, bindingList.GetBindings(), 1)
 
 	t.Cleanup(func() {
-		err = m.Action.UpdateBindings(ActionTriggerPostLogin, emptyBinding)
+		err = m.Action.UpdateBindings(ActionTriggerPostLogin, &emptyBinding)
 		assert.NoError(t, err)
 	})
 }
@@ -255,20 +256,20 @@ func givenAnAction(t *testing.T) *Action {
 	action := &Action{
 		Name: auth0.Stringf("Test Action (%s)", time.Now().Format(time.StampMilli)),
 		Code: auth0.String("exports.onExecutePostLogin = async (event, api) =\u003e {}"),
-		SupportedTriggers: []*ActionTrigger{
+		SupportedTriggers: &[]ActionTrigger{
 			{
 				ID:      auth0.String(ActionTriggerPostLogin),
 				Version: auth0.String("v2"),
 			},
 		},
-		Dependencies: []*ActionDependency{
+		Dependencies: &[]ActionDependency{
 			{
 				Name:        auth0.String("lodash"),
 				Version:     auth0.String("4.0.0"),
 				RegistryURL: auth0.String("https://www.npmjs.com/package/lodash"),
 			},
 		},
-		Secrets: []*ActionSecret{
+		Secrets: &[]ActionSecret{
 			{
 				Name:  auth0.String("mySecretName"),
 				Value: auth0.String("mySecretValue"),

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5431,6 +5431,14 @@ func (r *ResourceServer) GetName() string {
 	return *r.Name
 }
 
+// GetScopes returns the Scopes field if it's non-nil, zero value otherwise.
+func (r *ResourceServer) GetScopes() []ResourceServerScope {
+	if r == nil || r.Scopes == nil {
+		return nil
+	}
+	return *r.Scopes
+}
+
 // GetSigningAlgorithm returns the SigningAlgorithm field if it's non-nil, zero value otherwise.
 func (r *ResourceServer) GetSigningAlgorithm() string {
 	if r == nil || r.SigningAlgorithm == nil {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -7,6 +7,14 @@ import (
 	"time"
 )
 
+// GetAllChangesDeployed returns the AllChangesDeployed field if it's non-nil, zero value otherwise.
+func (a *Action) GetAllChangesDeployed() bool {
+	if a == nil || a.AllChangesDeployed == nil {
+		return false
+	}
+	return *a.AllChangesDeployed
+}
+
 // GetBuiltAt returns the BuiltAt field if it's non-nil, zero value otherwise.
 func (a *Action) GetBuiltAt() time.Time {
 	if a == nil || a.BuiltAt == nil {
@@ -29,6 +37,14 @@ func (a *Action) GetCreatedAt() time.Time {
 		return time.Time{}
 	}
 	return *a.CreatedAt
+}
+
+// GetDependencies returns the Dependencies field if it's non-nil, zero value otherwise.
+func (a *Action) GetDependencies() []ActionDependency {
+	if a == nil || a.Dependencies == nil {
+		return nil
+	}
+	return *a.Dependencies
 }
 
 // GetDeployedVersion returns the DeployedVersion field.
@@ -63,12 +79,28 @@ func (a *Action) GetRuntime() string {
 	return *a.Runtime
 }
 
+// GetSecrets returns the Secrets field if it's non-nil, zero value otherwise.
+func (a *Action) GetSecrets() []ActionSecret {
+	if a == nil || a.Secrets == nil {
+		return nil
+	}
+	return *a.Secrets
+}
+
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.
 func (a *Action) GetStatus() string {
 	if a == nil || a.Status == nil {
 		return ""
 	}
 	return *a.Status
+}
+
+// GetSupportedTriggers returns the SupportedTriggers field if it's non-nil, zero value otherwise.
+func (a *Action) GetSupportedTriggers() []ActionTrigger {
+	if a == nil || a.SupportedTriggers == nil {
+		return nil
+	}
+	return *a.SupportedTriggers
 }
 
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
@@ -124,6 +156,14 @@ func (a *ActionBinding) GetRef() *ActionBindingReference {
 	return a.Ref
 }
 
+// GetSecrets returns the Secrets field if it's non-nil, zero value otherwise.
+func (a *ActionBinding) GetSecrets() []ActionSecret {
+	if a == nil || a.Secrets == nil {
+		return nil
+	}
+	return *a.Secrets
+}
+
 // GetTriggerID returns the TriggerID field if it's non-nil, zero value otherwise.
 func (a *ActionBinding) GetTriggerID() string {
 	if a == nil || a.TriggerID == nil {
@@ -143,6 +183,14 @@ func (a *ActionBinding) GetUpdatedAt() time.Time {
 // String returns a string representation of ActionBinding.
 func (a *ActionBinding) String() string {
 	return Stringify(a)
+}
+
+// GetBindings returns the Bindings field if it's non-nil, zero value otherwise.
+func (a *ActionBindingList) GetBindings() []ActionBinding {
+	if a == nil || a.Bindings == nil {
+		return nil
+	}
+	return *a.Bindings
 }
 
 // String returns a string representation of ActionBindingList.
@@ -216,6 +264,14 @@ func (a *ActionExecution) GetID() string {
 	return *a.ID
 }
 
+// GetResults returns the Results field if it's non-nil, zero value otherwise.
+func (a *ActionExecution) GetResults() []ActionExecutionResult {
+	if a == nil || a.Results == nil {
+		return nil
+	}
+	return *a.Results
+}
+
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.
 func (a *ActionExecution) GetStatus() string {
 	if a == nil || a.Status == nil {
@@ -272,6 +328,14 @@ func (a *ActionExecutionResult) GetStartedAt() time.Time {
 // String returns a string representation of ActionExecutionResult.
 func (a *ActionExecutionResult) String() string {
 	return Stringify(a)
+}
+
+// GetActions returns the Actions field if it's non-nil, zero value otherwise.
+func (a *ActionList) GetActions() []Action {
+	if a == nil || a.Actions == nil {
+		return nil
+	}
+	return *a.Actions
 }
 
 // String returns a string representation of ActionList.
@@ -337,6 +401,14 @@ func (a *ActionTrigger) String() string {
 	return Stringify(a)
 }
 
+// GetTriggers returns the Triggers field if it's non-nil, zero value otherwise.
+func (a *ActionTriggerList) GetTriggers() []ActionTrigger {
+	if a == nil || a.Triggers == nil {
+		return nil
+	}
+	return *a.Triggers
+}
+
 // String returns a string representation of ActionTriggerList.
 func (a *ActionTriggerList) String() string {
 	return Stringify(a)
@@ -374,12 +446,36 @@ func (a *ActionVersion) GetCreatedAt() time.Time {
 	return *a.CreatedAt
 }
 
+// GetDependencies returns the Dependencies field if it's non-nil, zero value otherwise.
+func (a *ActionVersion) GetDependencies() []ActionDependency {
+	if a == nil || a.Dependencies == nil {
+		return nil
+	}
+	return *a.Dependencies
+}
+
+// GetErrors returns the Errors field if it's non-nil, zero value otherwise.
+func (a *ActionVersion) GetErrors() []ActionVersionError {
+	if a == nil || a.Errors == nil {
+		return nil
+	}
+	return *a.Errors
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (a *ActionVersion) GetID() string {
 	if a == nil || a.ID == nil {
 		return ""
 	}
 	return *a.ID
+}
+
+// GetNumber returns the Number field if it's non-nil, zero value otherwise.
+func (a *ActionVersion) GetNumber() int {
+	if a == nil || a.Number == nil {
+		return 0
+	}
+	return *a.Number
 }
 
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -9,6 +9,16 @@ import (
 	"time"
 )
 
+func TestAction_GetAllChangesDeployed(tt *testing.T) {
+	var zeroValue bool
+	a := &Action{AllChangesDeployed: &zeroValue}
+	a.GetAllChangesDeployed()
+	a = &Action{}
+	a.GetAllChangesDeployed()
+	a = nil
+	a.GetAllChangesDeployed()
+}
+
 func TestAction_GetBuiltAt(tt *testing.T) {
 	var zeroValue time.Time
 	a := &Action{BuiltAt: &zeroValue}
@@ -37,6 +47,16 @@ func TestAction_GetCreatedAt(tt *testing.T) {
 	a.GetCreatedAt()
 	a = nil
 	a.GetCreatedAt()
+}
+
+func TestAction_GetDependencies(tt *testing.T) {
+	var zeroValue []ActionDependency
+	a := &Action{Dependencies: &zeroValue}
+	a.GetDependencies()
+	a = &Action{}
+	a.GetDependencies()
+	a = nil
+	a.GetDependencies()
 }
 
 func TestAction_GetDeployedVersion(tt *testing.T) {
@@ -76,6 +96,16 @@ func TestAction_GetRuntime(tt *testing.T) {
 	a.GetRuntime()
 }
 
+func TestAction_GetSecrets(tt *testing.T) {
+	var zeroValue []ActionSecret
+	a := &Action{Secrets: &zeroValue}
+	a.GetSecrets()
+	a = &Action{}
+	a.GetSecrets()
+	a = nil
+	a.GetSecrets()
+}
+
 func TestAction_GetStatus(tt *testing.T) {
 	var zeroValue string
 	a := &Action{Status: &zeroValue}
@@ -84,6 +114,16 @@ func TestAction_GetStatus(tt *testing.T) {
 	a.GetStatus()
 	a = nil
 	a.GetStatus()
+}
+
+func TestAction_GetSupportedTriggers(tt *testing.T) {
+	var zeroValue []ActionTrigger
+	a := &Action{SupportedTriggers: &zeroValue}
+	a.GetSupportedTriggers()
+	a = &Action{}
+	a.GetSupportedTriggers()
+	a = nil
+	a.GetSupportedTriggers()
 }
 
 func TestAction_GetUpdatedAt(tt *testing.T) {
@@ -148,6 +188,16 @@ func TestActionBinding_GetRef(tt *testing.T) {
 	a.GetRef()
 }
 
+func TestActionBinding_GetSecrets(tt *testing.T) {
+	var zeroValue []ActionSecret
+	a := &ActionBinding{Secrets: &zeroValue}
+	a.GetSecrets()
+	a = &ActionBinding{}
+	a.GetSecrets()
+	a = nil
+	a.GetSecrets()
+}
+
 func TestActionBinding_GetTriggerID(tt *testing.T) {
 	var zeroValue string
 	a := &ActionBinding{TriggerID: &zeroValue}
@@ -174,6 +224,16 @@ func TestActionBinding_String(t *testing.T) {
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
+}
+
+func TestActionBindingList_GetBindings(tt *testing.T) {
+	var zeroValue []ActionBinding
+	a := &ActionBindingList{Bindings: &zeroValue}
+	a.GetBindings()
+	a = &ActionBindingList{}
+	a.GetBindings()
+	a = nil
+	a.GetBindings()
 }
 
 func TestActionBindingList_String(t *testing.T) {
@@ -270,6 +330,16 @@ func TestActionExecution_GetID(tt *testing.T) {
 	a.GetID()
 }
 
+func TestActionExecution_GetResults(tt *testing.T) {
+	var zeroValue []ActionExecutionResult
+	a := &ActionExecution{Results: &zeroValue}
+	a.GetResults()
+	a = &ActionExecution{}
+	a.GetResults()
+	a = nil
+	a.GetResults()
+}
+
 func TestActionExecution_GetStatus(tt *testing.T) {
 	var zeroValue string
 	a := &ActionExecution{Status: &zeroValue}
@@ -344,6 +414,16 @@ func TestActionExecutionResult_String(t *testing.T) {
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
+}
+
+func TestActionList_GetActions(tt *testing.T) {
+	var zeroValue []Action
+	a := &ActionList{Actions: &zeroValue}
+	a.GetActions()
+	a = &ActionList{}
+	a.GetActions()
+	a = nil
+	a.GetActions()
 }
 
 func TestActionList_String(t *testing.T) {
@@ -430,6 +510,16 @@ func TestActionTrigger_String(t *testing.T) {
 	}
 }
 
+func TestActionTriggerList_GetTriggers(tt *testing.T) {
+	var zeroValue []ActionTrigger
+	a := &ActionTriggerList{Triggers: &zeroValue}
+	a.GetTriggers()
+	a = &ActionTriggerList{}
+	a.GetTriggers()
+	a = nil
+	a.GetTriggers()
+}
+
 func TestActionTriggerList_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ActionTriggerList{}
@@ -475,6 +565,26 @@ func TestActionVersion_GetCreatedAt(tt *testing.T) {
 	a.GetCreatedAt()
 }
 
+func TestActionVersion_GetDependencies(tt *testing.T) {
+	var zeroValue []ActionDependency
+	a := &ActionVersion{Dependencies: &zeroValue}
+	a.GetDependencies()
+	a = &ActionVersion{}
+	a.GetDependencies()
+	a = nil
+	a.GetDependencies()
+}
+
+func TestActionVersion_GetErrors(tt *testing.T) {
+	var zeroValue []ActionVersionError
+	a := &ActionVersion{Errors: &zeroValue}
+	a.GetErrors()
+	a = &ActionVersion{}
+	a.GetErrors()
+	a = nil
+	a.GetErrors()
+}
+
 func TestActionVersion_GetID(tt *testing.T) {
 	var zeroValue string
 	a := &ActionVersion{ID: &zeroValue}
@@ -483,6 +593,16 @@ func TestActionVersion_GetID(tt *testing.T) {
 	a.GetID()
 	a = nil
 	a.GetID()
+}
+
+func TestActionVersion_GetNumber(tt *testing.T) {
+	var zeroValue int
+	a := &ActionVersion{Number: &zeroValue}
+	a.GetNumber()
+	a = &ActionVersion{}
+	a.GetNumber()
+	a = nil
+	a.GetNumber()
 }
 
 func TestActionVersion_GetStatus(tt *testing.T) {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -6933,6 +6933,16 @@ func TestResourceServer_GetName(tt *testing.T) {
 	r.GetName()
 }
 
+func TestResourceServer_GetScopes(tt *testing.T) {
+	var zeroValue []ResourceServerScope
+	r := &ResourceServer{Scopes: &zeroValue}
+	r.GetScopes()
+	r = &ResourceServer{}
+	r.GetScopes()
+	r = nil
+	r.GetScopes()
+}
+
 func TestResourceServer_GetSigningAlgorithm(tt *testing.T) {
 	var zeroValue string
 	r := &ResourceServer{SigningAlgorithm: &zeroValue}

--- a/management/resource_server.go
+++ b/management/resource_server.go
@@ -14,7 +14,7 @@ type ResourceServer struct {
 	Identifier *string `json:"identifier,omitempty"`
 
 	// Scopes supported by the resource server.
-	Scopes []*ResourceServerScope `json:"scopes,omitempty"`
+	Scopes *[]ResourceServerScope `json:"scopes,omitempty"`
 
 	// The algorithm used to sign tokens ["HS256" or "RS256"].
 	SigningAlgorithm *string `json:"signing_alg,omitempty"`
@@ -63,7 +63,7 @@ type ResourceServerScope struct {
 // ResourceServerList is a list of ResourceServers.
 type ResourceServerList struct {
 	List
-	ResourceServers []*ResourceServer `json:"resource_servers"`
+	ResourceServers []ResourceServer `json:"resource_servers"`
 }
 
 // ResourceServerManager is used for managing a ResourceServer.
@@ -121,7 +121,7 @@ func (m *ResourceServerManager) Stream(fn func(s *ResourceServer), opts ...Reque
 			return err
 		}
 		for _, s := range l.ResourceServers {
-			fn(s)
+			fn(&s)
 		}
 		if !l.HasNext() {
 			break

--- a/management/resource_server_test.go
+++ b/management/resource_server_test.go
@@ -20,7 +20,7 @@ func TestResourceServer_Create(t *testing.T) {
 		SigningAlgorithm:    auth0.String("HS256"),
 		TokenLifetime:       auth0.Int(7200),
 		TokenLifetimeForWeb: auth0.Int(3600),
-		Scopes: []*ResourceServerScope{
+		Scopes: &[]ResourceServerScope{
 			{
 				Value:       auth0.String("create:resource"),
 				Description: auth0.String("Create Resource"),
@@ -64,10 +64,12 @@ func TestResourceServer_Update(t *testing.T) {
 	expectedResourceServer.SkipConsentForVerifiableFirstPartyClients = auth0.Bool(true)
 	expectedResourceServer.TokenLifetime = auth0.Int(7200)
 	expectedResourceServer.TokenLifetimeForWeb = auth0.Int(5400)
-	expectedResourceServer.Scopes = append(expectedResourceServer.Scopes, &ResourceServerScope{
+
+	s := append(expectedResourceServer.GetScopes(), ResourceServerScope{
 		Value:       auth0.String("update:resource"),
 		Description: auth0.String("Update Resource"),
 	})
+	expectedResourceServer.Scopes = &s
 
 	err := m.ResourceServer.Update(resourceServerID, expectedResourceServer)
 
@@ -77,7 +79,7 @@ func TestResourceServer_Update(t *testing.T) {
 	assert.Equal(t, expectedResourceServer.GetSkipConsentForVerifiableFirstPartyClients(), true)
 	assert.Equal(t, expectedResourceServer.GetTokenLifetime(), 7200)
 	assert.Equal(t, expectedResourceServer.GetTokenLifetimeForWeb(), 5400)
-	assert.Equal(t, len(expectedResourceServer.Scopes), 2)
+	assert.Equal(t, len(expectedResourceServer.GetScopes()), 2)
 }
 
 func TestResourceServer_Delete(t *testing.T) {
@@ -103,7 +105,7 @@ func TestResourceServer_List(t *testing.T) {
 	resourceServerList, err := m.ResourceServer.List(IncludeFields("id"))
 
 	assert.NoError(t, err)
-	assert.Contains(t, resourceServerList.ResourceServers, &ResourceServer{ID: expectedResourceServer.ID})
+	assert.Contains(t, resourceServerList.ResourceServers, ResourceServer{ID: expectedResourceServer.ID})
 }
 
 func givenAResourceServer(t *testing.T) *ResourceServer {
@@ -115,7 +117,7 @@ func givenAResourceServer(t *testing.T) *ResourceServer {
 		SigningAlgorithm:    auth0.String("HS256"),
 		TokenLifetime:       auth0.Int(7200),
 		TokenLifetimeForWeb: auth0.Int(3600),
-		Scopes: []*ResourceServerScope{
+		Scopes: &[]ResourceServerScope{
 			{
 				Value:       auth0.String("create:resource"),
 				Description: auth0.String("Create Resource"),

--- a/management/role_test.go
+++ b/management/role_test.go
@@ -105,7 +105,7 @@ func TestRoleManager_Permissions(t *testing.T) {
 	resourceServer := givenAResourceServer(t)
 	permissions := []*Permission{
 		{
-			Name:                     resourceServer.Scopes[0].Value,
+			Name:                     resourceServer.GetScopes()[0].Value,
 			ResourceServerIdentifier: resourceServer.Identifier,
 		},
 	}

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -154,7 +154,7 @@ func TestUserManager_Permissions(t *testing.T) {
 	resourceServer := givenAResourceServer(t)
 	permissions := []*Permission{
 		{
-			Name:                     resourceServer.Scopes[0].Value,
+			Name:                     resourceServer.GetScopes()[0].Value,
 			ResourceServerIdentifier: resourceServer.Identifier,
 		},
 	}


### PR DESCRIPTION
## Description

There are some fields that are unable to be explicitly set to empty when making requests. This occurs with fields that are tagged with `omitempty` in their struct definitions; the system has no way to differentiate between explicitly empty and omitted. This shortcoming has been frequently logged as an issue in the Terraform provider repo, cataloged [here](https://github.com/auth0/terraform-provider-auth0/issues/14). This PR attempts to completely rectify this inability by setting the field types to pointers. By doing so, we introduce a tertiary state that we can use to distinguish between omitted and explicitly empty values. 

## References

- [Related issue in auth0/terraform-provider-auth0](https://github.com/auth0/terraform-provider-auth0/issues/14)

## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [ ] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [ ] I have reviewed my own code beforehand.
- [ ] I have added documentation for new/changed functionality in this PR.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [ ] The correct base branch is being used, if not `main`.
