### PR TITLE
DXCDT-218: Allow empty fields through pointers 

### DIFF
--- a/management/actions.go
+++ b/management/actions.go
@@ -77,16 +77,16 @@ type Action struct {
 	Name *string `json:"name"`
 	// List of triggers that this action supports. At this time, an action can
 	// only target a single trigger at a time.
-	SupportedTriggers []*ActionTrigger `json:"supported_triggers"`
+	SupportedTriggers []ActionTrigger `json:"supported_triggers"`
 	// The source code of the action.
 	Code *string `json:"code,omitempty"`
 	// List of third party npm modules, and their versions, that this action
 	// depends on.
-	Dependencies []*ActionDependency `json:"dependencies,omitempty"`
+	Dependencies *[]ActionDependency `json:"dependencies,omitempty"`
 	// The Node runtime. For example `node16`, defaults to `node12`
 	Runtime *string `json:"runtime,omitempty"`
 	// List of secrets that are included in an action or a version of an action.
-	Secrets []*ActionSecret `json:"secrets,omitempty"`
+	Secrets *[]ActionSecret `json:"secrets,omitempty"`
 	// Version of the action that is currently deployed.
 	DeployedVersion *ActionVersion `json:"deployed_version,omitempty"`
 	// The build status of this action.

--- a/management/actions_test.go
+++ b/management/actions_test.go
@@ -17,20 +17,20 @@ func TestActionManager_Create(t *testing.T) {
 	expectedAction := &Action{
 		Name: auth0.Stringf("Test Action (%s)", time.Now().Format(time.StampMilli)),
 		Code: auth0.String("exports.onExecutePostLogin = async (event, api) =\u003e {}"),
-		SupportedTriggers: []*ActionTrigger{
+		SupportedTriggers: []ActionTrigger{
 			{
 				ID:      auth0.String(ActionTriggerPostLogin),
 				Version: auth0.String("v2"),
 			},
 		},
-		Dependencies: []*ActionDependency{
+		Dependencies: &[]ActionDependency{
 			{
 				Name:        auth0.String("lodash"),
 				Version:     auth0.String("4.0.0"),
 				RegistryURL: auth0.String("https://www.npmjs.com/package/lodash"),
 			},
 		},
-		Secrets: []*ActionSecret{
+		Secrets: &[]ActionSecret{
 			{
 				Name:  auth0.String("mySecretName"),
 				Value: auth0.String("mySecretValue"),
@@ -255,20 +255,20 @@ func givenAnAction(t *testing.T) *Action {
 	action := &Action{
 		Name: auth0.Stringf("Test Action (%s)", time.Now().Format(time.StampMilli)),
 		Code: auth0.String("exports.onExecutePostLogin = async (event, api) =\u003e {}"),
-		SupportedTriggers: []*ActionTrigger{
+		SupportedTriggers: []ActionTrigger{
 			{
 				ID:      auth0.String(ActionTriggerPostLogin),
 				Version: auth0.String("v2"),
 			},
 		},
-		Dependencies: []*ActionDependency{
+		Dependencies: &[]ActionDependency{
 			{
 				Name:        auth0.String("lodash"),
 				Version:     auth0.String("4.0.0"),
 				RegistryURL: auth0.String("https://www.npmjs.com/package/lodash"),
 			},
 		},
-		Secrets: []*ActionSecret{
+		Secrets: &[]ActionSecret{
 			{
 				Name:  auth0.String("mySecretName"),
 				Value: auth0.String("mySecretValue"),

--- a/management/client.go
+++ b/management/client.go
@@ -42,19 +42,19 @@ type Client struct {
 	OIDCConformant *bool `json:"oidc_conformant,omitempty"`
 
 	// The URLs that Auth0 can use to as a callback for the client.
-	Callbacks      []interface{} `json:"callbacks,omitempty"`
-	AllowedOrigins []interface{} `json:"allowed_origins,omitempty"`
+	Callbacks      *[]string `json:"callbacks,omitempty"`
+	AllowedOrigins *[]string `json:"allowed_origins,omitempty"`
 
 	// A set of URLs that represents valid web origins for use with web message response mode.
-	WebOrigins        []interface{}           `json:"web_origins,omitempty"`
-	ClientAliases     []interface{}           `json:"client_aliases,omitempty"`
-	AllowedClients    []interface{}           `json:"allowed_clients,omitempty"`
-	AllowedLogoutURLs []interface{}           `json:"allowed_logout_urls,omitempty"`
+	WebOrigins        *[]string               `json:"web_origins,omitempty"`
+	ClientAliases     *[]string               `json:"client_aliases,omitempty"`
+	AllowedClients    *[]string               `json:"allowed_clients,omitempty"`
+	AllowedLogoutURLs *[]string               `json:"allowed_logout_urls,omitempty"`
 	JWTConfiguration  *ClientJWTConfiguration `json:"jwt_configuration,omitempty"`
 
 	// Client signing keys.
 	SigningKeys   []map[string]string `json:"signing_keys,omitempty"`
-	EncryptionKey map[string]string   `json:"encryption_key,omitempty"`
+	EncryptionKey *map[string]string  `json:"encryption_key,omitempty"`
 	SSO           *bool               `json:"sso,omitempty"`
 
 	// True to disable Single Sign On, false otherwise (default: false).
@@ -65,7 +65,7 @@ type Client struct {
 	CrossOriginAuth *bool `json:"cross_origin_auth,omitempty"`
 
 	// List of acceptable Grant Types for this Client.
-	GrantTypes []interface{} `json:"grant_types,omitempty"`
+	GrantTypes *[]string `json:"grant_types,omitempty"`
 
 	// URL for the location in your site where the cross origin verification
 	// takes place for the cross-origin auth flow when performing Auth in your
@@ -84,9 +84,9 @@ type Client struct {
 	// 	'none' (public client without a client secret),
 	// 	'client_secret_post' (client uses HTTP POST parameters) or
 	// 	'client_secret_basic' (client uses HTTP Basic)
-	TokenEndpointAuthMethod *string                `json:"token_endpoint_auth_method,omitempty"`
-	ClientMetadata          map[string]string      `json:"client_metadata,omitempty"`
-	Mobile                  map[string]interface{} `json:"mobile,omitempty"`
+	TokenEndpointAuthMethod *string            `json:"token_endpoint_auth_method,omitempty"`
+	ClientMetadata          *map[string]string `json:"client_metadata,omitempty"`
+	Mobile                  *ClientMobile      `json:"mobile,omitempty"`
 
 	// Initiate login uri, must be https and cannot contain a fragment.
 	InitiateLoginURI *string `json:"initiate_login_uri,omitempty"`
@@ -107,7 +107,7 @@ type ClientJWTConfiguration struct {
 	// true
 	SecretEncoded *bool `json:"secret_encoded,omitempty"`
 
-	Scopes map[string]interface{} `json:"scopes,omitempty"`
+	Scopes *map[string]string `json:"scopes,omitempty"`
 
 	// Algorithm used to sign JWTs. Can be "HS256" or "RS256"
 	Algorithm *string `json:"alg,omitempty"`
@@ -116,10 +116,33 @@ type ClientJWTConfiguration struct {
 // ClientNativeSocialLogin is used to configure Native Social Login for our Client.
 type ClientNativeSocialLogin struct {
 	// Native Social Login support for the Apple connection
-	Apple map[string]interface{} `json:"apple,omitempty"`
+	Apple *ClientNativeSocialLoginSupportEnabled `json:"apple,omitempty"`
 
 	// Native Social Login support for the Facebook connection
-	Facebook map[string]interface{} `json:"facebook,omitempty"`
+	Facebook *ClientNativeSocialLoginSupportEnabled `json:"facebook,omitempty"`
+}
+
+// ClientNativeSocialLoginSupportEnabled used to indicate if support is enabled or not.
+type ClientNativeSocialLoginSupportEnabled struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// ClientMobile is used to configure mobile app settings.
+type ClientMobile struct {
+	Android *ClientMobileAndroid `json:"android,omitempty"`
+	IOS     *ClientMobileIOS     `json:"ios,omitempty"`
+}
+
+// ClientMobileAndroid is used to configure Android app settings.
+type ClientMobileAndroid struct {
+	AppPackageName *string   `json:"app_package_name,omitempty"`
+	KeyHashes      *[]string `json:"sha256_cert_fingerprints,omitempty"`
+}
+
+// ClientMobileIOS is used to configure iOS app settings.
+type ClientMobileIOS struct {
+	TeamID *string `json:"team_id,omitempty"`
+	AppID  *string `json:"app_bundle_identifier,omitempty"`
 }
 
 // ClientRefreshToken is used to configure the Refresh Token settings for our Client.

--- a/management/client_grant.go
+++ b/management/client_grant.go
@@ -13,7 +13,7 @@ type ClientGrant struct {
 	// The audience.
 	Audience *string `json:"audience,omitempty"`
 
-	Scope *[]string `json:"scope"`
+	Scope []string `json:"scope"`
 }
 
 // ClientGrantList is a list of ClientGrants.

--- a/management/client_grant.go
+++ b/management/client_grant.go
@@ -13,7 +13,7 @@ type ClientGrant struct {
 	// The audience.
 	Audience *string `json:"audience,omitempty"`
 
-	Scope []interface{} `json:"scope"`
+	Scope *[]string `json:"scope"`
 }
 
 // ClientGrantList is a list of ClientGrants.

--- a/management/client_grant_test.go
+++ b/management/client_grant_test.go
@@ -15,7 +15,7 @@ func TestClientGrantManager_Create(t *testing.T) {
 	expectedClientGrant := &ClientGrant{
 		ClientID: client.ClientID,
 		Audience: resourceServer.Identifier,
-		Scope:    &[]string{"create:resource"},
+		Scope:    []string{"create:resource"},
 	}
 
 	err := m.ClientGrant.Create(expectedClientGrant)
@@ -51,13 +51,13 @@ func TestClientGrantManager_Update(t *testing.T) {
 	expectedClientGrant.Audience = nil // Read-Only: Additional properties not allowed.
 	expectedClientGrant.ClientID = nil // Read-Only: Additional properties not allowed.
 
-	scope := expectedClientGrant.GetScope()
+	scope := expectedClientGrant.Scope
 	scope = append(scope, "update:resource")
-	expectedClientGrant.Scope = &scope
+	expectedClientGrant.Scope = scope
 
 	err := m.ClientGrant.Update(clientGrantID, expectedClientGrant)
 	assert.NoError(t, err)
-	assert.Equal(t, len(expectedClientGrant.GetScope()), 2)
+	assert.Equal(t, len(expectedClientGrant.Scope), 2)
 }
 
 func TestClientGrantManager_Delete(t *testing.T) {
@@ -95,7 +95,7 @@ func givenAClientGrant(t *testing.T) (clientGrant *ClientGrant) {
 	clientGrant = &ClientGrant{
 		ClientID: client.ClientID,
 		Audience: resourceServer.Identifier,
-		Scope:    &[]string{"create:resource"},
+		Scope:    []string{"create:resource"},
 	}
 
 	err := m.ClientGrant.Create(clientGrant)

--- a/management/client_grant_test.go
+++ b/management/client_grant_test.go
@@ -15,7 +15,7 @@ func TestClientGrantManager_Create(t *testing.T) {
 	expectedClientGrant := &ClientGrant{
 		ClientID: client.ClientID,
 		Audience: resourceServer.Identifier,
-		Scope:    []interface{}{"create:resource"},
+		Scope:    &[]string{"create:resource"},
 	}
 
 	err := m.ClientGrant.Create(expectedClientGrant)
@@ -51,11 +51,13 @@ func TestClientGrantManager_Update(t *testing.T) {
 	expectedClientGrant.Audience = nil // Read-Only: Additional properties not allowed.
 	expectedClientGrant.ClientID = nil // Read-Only: Additional properties not allowed.
 
-	expectedClientGrant.Scope = append(expectedClientGrant.Scope, "update:resource")
+	scope := expectedClientGrant.GetScope()
+	scope = append(scope, "update:resource")
+	expectedClientGrant.Scope = &scope
 
 	err := m.ClientGrant.Update(clientGrantID, expectedClientGrant)
 	assert.NoError(t, err)
-	assert.Equal(t, len(expectedClientGrant.Scope), 2)
+	assert.Equal(t, len(expectedClientGrant.GetScope()), 2)
 }
 
 func TestClientGrantManager_Delete(t *testing.T) {
@@ -93,7 +95,7 @@ func givenAClientGrant(t *testing.T) (clientGrant *ClientGrant) {
 	clientGrant = &ClientGrant{
 		ClientID: client.ClientID,
 		Audience: resourceServer.Identifier,
-		Scope:    []interface{}{"create:resource"},
+		Scope:    &[]string{"create:resource"},
 	}
 
 	err := m.ClientGrant.Create(clientGrant)

--- a/management/connection.go
+++ b/management/connection.go
@@ -123,14 +123,14 @@ type Connection struct {
 	// The identifiers of the clients for which the connection is to be
 	// enabled. If the array is empty or the property is not specified, no
 	// clients are enabled.
-	EnabledClients []interface{} `json:"enabled_clients,omitempty"`
+	EnabledClients *[]string `json:"enabled_clients,omitempty"`
 
 	// Defines the realms for which the connection will be used (ie: email
 	// domains). If the array is empty or the property is not specified, the
 	// connection name will be added as realm.
-	Realms []interface{} `json:"realms,omitempty"`
+	Realms *[]string `json:"realms,omitempty"`
 
-	Metadata map[string]string `json:"metadata,omitempty"`
+	Metadata *map[string]string `json:"metadata,omitempty"`
 
 	// Provisioning Ticket URL is Ticket URL for Active Directory/LDAP, etc.
 	ProvisioningTicketURL *string `json:"provisioning_ticket_url,omitempty"`
@@ -283,11 +283,12 @@ type ConnectionOptions struct {
 
 	RequiresUsername *bool `json:"requires_username,omitempty"`
 
-	// Scripts for the connection
+	// Scripts for the connection.
 	// Allowed keys are: "get_user", "login", "create", "verify", "change_password", "delete" or "change_email".
-	CustomScripts map[string]interface{} `json:"customScripts,omitempty"`
-	// configuration variables that can be used in custom scripts
-	Configuration map[string]interface{} `json:"configuration,omitempty"`
+	CustomScripts *map[string]string `json:"customScripts,omitempty"`
+
+	// Configuration variables that can be used in custom scripts.
+	Configuration *map[string]string `json:"configuration,omitempty"`
 
 	StrategyVersion *int `json:"strategy_version,omitempty"`
 
@@ -302,7 +303,7 @@ type ConnectionOptionsGoogleOAuth2 struct {
 	ClientID     *string `json:"client_id,omitempty"`
 	ClientSecret *string `json:"client_secret,omitempty"`
 
-	AllowedAudiences []interface{} `json:"allowed_audiences,omitempty"`
+	AllowedAudiences *[]string `json:"allowed_audiences,omitempty"`
 
 	Email                  *bool         `json:"email,omitempty" scope:"email"`
 	Profile                *bool         `json:"profile,omitempty" scope:"profile"`
@@ -665,9 +666,9 @@ type ConnectionOptionsOIDC struct {
 	ClientID     *string `json:"client_id,omitempty"`
 	ClientSecret *string `json:"client_secret,omitempty"`
 
-	TenantDomain  *string       `json:"tenant_domain,omitempty"`
-	DomainAliases []interface{} `json:"domain_aliases,omitempty"`
-	LogoURL       *string       `json:"icon_url,omitempty"`
+	TenantDomain  *string   `json:"tenant_domain,omitempty"`
+	DomainAliases *[]string `json:"domain_aliases,omitempty"`
+	LogoURL       *string   `json:"icon_url,omitempty"`
 
 	DiscoveryURL          *string `json:"discovery_url"`
 	AuthorizationEndpoint *string `json:"authorization_endpoint"`
@@ -722,7 +723,7 @@ type ConnectionOptionsOAuth2 struct {
 	PKCEEnabled        *bool     `json:"pkce_enabled,omitempty"`
 	// Scripts for the connection
 	// Allowed keys are: "fetchUserProfile"
-	Scripts map[string]interface{} `json:"scripts,omitempty"`
+	Scripts *map[string]string `json:"scripts,omitempty"`
 
 	UpstreamParams map[string]interface{} `json:"upstream_params,omitempty"`
 }
@@ -754,10 +755,10 @@ func (c *ConnectionOptionsOAuth2) SetScopes(enable bool, scopes ...string) {
 
 // ConnectionOptionsAD is used to configure an AD Connection.
 type ConnectionOptionsAD struct {
-	TenantDomain  *string       `json:"tenant_domain,omitempty"`
-	DomainAliases []interface{} `json:"domain_aliases,omitempty"`
-	LogoURL       *string       `json:"icon_url,omitempty"`
-	IPs           []interface{} `json:"ips"`
+	TenantDomain  *string   `json:"tenant_domain,omitempty"`
+	DomainAliases *[]string `json:"domain_aliases,omitempty"`
+	LogoURL       *string   `json:"icon_url,omitempty"`
+	IPs           *[]string `json:"ips,omitempty"`
 
 	CertAuth             *bool `json:"certAuth,omitempty"`
 	Kerberos             *bool `json:"kerberos,omitempty"`
@@ -775,11 +776,11 @@ type ConnectionOptionsAzureAD struct {
 	ClientID     *string `json:"client_id,omitempty"`
 	ClientSecret *string `json:"client_secret,omitempty"`
 
-	AppID         *string       `json:"app_id,omitempty"`
-	TenantDomain  *string       `json:"tenant_domain,omitempty"`
-	Domain        *string       `json:"domain,omitempty"`
-	DomainAliases []interface{} `json:"domain_aliases,omitempty"`
-	LogoURL       *string       `json:"icon_url,omitempty"`
+	AppID         *string   `json:"app_id,omitempty"`
+	TenantDomain  *string   `json:"tenant_domain,omitempty"`
+	Domain        *string   `json:"domain,omitempty"`
+	DomainAliases *[]string `json:"domain_aliases,omitempty"`
+	LogoURL       *string   `json:"icon_url,omitempty"`
 
 	IdentityAPI *string `json:"identity_api"`
 
@@ -819,10 +820,10 @@ func (c *ConnectionOptionsAzureAD) SetScopes(enable bool, scopes ...string) {
 
 // ConnectionOptionsADFS is used to configure an ADFS Connection.
 type ConnectionOptionsADFS struct {
-	TenantDomain  *string       `json:"tenant_domain,omitempty"`
-	DomainAliases []interface{} `json:"domain_aliases,omitempty"`
-	LogoURL       *string       `json:"icon_url,omitempty"`
-	ADFSServer    *string       `json:"adfs_server,omitempty"`
+	TenantDomain  *string   `json:"tenant_domain,omitempty"`
+	DomainAliases *[]string `json:"domain_aliases,omitempty"`
+	LogoURL       *string   `json:"icon_url,omitempty"`
+	ADFSServer    *string   `json:"adfs_server,omitempty"`
 
 	EnableUsersAPI *bool `json:"api_enable_users,omitempty"`
 
@@ -844,7 +845,7 @@ type ConnectionOptionsSAML struct {
 	Thumbprints        []interface{}                      `json:"thumbprints,omitempty"`
 	ProtocolBinding    *string                            `json:"protocolBinding,omitempty"`
 	TenantDomain       *string                            `json:"tenant_domain,omitempty"`
-	DomainAliases      []interface{}                      `json:"domain_aliases,omitempty"`
+	DomainAliases      *[]string                          `json:"domain_aliases,omitempty"`
 	SignInEndpoint     *string                            `json:"signInEndpoint,omitempty"`
 	SignOutEndpoint    *string                            `json:"signOutEndpoint,omitempty"`
 	DisableSignOut     *bool                              `json:"disableSignout,omitempty"`
@@ -903,8 +904,8 @@ type ConnectionOptionsGoogleApps struct {
 	SetUserAttributes  *string   `json:"set_user_root_attributes,omitempty"`
 	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`
 
-	DomainAliases []interface{} `json:"domain_aliases,omitempty"`
-	LogoURL       *string       `json:"icon_url,omitempty"`
+	DomainAliases *[]string `json:"domain_aliases,omitempty"`
+	LogoURL       *string   `json:"icon_url,omitempty"`
 
 	UpstreamParams map[string]interface{} `json:"upstream_params,omitempty"`
 }

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -33,7 +33,7 @@ var connectionTestCases = []connectionTestCase{
 			Strategy: auth0.String("google-oauth2"),
 		},
 		options: &ConnectionOptionsGoogleOAuth2{
-			AllowedAudiences: []interface{}{
+			AllowedAudiences: &[]string{
 				"example.com",
 				"api.example.com",
 			},

--- a/management/example_test.go
+++ b/management/example_test.go
@@ -161,7 +161,7 @@ func ExampleConnectionManager_Create() {
 		Options: &management.ConnectionOptionsGoogleOAuth2{
 			ClientID:     auth0.String(""), // replace with your client id
 			ClientSecret: auth0.String(""),
-			AllowedAudiences: []interface{}{
+			AllowedAudiences: &[]string{
 				"example.com",
 				"api.example.com",
 			},

--- a/management/hook.go
+++ b/management/hook.go
@@ -22,7 +22,7 @@ type Hook struct {
 	TriggerID *string `json:"triggerId,omitempty"`
 
 	// Used to store additional metadata
-	Dependencies *map[string]interface{} `json:"dependencies,omitempty"`
+	Dependencies *map[string]string `json:"dependencies,omitempty"`
 
 	// Enabled should be set to true if the hook is enabled, false otherwise.
 	Enabled *bool `json:"enabled,omitempty"`

--- a/management/log_stream.go
+++ b/management/log_stream.go
@@ -40,7 +40,7 @@ type LogStream struct {
 
 	// Only logs events matching these filters will be delivered by the stream.
 	// If omitted or empty, all events will be delivered.
-	Filters []interface{} `json:"filters,omitempty"`
+	Filters *[]map[string]string `json:"filters,omitempty"`
 
 	// Sink for validation.
 	Sink interface{} `json:"-"`
@@ -146,7 +146,7 @@ type LogStreamSinkHTTP struct {
 	// HTTP Authorization
 	Authorization *string `json:"httpAuthorization,omitempty"`
 	// Custom HTTP headers
-	CustomHeaders []interface{} `json:"httpCustomHeaders,omitempty"`
+	CustomHeaders *[]map[string]string `json:"httpCustomHeaders,omitempty"`
 }
 
 // LogStreamSinkDatadog is used to export logs to Datadog.

--- a/management/log_stream_test.go
+++ b/management/log_stream_test.go
@@ -129,8 +129,8 @@ func TestLogStreamManager_Update(t *testing.T) {
 
 			logStream := givenALogStream(t, testCase)
 			updatedLogStream := &LogStream{
-				Filters: []interface{}{
-					map[string]string{
+				Filters: &[]map[string]string{
+					{
 						"type": "category",
 						"name": "auth.login.fail",
 					},

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -920,6 +920,14 @@ func (c *Client) GetLogoURI() string {
 	return *c.LogoURI
 }
 
+// GetMobile returns the Mobile field.
+func (c *Client) GetMobile() *ClientMobile {
+	if c == nil {
+		return nil
+	}
+	return c.Mobile
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (c *Client) GetName() string {
 	if c == nil || c.Name == nil {
@@ -1063,6 +1071,14 @@ func (c *ClientJWTConfiguration) GetLifetimeInSeconds() int {
 	return *c.LifetimeInSeconds
 }
 
+// GetScopes returns the Scopes field if it's non-nil, zero value otherwise.
+func (c *ClientJWTConfiguration) GetScopes() map[string]string {
+	if c == nil || c.Scopes == nil {
+		return map[string]string{}
+	}
+	return *c.Scopes
+}
+
 // GetSecretEncoded returns the SecretEncoded field if it's non-nil, zero value otherwise.
 func (c *ClientJWTConfiguration) GetSecretEncoded() bool {
 	if c == nil || c.SecretEncoded == nil {
@@ -1081,8 +1097,100 @@ func (c *ClientList) String() string {
 	return Stringify(c)
 }
 
+// GetAndroid returns the Android field.
+func (c *ClientMobile) GetAndroid() *ClientMobileAndroid {
+	if c == nil {
+		return nil
+	}
+	return c.Android
+}
+
+// GetIOS returns the IOS field.
+func (c *ClientMobile) GetIOS() *ClientMobileIOS {
+	if c == nil {
+		return nil
+	}
+	return c.IOS
+}
+
+// String returns a string representation of ClientMobile.
+func (c *ClientMobile) String() string {
+	return Stringify(c)
+}
+
+// GetAppPackageName returns the AppPackageName field if it's non-nil, zero value otherwise.
+func (c *ClientMobileAndroid) GetAppPackageName() string {
+	if c == nil || c.AppPackageName == nil {
+		return ""
+	}
+	return *c.AppPackageName
+}
+
+// GetKeyHashes returns the KeyHashes field if it's non-nil, zero value otherwise.
+func (c *ClientMobileAndroid) GetKeyHashes() []string {
+	if c == nil || c.KeyHashes == nil {
+		return nil
+	}
+	return *c.KeyHashes
+}
+
+// String returns a string representation of ClientMobileAndroid.
+func (c *ClientMobileAndroid) String() string {
+	return Stringify(c)
+}
+
+// GetAppID returns the AppID field if it's non-nil, zero value otherwise.
+func (c *ClientMobileIOS) GetAppID() string {
+	if c == nil || c.AppID == nil {
+		return ""
+	}
+	return *c.AppID
+}
+
+// GetTeamID returns the TeamID field if it's non-nil, zero value otherwise.
+func (c *ClientMobileIOS) GetTeamID() string {
+	if c == nil || c.TeamID == nil {
+		return ""
+	}
+	return *c.TeamID
+}
+
+// String returns a string representation of ClientMobileIOS.
+func (c *ClientMobileIOS) String() string {
+	return Stringify(c)
+}
+
+// GetApple returns the Apple field.
+func (c *ClientNativeSocialLogin) GetApple() *ClientNativeSocialLoginSupportEnabled {
+	if c == nil {
+		return nil
+	}
+	return c.Apple
+}
+
+// GetFacebook returns the Facebook field.
+func (c *ClientNativeSocialLogin) GetFacebook() *ClientNativeSocialLoginSupportEnabled {
+	if c == nil {
+		return nil
+	}
+	return c.Facebook
+}
+
 // String returns a string representation of ClientNativeSocialLogin.
 func (c *ClientNativeSocialLogin) String() string {
+	return Stringify(c)
+}
+
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (c *ClientNativeSocialLoginSupportEnabled) GetEnabled() bool {
+	if c == nil || c.Enabled == nil {
+		return false
+	}
+	return *c.Enabled
+}
+
+// String returns a string representation of ClientNativeSocialLoginSupportEnabled.
+func (c *ClientNativeSocialLoginSupportEnabled) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1037,14 +1037,6 @@ func (c *ClientGrant) GetID() string {
 	return *c.ID
 }
 
-// GetScope returns the Scope field if it's non-nil, zero value otherwise.
-func (c *ClientGrant) GetScope() []string {
-	if c == nil || c.Scope == nil {
-		return nil
-	}
-	return *c.Scope
-}
-
 // String returns a string representation of ClientGrant.
 func (c *ClientGrant) String() string {
 	return Stringify(c)

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -720,12 +720,52 @@ func (b *BruteForceProtection) String() string {
 	return Stringify(b)
 }
 
+// GetAllowedClients returns the AllowedClients field if it's non-nil, zero value otherwise.
+func (c *Client) GetAllowedClients() []string {
+	if c == nil || c.AllowedClients == nil {
+		return nil
+	}
+	return *c.AllowedClients
+}
+
+// GetAllowedLogoutURLs returns the AllowedLogoutURLs field if it's non-nil, zero value otherwise.
+func (c *Client) GetAllowedLogoutURLs() []string {
+	if c == nil || c.AllowedLogoutURLs == nil {
+		return nil
+	}
+	return *c.AllowedLogoutURLs
+}
+
+// GetAllowedOrigins returns the AllowedOrigins field if it's non-nil, zero value otherwise.
+func (c *Client) GetAllowedOrigins() []string {
+	if c == nil || c.AllowedOrigins == nil {
+		return nil
+	}
+	return *c.AllowedOrigins
+}
+
 // GetAppType returns the AppType field if it's non-nil, zero value otherwise.
 func (c *Client) GetAppType() string {
 	if c == nil || c.AppType == nil {
 		return ""
 	}
 	return *c.AppType
+}
+
+// GetCallbacks returns the Callbacks field if it's non-nil, zero value otherwise.
+func (c *Client) GetCallbacks() []string {
+	if c == nil || c.Callbacks == nil {
+		return nil
+	}
+	return *c.Callbacks
+}
+
+// GetClientAliases returns the ClientAliases field if it's non-nil, zero value otherwise.
+func (c *Client) GetClientAliases() []string {
+	if c == nil || c.ClientAliases == nil {
+		return nil
+	}
+	return *c.ClientAliases
 }
 
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
@@ -736,12 +776,12 @@ func (c *Client) GetClientID() string {
 	return *c.ClientID
 }
 
-// GetClientMetadata returns the ClientMetadata map if it's non-nil, an empty map otherwise.
+// GetClientMetadata returns the ClientMetadata field if it's non-nil, zero value otherwise.
 func (c *Client) GetClientMetadata() map[string]string {
 	if c == nil || c.ClientMetadata == nil {
 		return map[string]string{}
 	}
-	return c.ClientMetadata
+	return *c.ClientMetadata
 }
 
 // GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
@@ -800,12 +840,12 @@ func (c *Client) GetDescription() string {
 	return *c.Description
 }
 
-// GetEncryptionKey returns the EncryptionKey map if it's non-nil, an empty map otherwise.
+// GetEncryptionKey returns the EncryptionKey field if it's non-nil, zero value otherwise.
 func (c *Client) GetEncryptionKey() map[string]string {
 	if c == nil || c.EncryptionKey == nil {
 		return map[string]string{}
 	}
-	return c.EncryptionKey
+	return *c.EncryptionKey
 }
 
 // GetFormTemplate returns the FormTemplate field if it's non-nil, zero value otherwise.
@@ -814,6 +854,14 @@ func (c *Client) GetFormTemplate() string {
 		return ""
 	}
 	return *c.FormTemplate
+}
+
+// GetGrantTypes returns the GrantTypes field if it's non-nil, zero value otherwise.
+func (c *Client) GetGrantTypes() []string {
+	if c == nil || c.GrantTypes == nil {
+		return nil
+	}
+	return *c.GrantTypes
 }
 
 // GetInitiateLoginURI returns the InitiateLoginURI field if it's non-nil, zero value otherwise.
@@ -928,6 +976,14 @@ func (c *Client) GetTokenEndpointAuthMethod() string {
 	return *c.TokenEndpointAuthMethod
 }
 
+// GetWebOrigins returns the WebOrigins field if it's non-nil, zero value otherwise.
+func (c *Client) GetWebOrigins() []string {
+	if c == nil || c.WebOrigins == nil {
+		return nil
+	}
+	return *c.WebOrigins
+}
+
 // String returns a string representation of Client.
 func (c *Client) String() string {
 	return Stringify(c)
@@ -955,6 +1011,14 @@ func (c *ClientGrant) GetID() string {
 		return ""
 	}
 	return *c.ID
+}
+
+// GetScope returns the Scope field if it's non-nil, zero value otherwise.
+func (c *ClientGrant) GetScope() []string {
+	if c == nil || c.Scope == nil {
+		return nil
+	}
+	return *c.Scope
 }
 
 // String returns a string representation of ClientGrant.
@@ -1075,6 +1139,14 @@ func (c *Connection) GetDisplayName() string {
 	return *c.DisplayName
 }
 
+// GetEnabledClients returns the EnabledClients field if it's non-nil, zero value otherwise.
+func (c *Connection) GetEnabledClients() []string {
+	if c == nil || c.EnabledClients == nil {
+		return nil
+	}
+	return *c.EnabledClients
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (c *Connection) GetID() string {
 	if c == nil || c.ID == nil {
@@ -1091,12 +1163,12 @@ func (c *Connection) GetIsDomainConnection() bool {
 	return *c.IsDomainConnection
 }
 
-// GetMetadata returns the Metadata map if it's non-nil, an empty map otherwise.
+// GetMetadata returns the Metadata field if it's non-nil, zero value otherwise.
 func (c *Connection) GetMetadata() map[string]string {
 	if c == nil || c.Metadata == nil {
 		return map[string]string{}
 	}
-	return c.Metadata
+	return *c.Metadata
 }
 
 // GetName returns the Name field if it's non-nil, zero value otherwise.
@@ -1113,6 +1185,14 @@ func (c *Connection) GetProvisioningTicketURL() string {
 		return ""
 	}
 	return *c.ProvisioningTicketURL
+}
+
+// GetRealms returns the Realms field if it's non-nil, zero value otherwise.
+func (c *Connection) GetRealms() []string {
+	if c == nil || c.Realms == nil {
+		return nil
+	}
+	return *c.Realms
 }
 
 // GetShowAsButton returns the ShowAsButton field if it's non-nil, zero value otherwise.
@@ -1192,6 +1272,22 @@ func (c *ConnectionOptions) GetBruteForceProtection() bool {
 		return false
 	}
 	return *c.BruteForceProtection
+}
+
+// GetConfiguration returns the Configuration field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptions) GetConfiguration() map[string]string {
+	if c == nil || c.Configuration == nil {
+		return map[string]string{}
+	}
+	return *c.Configuration
+}
+
+// GetCustomScripts returns the CustomScripts field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptions) GetCustomScripts() map[string]string {
+	if c == nil || c.CustomScripts == nil {
+		return map[string]string{}
+	}
+	return *c.CustomScripts
 }
 
 // GetDisableSignup returns the DisableSignup field if it's non-nil, zero value otherwise.
@@ -1287,6 +1383,22 @@ func (c *ConnectionOptionsAD) GetDisableCache() bool {
 	return *c.DisableCache
 }
 
+// GetDomainAliases returns the DomainAliases field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetDomainAliases() []string {
+	if c == nil || c.DomainAliases == nil {
+		return nil
+	}
+	return *c.DomainAliases
+}
+
+// GetIPs returns the IPs field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetIPs() []string {
+	if c == nil || c.IPs == nil {
+		return nil
+	}
+	return *c.IPs
+}
+
 // GetKerberos returns the Kerberos field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsAD) GetKerberos() bool {
 	if c == nil || c.Kerberos == nil {
@@ -1338,6 +1450,14 @@ func (c *ConnectionOptionsADFS) GetADFSServer() string {
 		return ""
 	}
 	return *c.ADFSServer
+}
+
+// GetDomainAliases returns the DomainAliases field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetDomainAliases() []string {
+	if c == nil || c.DomainAliases == nil {
+		return nil
+	}
+	return *c.DomainAliases
 }
 
 // GetEnableUsersAPI returns the EnableUsersAPI field if it's non-nil, zero value otherwise.
@@ -1524,6 +1644,14 @@ func (c *ConnectionOptionsAzureAD) GetDomain() string {
 		return ""
 	}
 	return *c.Domain
+}
+
+// GetDomainAliases returns the DomainAliases field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetDomainAliases() []string {
+	if c == nil || c.DomainAliases == nil {
+		return nil
+	}
+	return *c.DomainAliases
 }
 
 // GetEnableUsersAPI returns the EnableUsersAPI field if it's non-nil, zero value otherwise.
@@ -2375,6 +2503,14 @@ func (c *ConnectionOptionsGoogleApps) GetDomain() string {
 	return *c.Domain
 }
 
+// GetDomainAliases returns the DomainAliases field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetDomainAliases() []string {
+	if c == nil || c.DomainAliases == nil {
+		return nil
+	}
+	return *c.DomainAliases
+}
+
 // GetEnableUsersAPI returns the EnableUsersAPI field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsGoogleApps) GetEnableUsersAPI() bool {
 	if c == nil || c.EnableUsersAPI == nil {
@@ -2450,6 +2586,14 @@ func (c *ConnectionOptionsGoogleOAuth2) GetAdsenseManagement() bool {
 		return false
 	}
 	return *c.AdsenseManagement
+}
+
+// GetAllowedAudiences returns the AllowedAudiences field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleOAuth2) GetAllowedAudiences() []string {
+	if c == nil || c.AllowedAudiences == nil {
+		return nil
+	}
+	return *c.AllowedAudiences
 }
 
 // GetAnalytics returns the Analytics field if it's non-nil, zero value otherwise.
@@ -2846,6 +2990,14 @@ func (c *ConnectionOptionsOAuth2) GetScope() string {
 	return *c.Scope
 }
 
+// GetScripts returns the Scripts field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOAuth2) GetScripts() map[string]string {
+	if c == nil || c.Scripts == nil {
+		return map[string]string{}
+	}
+	return *c.Scripts
+}
+
 // GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsOAuth2) GetSetUserAttributes() string {
 	if c == nil || c.SetUserAttributes == nil {
@@ -2897,6 +3049,14 @@ func (c *ConnectionOptionsOIDC) GetDiscoveryURL() string {
 		return ""
 	}
 	return *c.DiscoveryURL
+}
+
+// GetDomainAliases returns the DomainAliases field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetDomainAliases() []string {
+	if c == nil || c.DomainAliases == nil {
+		return nil
+	}
+	return *c.DomainAliases
 }
 
 // GetIssuer returns the Issuer field if it's non-nil, zero value otherwise.
@@ -3088,6 +3248,14 @@ func (c *ConnectionOptionsSAML) GetDisableSignOut() bool {
 		return false
 	}
 	return *c.DisableSignOut
+}
+
+// GetDomainAliases returns the DomainAliases field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetDomainAliases() []string {
+	if c == nil || c.DomainAliases == nil {
+		return nil
+	}
+	return *c.DomainAliases
 }
 
 // GetEntityID returns the EntityID field if it's non-nil, zero value otherwise.
@@ -4114,6 +4282,14 @@ func (g *GrantList) String() string {
 	return Stringify(g)
 }
 
+// GetDependencies returns the Dependencies field if it's non-nil, zero value otherwise.
+func (h *Hook) GetDependencies() map[string]string {
+	if h == nil || h.Dependencies == nil {
+		return map[string]string{}
+	}
+	return *h.Dependencies
+}
+
 // GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
 func (h *Hook) GetEnabled() bool {
 	if h == nil || h.Enabled == nil {
@@ -4883,6 +5059,14 @@ func (o *Organization) GetID() string {
 	return *o.ID
 }
 
+// GetMetadata returns the Metadata field if it's non-nil, zero value otherwise.
+func (o *Organization) GetMetadata() map[string]string {
+	if o == nil || o.Metadata == nil {
+		return map[string]string{}
+	}
+	return *o.Metadata
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (o *Organization) GetName() string {
 	if o == nil || o.Name == nil {
@@ -4894,6 +5078,14 @@ func (o *Organization) GetName() string {
 // String returns a string representation of Organization.
 func (o *Organization) String() string {
 	return Stringify(o)
+}
+
+// GetColors returns the Colors field if it's non-nil, zero value otherwise.
+func (o *OrganizationBranding) GetColors() map[string]string {
+	if o == nil || o.Colors == nil {
+		return map[string]string{}
+	}
+	return *o.Colors
 }
 
 // GetLogoURL returns the LogoURL field if it's non-nil, zero value otherwise.
@@ -5335,6 +5527,22 @@ func (r *ResourceServer) GetName() string {
 	return *r.Name
 }
 
+// GetOptions returns the Options field if it's non-nil, zero value otherwise.
+func (r *ResourceServer) GetOptions() map[string]string {
+	if r == nil || r.Options == nil {
+		return map[string]string{}
+	}
+	return *r.Options
+}
+
+// GetScopes returns the Scopes field if it's non-nil, zero value otherwise.
+func (r *ResourceServer) GetScopes() []ResourceServerScope {
+	if r == nil || r.Scopes == nil {
+		return nil
+	}
+	return *r.Scopes
+}
+
 // GetSigningAlgorithm returns the SigningAlgorithm field if it's non-nil, zero value otherwise.
 func (r *ResourceServer) GetSigningAlgorithm() string {
 	if r == nil || r.SigningAlgorithm == nil {
@@ -5686,6 +5894,14 @@ func (s *SuspiciousIPThrottling) String() string {
 	return Stringify(s)
 }
 
+// GetAllowedLogoutURLs returns the AllowedLogoutURLs field if it's non-nil, zero value otherwise.
+func (t *Tenant) GetAllowedLogoutURLs() []string {
+	if t == nil || t.AllowedLogoutURLs == nil {
+		return nil
+	}
+	return *t.AllowedLogoutURLs
+}
+
 // GetChangePassword returns the ChangePassword field.
 func (t *Tenant) GetChangePassword() *TenantChangePassword {
 	if t == nil {
@@ -5724,6 +5940,14 @@ func (t *Tenant) GetDeviceFlow() *TenantDeviceFlow {
 		return nil
 	}
 	return t.DeviceFlow
+}
+
+// GetEnabledLocales returns the EnabledLocales field if it's non-nil, zero value otherwise.
+func (t *Tenant) GetEnabledLocales() []string {
+	if t == nil || t.EnabledLocales == nil {
+		return nil
+	}
+	return *t.EnabledLocales
 }
 
 // GetErrorPage returns the ErrorPage field.
@@ -5780,6 +6004,14 @@ func (t *Tenant) GetSandboxVersion() string {
 		return ""
 	}
 	return *t.SandboxVersion
+}
+
+// GetSandboxVersionAvailable returns the SandboxVersionAvailable field if it's non-nil, zero value otherwise.
+func (t *Tenant) GetSandboxVersionAvailable() []string {
+	if t == nil || t.SandboxVersionAvailable == nil {
+		return nil
+	}
+	return *t.SandboxVersionAvailable
 }
 
 // GetSessionCookie returns the SessionCookie field.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -31,6 +31,14 @@ func (a *Action) GetCreatedAt() time.Time {
 	return *a.CreatedAt
 }
 
+// GetDependencies returns the Dependencies field if it's non-nil, zero value otherwise.
+func (a *Action) GetDependencies() []ActionDependency {
+	if a == nil || a.Dependencies == nil {
+		return nil
+	}
+	return *a.Dependencies
+}
+
 // GetDeployedVersion returns the DeployedVersion field.
 func (a *Action) GetDeployedVersion() *ActionVersion {
 	if a == nil {
@@ -61,6 +69,14 @@ func (a *Action) GetRuntime() string {
 		return ""
 	}
 	return *a.Runtime
+}
+
+// GetSecrets returns the Secrets field if it's non-nil, zero value otherwise.
+func (a *Action) GetSecrets() []ActionSecret {
+	if a == nil || a.Secrets == nil {
+		return nil
+	}
+	return *a.Secrets
 }
 
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -1177,6 +1177,13 @@ func TestClient_GetLogoURI(tt *testing.T) {
 	c.GetLogoURI()
 }
 
+func TestClient_GetMobile(tt *testing.T) {
+	c := &Client{}
+	c.GetMobile()
+	c = nil
+	c.GetMobile()
+}
+
 func TestClient_GetName(tt *testing.T) {
 	var zeroValue string
 	c := &Client{Name: &zeroValue}
@@ -1355,6 +1362,16 @@ func TestClientJWTConfiguration_GetLifetimeInSeconds(tt *testing.T) {
 	c.GetLifetimeInSeconds()
 }
 
+func TestClientJWTConfiguration_GetScopes(tt *testing.T) {
+	var zeroValue map[string]string
+	c := &ClientJWTConfiguration{Scopes: &zeroValue}
+	c.GetScopes()
+	c = &ClientJWTConfiguration{}
+	c.GetScopes()
+	c = nil
+	c.GetScopes()
+}
+
 func TestClientJWTConfiguration_GetSecretEncoded(tt *testing.T) {
 	var zeroValue bool
 	c := &ClientJWTConfiguration{SecretEncoded: &zeroValue}
@@ -1381,9 +1398,119 @@ func TestClientList_String(t *testing.T) {
 	}
 }
 
+func TestClientMobile_GetAndroid(tt *testing.T) {
+	c := &ClientMobile{}
+	c.GetAndroid()
+	c = nil
+	c.GetAndroid()
+}
+
+func TestClientMobile_GetIOS(tt *testing.T) {
+	c := &ClientMobile{}
+	c.GetIOS()
+	c = nil
+	c.GetIOS()
+}
+
+func TestClientMobile_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ClientMobile{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestClientMobileAndroid_GetAppPackageName(tt *testing.T) {
+	var zeroValue string
+	c := &ClientMobileAndroid{AppPackageName: &zeroValue}
+	c.GetAppPackageName()
+	c = &ClientMobileAndroid{}
+	c.GetAppPackageName()
+	c = nil
+	c.GetAppPackageName()
+}
+
+func TestClientMobileAndroid_GetKeyHashes(tt *testing.T) {
+	var zeroValue []string
+	c := &ClientMobileAndroid{KeyHashes: &zeroValue}
+	c.GetKeyHashes()
+	c = &ClientMobileAndroid{}
+	c.GetKeyHashes()
+	c = nil
+	c.GetKeyHashes()
+}
+
+func TestClientMobileAndroid_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ClientMobileAndroid{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestClientMobileIOS_GetAppID(tt *testing.T) {
+	var zeroValue string
+	c := &ClientMobileIOS{AppID: &zeroValue}
+	c.GetAppID()
+	c = &ClientMobileIOS{}
+	c.GetAppID()
+	c = nil
+	c.GetAppID()
+}
+
+func TestClientMobileIOS_GetTeamID(tt *testing.T) {
+	var zeroValue string
+	c := &ClientMobileIOS{TeamID: &zeroValue}
+	c.GetTeamID()
+	c = &ClientMobileIOS{}
+	c.GetTeamID()
+	c = nil
+	c.GetTeamID()
+}
+
+func TestClientMobileIOS_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ClientMobileIOS{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestClientNativeSocialLogin_GetApple(tt *testing.T) {
+	c := &ClientNativeSocialLogin{}
+	c.GetApple()
+	c = nil
+	c.GetApple()
+}
+
+func TestClientNativeSocialLogin_GetFacebook(tt *testing.T) {
+	c := &ClientNativeSocialLogin{}
+	c.GetFacebook()
+	c = nil
+	c.GetFacebook()
+}
+
 func TestClientNativeSocialLogin_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ClientNativeSocialLogin{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestClientNativeSocialLoginSupportEnabled_GetEnabled(tt *testing.T) {
+	var zeroValue bool
+	c := &ClientNativeSocialLoginSupportEnabled{Enabled: &zeroValue}
+	c.GetEnabled()
+	c = &ClientNativeSocialLoginSupportEnabled{}
+	c.GetEnabled()
+	c = nil
+	c.GetEnabled()
+}
+
+func TestClientNativeSocialLoginSupportEnabled_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ClientNativeSocialLoginSupportEnabled{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -1316,16 +1316,6 @@ func TestClientGrant_GetID(tt *testing.T) {
 	c.GetID()
 }
 
-func TestClientGrant_GetScope(tt *testing.T) {
-	var zeroValue []string
-	c := &ClientGrant{Scope: &zeroValue}
-	c.GetScope()
-	c = &ClientGrant{}
-	c.GetScope()
-	c = nil
-	c.GetScope()
-}
-
 func TestClientGrant_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ClientGrant{}

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -39,6 +39,16 @@ func TestAction_GetCreatedAt(tt *testing.T) {
 	a.GetCreatedAt()
 }
 
+func TestAction_GetDependencies(tt *testing.T) {
+	var zeroValue []ActionDependency
+	a := &Action{Dependencies: &zeroValue}
+	a.GetDependencies()
+	a = &Action{}
+	a.GetDependencies()
+	a = nil
+	a.GetDependencies()
+}
+
 func TestAction_GetDeployedVersion(tt *testing.T) {
 	a := &Action{}
 	a.GetDeployedVersion()
@@ -74,6 +84,16 @@ func TestAction_GetRuntime(tt *testing.T) {
 	a.GetRuntime()
 	a = nil
 	a.GetRuntime()
+}
+
+func TestAction_GetSecrets(tt *testing.T) {
+	var zeroValue []ActionSecret
+	a := &Action{Secrets: &zeroValue}
+	a.GetSecrets()
+	a = &Action{}
+	a.GetSecrets()
+	a = nil
+	a.GetSecrets()
 }
 
 func TestAction_GetStatus(tt *testing.T) {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -930,6 +930,36 @@ func TestBruteForceProtection_String(t *testing.T) {
 	}
 }
 
+func TestClient_GetAllowedClients(tt *testing.T) {
+	var zeroValue []string
+	c := &Client{AllowedClients: &zeroValue}
+	c.GetAllowedClients()
+	c = &Client{}
+	c.GetAllowedClients()
+	c = nil
+	c.GetAllowedClients()
+}
+
+func TestClient_GetAllowedLogoutURLs(tt *testing.T) {
+	var zeroValue []string
+	c := &Client{AllowedLogoutURLs: &zeroValue}
+	c.GetAllowedLogoutURLs()
+	c = &Client{}
+	c.GetAllowedLogoutURLs()
+	c = nil
+	c.GetAllowedLogoutURLs()
+}
+
+func TestClient_GetAllowedOrigins(tt *testing.T) {
+	var zeroValue []string
+	c := &Client{AllowedOrigins: &zeroValue}
+	c.GetAllowedOrigins()
+	c = &Client{}
+	c.GetAllowedOrigins()
+	c = nil
+	c.GetAllowedOrigins()
+}
+
 func TestClient_GetAppType(tt *testing.T) {
 	var zeroValue string
 	c := &Client{AppType: &zeroValue}
@@ -938,6 +968,26 @@ func TestClient_GetAppType(tt *testing.T) {
 	c.GetAppType()
 	c = nil
 	c.GetAppType()
+}
+
+func TestClient_GetCallbacks(tt *testing.T) {
+	var zeroValue []string
+	c := &Client{Callbacks: &zeroValue}
+	c.GetCallbacks()
+	c = &Client{}
+	c.GetCallbacks()
+	c = nil
+	c.GetCallbacks()
+}
+
+func TestClient_GetClientAliases(tt *testing.T) {
+	var zeroValue []string
+	c := &Client{ClientAliases: &zeroValue}
+	c.GetClientAliases()
+	c = &Client{}
+	c.GetClientAliases()
+	c = nil
+	c.GetClientAliases()
 }
 
 func TestClient_GetClientID(tt *testing.T) {
@@ -951,8 +1001,8 @@ func TestClient_GetClientID(tt *testing.T) {
 }
 
 func TestClient_GetClientMetadata(tt *testing.T) {
-	zeroValue := map[string]string{}
-	c := &Client{ClientMetadata: zeroValue}
+	var zeroValue map[string]string
+	c := &Client{ClientMetadata: &zeroValue}
 	c.GetClientMetadata()
 	c = &Client{}
 	c.GetClientMetadata()
@@ -1031,8 +1081,8 @@ func TestClient_GetDescription(tt *testing.T) {
 }
 
 func TestClient_GetEncryptionKey(tt *testing.T) {
-	zeroValue := map[string]string{}
-	c := &Client{EncryptionKey: zeroValue}
+	var zeroValue map[string]string
+	c := &Client{EncryptionKey: &zeroValue}
 	c.GetEncryptionKey()
 	c = &Client{}
 	c.GetEncryptionKey()
@@ -1048,6 +1098,16 @@ func TestClient_GetFormTemplate(tt *testing.T) {
 	c.GetFormTemplate()
 	c = nil
 	c.GetFormTemplate()
+}
+
+func TestClient_GetGrantTypes(tt *testing.T) {
+	var zeroValue []string
+	c := &Client{GrantTypes: &zeroValue}
+	c.GetGrantTypes()
+	c = &Client{}
+	c.GetGrantTypes()
+	c = nil
+	c.GetGrantTypes()
 }
 
 func TestClient_GetInitiateLoginURI(tt *testing.T) {
@@ -1181,6 +1241,16 @@ func TestClient_GetTokenEndpointAuthMethod(tt *testing.T) {
 	c.GetTokenEndpointAuthMethod()
 }
 
+func TestClient_GetWebOrigins(tt *testing.T) {
+	var zeroValue []string
+	c := &Client{WebOrigins: &zeroValue}
+	c.GetWebOrigins()
+	c = &Client{}
+	c.GetWebOrigins()
+	c = nil
+	c.GetWebOrigins()
+}
+
 func TestClient_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &Client{}
@@ -1217,6 +1287,16 @@ func TestClientGrant_GetID(tt *testing.T) {
 	c.GetID()
 	c = nil
 	c.GetID()
+}
+
+func TestClientGrant_GetScope(tt *testing.T) {
+	var zeroValue []string
+	c := &ClientGrant{Scope: &zeroValue}
+	c.GetScope()
+	c = &ClientGrant{}
+	c.GetScope()
+	c = nil
+	c.GetScope()
 }
 
 func TestClientGrant_String(t *testing.T) {
@@ -1377,6 +1457,16 @@ func TestConnection_GetDisplayName(tt *testing.T) {
 	c.GetDisplayName()
 }
 
+func TestConnection_GetEnabledClients(tt *testing.T) {
+	var zeroValue []string
+	c := &Connection{EnabledClients: &zeroValue}
+	c.GetEnabledClients()
+	c = &Connection{}
+	c.GetEnabledClients()
+	c = nil
+	c.GetEnabledClients()
+}
+
 func TestConnection_GetID(tt *testing.T) {
 	var zeroValue string
 	c := &Connection{ID: &zeroValue}
@@ -1398,8 +1488,8 @@ func TestConnection_GetIsDomainConnection(tt *testing.T) {
 }
 
 func TestConnection_GetMetadata(tt *testing.T) {
-	zeroValue := map[string]string{}
-	c := &Connection{Metadata: zeroValue}
+	var zeroValue map[string]string
+	c := &Connection{Metadata: &zeroValue}
 	c.GetMetadata()
 	c = &Connection{}
 	c.GetMetadata()
@@ -1425,6 +1515,16 @@ func TestConnection_GetProvisioningTicketURL(tt *testing.T) {
 	c.GetProvisioningTicketURL()
 	c = nil
 	c.GetProvisioningTicketURL()
+}
+
+func TestConnection_GetRealms(tt *testing.T) {
+	var zeroValue []string
+	c := &Connection{Realms: &zeroValue}
+	c.GetRealms()
+	c = &Connection{}
+	c.GetRealms()
+	c = nil
+	c.GetRealms()
 }
 
 func TestConnection_GetShowAsButton(tt *testing.T) {
@@ -1529,6 +1629,26 @@ func TestConnectionOptions_GetBruteForceProtection(tt *testing.T) {
 	c.GetBruteForceProtection()
 	c = nil
 	c.GetBruteForceProtection()
+}
+
+func TestConnectionOptions_GetConfiguration(tt *testing.T) {
+	var zeroValue map[string]string
+	c := &ConnectionOptions{Configuration: &zeroValue}
+	c.GetConfiguration()
+	c = &ConnectionOptions{}
+	c.GetConfiguration()
+	c = nil
+	c.GetConfiguration()
+}
+
+func TestConnectionOptions_GetCustomScripts(tt *testing.T) {
+	var zeroValue map[string]string
+	c := &ConnectionOptions{CustomScripts: &zeroValue}
+	c.GetCustomScripts()
+	c = &ConnectionOptions{}
+	c.GetCustomScripts()
+	c = nil
+	c.GetCustomScripts()
 }
 
 func TestConnectionOptions_GetDisableSignup(tt *testing.T) {
@@ -1649,6 +1769,26 @@ func TestConnectionOptionsAD_GetDisableCache(tt *testing.T) {
 	c.GetDisableCache()
 }
 
+func TestConnectionOptionsAD_GetDomainAliases(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsAD{DomainAliases: &zeroValue}
+	c.GetDomainAliases()
+	c = &ConnectionOptionsAD{}
+	c.GetDomainAliases()
+	c = nil
+	c.GetDomainAliases()
+}
+
+func TestConnectionOptionsAD_GetIPs(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsAD{IPs: &zeroValue}
+	c.GetIPs()
+	c = &ConnectionOptionsAD{}
+	c.GetIPs()
+	c = nil
+	c.GetIPs()
+}
+
 func TestConnectionOptionsAD_GetKerberos(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptionsAD{Kerberos: &zeroValue}
@@ -1715,6 +1855,16 @@ func TestConnectionOptionsADFS_GetADFSServer(tt *testing.T) {
 	c.GetADFSServer()
 	c = nil
 	c.GetADFSServer()
+}
+
+func TestConnectionOptionsADFS_GetDomainAliases(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsADFS{DomainAliases: &zeroValue}
+	c.GetDomainAliases()
+	c = &ConnectionOptionsADFS{}
+	c.GetDomainAliases()
+	c = nil
+	c.GetDomainAliases()
 }
 
 func TestConnectionOptionsADFS_GetEnableUsersAPI(tt *testing.T) {
@@ -1951,6 +2101,16 @@ func TestConnectionOptionsAzureAD_GetDomain(tt *testing.T) {
 	c.GetDomain()
 	c = nil
 	c.GetDomain()
+}
+
+func TestConnectionOptionsAzureAD_GetDomainAliases(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsAzureAD{DomainAliases: &zeroValue}
+	c.GetDomainAliases()
+	c = &ConnectionOptionsAzureAD{}
+	c.GetDomainAliases()
+	c = nil
+	c.GetDomainAliases()
 }
 
 func TestConnectionOptionsAzureAD_GetEnableUsersAPI(tt *testing.T) {
@@ -3017,6 +3177,16 @@ func TestConnectionOptionsGoogleApps_GetDomain(tt *testing.T) {
 	c.GetDomain()
 }
 
+func TestConnectionOptionsGoogleApps_GetDomainAliases(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsGoogleApps{DomainAliases: &zeroValue}
+	c.GetDomainAliases()
+	c = &ConnectionOptionsGoogleApps{}
+	c.GetDomainAliases()
+	c = nil
+	c.GetDomainAliases()
+}
+
 func TestConnectionOptionsGoogleApps_GetEnableUsersAPI(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptionsGoogleApps{EnableUsersAPI: &zeroValue}
@@ -3113,6 +3283,16 @@ func TestConnectionOptionsGoogleOAuth2_GetAdsenseManagement(tt *testing.T) {
 	c.GetAdsenseManagement()
 	c = nil
 	c.GetAdsenseManagement()
+}
+
+func TestConnectionOptionsGoogleOAuth2_GetAllowedAudiences(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsGoogleOAuth2{AllowedAudiences: &zeroValue}
+	c.GetAllowedAudiences()
+	c = &ConnectionOptionsGoogleOAuth2{}
+	c.GetAllowedAudiences()
+	c = nil
+	c.GetAllowedAudiences()
 }
 
 func TestConnectionOptionsGoogleOAuth2_GetAnalytics(tt *testing.T) {
@@ -3611,6 +3791,16 @@ func TestConnectionOptionsOAuth2_GetScope(tt *testing.T) {
 	c.GetScope()
 }
 
+func TestConnectionOptionsOAuth2_GetScripts(tt *testing.T) {
+	var zeroValue map[string]string
+	c := &ConnectionOptionsOAuth2{Scripts: &zeroValue}
+	c.GetScripts()
+	c = &ConnectionOptionsOAuth2{}
+	c.GetScripts()
+	c = nil
+	c.GetScripts()
+}
+
 func TestConnectionOptionsOAuth2_GetSetUserAttributes(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsOAuth2{SetUserAttributes: &zeroValue}
@@ -3677,6 +3867,16 @@ func TestConnectionOptionsOIDC_GetDiscoveryURL(tt *testing.T) {
 	c.GetDiscoveryURL()
 	c = nil
 	c.GetDiscoveryURL()
+}
+
+func TestConnectionOptionsOIDC_GetDomainAliases(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsOIDC{DomainAliases: &zeroValue}
+	c.GetDomainAliases()
+	c = &ConnectionOptionsOIDC{}
+	c.GetDomainAliases()
+	c = nil
+	c.GetDomainAliases()
 }
 
 func TestConnectionOptionsOIDC_GetIssuer(tt *testing.T) {
@@ -3921,6 +4121,16 @@ func TestConnectionOptionsSAML_GetDisableSignOut(tt *testing.T) {
 	c.GetDisableSignOut()
 	c = nil
 	c.GetDisableSignOut()
+}
+
+func TestConnectionOptionsSAML_GetDomainAliases(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsSAML{DomainAliases: &zeroValue}
+	c.GetDomainAliases()
+	c = &ConnectionOptionsSAML{}
+	c.GetDomainAliases()
+	c = nil
+	c.GetDomainAliases()
 }
 
 func TestConnectionOptionsSAML_GetEntityID(tt *testing.T) {
@@ -5213,6 +5423,16 @@ func TestGrantList_String(t *testing.T) {
 	}
 }
 
+func TestHook_GetDependencies(tt *testing.T) {
+	var zeroValue map[string]string
+	h := &Hook{Dependencies: &zeroValue}
+	h.GetDependencies()
+	h = &Hook{}
+	h.GetDependencies()
+	h = nil
+	h.GetDependencies()
+}
+
 func TestHook_GetEnabled(tt *testing.T) {
 	var zeroValue bool
 	h := &Hook{Enabled: &zeroValue}
@@ -6222,6 +6442,16 @@ func TestOrganization_GetID(tt *testing.T) {
 	o.GetID()
 }
 
+func TestOrganization_GetMetadata(tt *testing.T) {
+	var zeroValue map[string]string
+	o := &Organization{Metadata: &zeroValue}
+	o.GetMetadata()
+	o = &Organization{}
+	o.GetMetadata()
+	o = nil
+	o.GetMetadata()
+}
+
 func TestOrganization_GetName(tt *testing.T) {
 	var zeroValue string
 	o := &Organization{Name: &zeroValue}
@@ -6238,6 +6468,16 @@ func TestOrganization_String(t *testing.T) {
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
+}
+
+func TestOrganizationBranding_GetColors(tt *testing.T) {
+	var zeroValue map[string]string
+	o := &OrganizationBranding{Colors: &zeroValue}
+	o.GetColors()
+	o = &OrganizationBranding{}
+	o.GetColors()
+	o = nil
+	o.GetColors()
 }
 
 func TestOrganizationBranding_GetLogoURL(tt *testing.T) {
@@ -6813,6 +7053,26 @@ func TestResourceServer_GetName(tt *testing.T) {
 	r.GetName()
 }
 
+func TestResourceServer_GetOptions(tt *testing.T) {
+	var zeroValue map[string]string
+	r := &ResourceServer{Options: &zeroValue}
+	r.GetOptions()
+	r = &ResourceServer{}
+	r.GetOptions()
+	r = nil
+	r.GetOptions()
+}
+
+func TestResourceServer_GetScopes(tt *testing.T) {
+	var zeroValue []ResourceServerScope
+	r := &ResourceServer{Scopes: &zeroValue}
+	r.GetScopes()
+	r = &ResourceServer{}
+	r.GetScopes()
+	r = nil
+	r.GetScopes()
+}
+
 func TestResourceServer_GetSigningAlgorithm(tt *testing.T) {
 	var zeroValue string
 	r := &ResourceServer{SigningAlgorithm: &zeroValue}
@@ -7262,6 +7522,16 @@ func TestSuspiciousIPThrottling_String(t *testing.T) {
 	}
 }
 
+func TestTenant_GetAllowedLogoutURLs(tt *testing.T) {
+	var zeroValue []string
+	t := &Tenant{AllowedLogoutURLs: &zeroValue}
+	t.GetAllowedLogoutURLs()
+	t = &Tenant{}
+	t.GetAllowedLogoutURLs()
+	t = nil
+	t.GetAllowedLogoutURLs()
+}
+
 func TestTenant_GetChangePassword(tt *testing.T) {
 	t := &Tenant{}
 	t.GetChangePassword()
@@ -7304,6 +7574,16 @@ func TestTenant_GetDeviceFlow(tt *testing.T) {
 	t.GetDeviceFlow()
 	t = nil
 	t.GetDeviceFlow()
+}
+
+func TestTenant_GetEnabledLocales(tt *testing.T) {
+	var zeroValue []string
+	t := &Tenant{EnabledLocales: &zeroValue}
+	t.GetEnabledLocales()
+	t = &Tenant{}
+	t.GetEnabledLocales()
+	t = nil
+	t.GetEnabledLocales()
 }
 
 func TestTenant_GetErrorPage(tt *testing.T) {
@@ -7365,6 +7645,16 @@ func TestTenant_GetSandboxVersion(tt *testing.T) {
 	t.GetSandboxVersion()
 	t = nil
 	t.GetSandboxVersion()
+}
+
+func TestTenant_GetSandboxVersionAvailable(tt *testing.T) {
+	var zeroValue []string
+	t := &Tenant{SandboxVersionAvailable: &zeroValue}
+	t.GetSandboxVersionAvailable()
+	t = &Tenant{}
+	t.GetSandboxVersionAvailable()
+	t = nil
+	t.GetSandboxVersionAvailable()
 }
 
 func TestTenant_GetSessionCookie(tt *testing.T) {

--- a/management/organization.go
+++ b/management/organization.go
@@ -20,16 +20,16 @@ type Organization struct {
 
 	// Metadata associated with the organization, in the form of an object with
 	// string values (max 255 chars). Maximum of 10 metadata properties allowed.
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Metadata *map[string]string `json:"metadata,omitempty"`
 }
 
 // OrganizationBranding holds branding information for an Organization.
 type OrganizationBranding struct {
-	// URL of logo to display on login page
+	// URL of logo to display on login page.
 	LogoURL *string `json:"logo_url,omitempty"`
 
-	// Color scheme used to customize the login pages
-	Colors map[string]interface{} `json:"colors,omitempty"`
+	// Color scheme used to customize the login pages.
+	Colors *map[string]string `json:"colors,omitempty"`
 }
 
 // OrganizationMember holds member information for an Organization.

--- a/management/organization_test.go
+++ b/management/organization_test.go
@@ -102,9 +102,9 @@ func TestOrganizationManager_AddConnection(t *testing.T) {
 		Name:        auth0.String(fmt.Sprintf("test-conn%v", rand.Intn(999))),
 		DisplayName: auth0.String(fmt.Sprintf("Test Connection %v", rand.Intn(999))),
 		Strategy:    auth0.String(ConnectionStrategyAuth0),
-		EnabledClients: []interface{}{
+		EnabledClients: &[]string{
 			os.Getenv("AUTH0_CLIENT_ID"),
-			client.ClientID,
+			client.GetClientID(),
 		},
 	}})
 	orgConn := &OrganizationConnection{
@@ -329,9 +329,9 @@ func givenAnOrganizationConnection(t *testing.T, orgID string) *OrganizationConn
 			Name:        auth0.String(fmt.Sprintf("test-conn%v", rand.Intn(999))),
 			DisplayName: auth0.String(fmt.Sprintf("Test Connection %v", rand.Intn(999))),
 			Strategy:    auth0.String(ConnectionStrategyAuth0),
-			EnabledClients: []interface{}{
+			EnabledClients: &[]string{
 				os.Getenv("AUTH0_CLIENT_ID"),
-				client.ClientID,
+				client.GetClientID(),
 			},
 		},
 	})

--- a/management/resource_server.go
+++ b/management/resource_server.go
@@ -14,7 +14,7 @@ type ResourceServer struct {
 	Identifier *string `json:"identifier,omitempty"`
 
 	// Scopes supported by the resource server.
-	Scopes []*ResourceServerScope `json:"scopes,omitempty"`
+	Scopes *[]ResourceServerScope `json:"scopes,omitempty"`
 
 	// The algorithm used to sign tokens ["HS256" or "RS256"].
 	SigningAlgorithm *string `json:"signing_alg,omitempty"`
@@ -41,7 +41,7 @@ type ResourceServer struct {
 	// verifying the JWT sent to Auth0 for token introspection.
 	VerificationLocation *string `json:"verificationLocation,omitempty"`
 
-	Options map[string]interface{} `json:"options,omitempty"`
+	Options *map[string]string `json:"options,omitempty"`
 
 	// Enables the enforcement of the authorization policies.
 	EnforcePolicies *bool `json:"enforce_policies,omitempty"`

--- a/management/resource_server_test.go
+++ b/management/resource_server_test.go
@@ -20,7 +20,7 @@ func TestResourceServer_Create(t *testing.T) {
 		SigningAlgorithm:    auth0.String("HS256"),
 		TokenLifetime:       auth0.Int(7200),
 		TokenLifetimeForWeb: auth0.Int(3600),
-		Scopes: []*ResourceServerScope{
+		Scopes: &[]ResourceServerScope{
 			{
 				Value:       auth0.String("create:resource"),
 				Description: auth0.String("Create Resource"),
@@ -64,10 +64,11 @@ func TestResourceServer_Update(t *testing.T) {
 	expectedResourceServer.SkipConsentForVerifiableFirstPartyClients = auth0.Bool(true)
 	expectedResourceServer.TokenLifetime = auth0.Int(7200)
 	expectedResourceServer.TokenLifetimeForWeb = auth0.Int(5400)
-	expectedResourceServer.Scopes = append(expectedResourceServer.Scopes, &ResourceServerScope{
+	scopes := append(expectedResourceServer.GetScopes(), ResourceServerScope{
 		Value:       auth0.String("update:resource"),
 		Description: auth0.String("Update Resource"),
 	})
+	expectedResourceServer.Scopes = &scopes
 
 	err := m.ResourceServer.Update(resourceServerID, expectedResourceServer)
 
@@ -77,7 +78,7 @@ func TestResourceServer_Update(t *testing.T) {
 	assert.Equal(t, expectedResourceServer.GetSkipConsentForVerifiableFirstPartyClients(), true)
 	assert.Equal(t, expectedResourceServer.GetTokenLifetime(), 7200)
 	assert.Equal(t, expectedResourceServer.GetTokenLifetimeForWeb(), 5400)
-	assert.Equal(t, len(expectedResourceServer.Scopes), 2)
+	assert.Equal(t, len(expectedResourceServer.GetScopes()), 2)
 }
 
 func TestResourceServer_Delete(t *testing.T) {
@@ -115,7 +116,7 @@ func givenAResourceServer(t *testing.T) *ResourceServer {
 		SigningAlgorithm:    auth0.String("HS256"),
 		TokenLifetime:       auth0.Int(7200),
 		TokenLifetimeForWeb: auth0.Int(3600),
-		Scopes: []*ResourceServerScope{
+		Scopes: &[]ResourceServerScope{
 			{
 				Value:       auth0.String("create:resource"),
 				Description: auth0.String("Create Resource"),

--- a/management/role_test.go
+++ b/management/role_test.go
@@ -105,7 +105,7 @@ func TestRoleManager_Permissions(t *testing.T) {
 	resourceServer := givenAResourceServer(t)
 	permissions := []*Permission{
 		{
-			Name:                     resourceServer.Scopes[0].Value,
+			Name:                     resourceServer.GetScopes()[0].Value,
 			ResourceServerIdentifier: resourceServer.Identifier,
 		},
 	}

--- a/management/tenant.go
+++ b/management/tenant.go
@@ -46,7 +46,7 @@ type Tenant struct {
 	UniversalLogin *TenantUniversalLogin `json:"universal_login,omitempty"`
 
 	// A set of URLs that are valid to redirect to after logout from Auth0.
-	AllowedLogoutURLs []interface{} `json:"allowed_logout_urls,omitempty"`
+	AllowedLogoutURLs *[]string `json:"allowed_logout_urls,omitempty"`
 
 	// Login session lifetime, how long the session will stay valid (hours).
 	//
@@ -67,14 +67,14 @@ type Tenant struct {
 	SandboxVersion *string `json:"sandbox_version,omitempty"`
 
 	// A set of available sandbox versions for the extensibility environment
-	SandboxVersionAvailable []interface{} `json:"sandbox_versions_available,omitempty"`
+	SandboxVersionAvailable *[]string `json:"sandbox_versions_available,omitempty"`
 
 	// The default absolute redirection uri, must be https and cannot contain a
 	// fragment.
 	DefaultRedirectionURI *string `json:"default_redirection_uri,omitempty"`
 
 	// Supported locales for the UI
-	EnabledLocales []interface{} `json:"enabled_locales,omitempty"`
+	EnabledLocales *[]string `json:"enabled_locales,omitempty"`
 
 	SessionCookie *TenantSessionCookie `json:"session_cookie,omitempty"`
 }

--- a/management/tenant_test.go
+++ b/management/tenant_test.go
@@ -34,6 +34,9 @@ func TestTenantManager(t *testing.T) {
 		SessionCookie: &TenantSessionCookie{
 			Mode: auth0.String("non-persistent"),
 		},
+		AllowedLogoutURLs:       &[]string{"https://app.com/logout", "localhost/logout"},
+		EnabledLocales:          &[]string{"fr", "en", "es"},
+		SandboxVersionAvailable: nil,
 	}
 	err = m.Tenant.Update(newTenantSettings)
 	assert.NoError(t, err)
@@ -47,6 +50,9 @@ func TestTenantManager(t *testing.T) {
 	assert.Equal(t, newTenantSettings.GetSupportEmail(), actualTenantSettings.GetSupportEmail())
 	assert.Equal(t, newTenantSettings.GetSupportURL(), actualTenantSettings.GetSupportURL())
 	assert.Equal(t, newTenantSettings.SessionCookie.GetMode(), actualTenantSettings.SessionCookie.GetMode())
+	assert.Equal(t, newTenantSettings.GetAllowedLogoutURLs(), actualTenantSettings.GetAllowedLogoutURLs())
+	assert.Equal(t, newTenantSettings.GetEnabledLocales(), actualTenantSettings.GetEnabledLocales())
+	assert.Equal(t, newTenantSettings.GetSandboxVersion(), actualTenantSettings.GetSandboxVersion())
 }
 
 func TestTenant_MarshalJSON(t *testing.T) {
@@ -62,6 +68,8 @@ func TestTenant_MarshalJSON(t *testing.T) {
 		{SessionLifetime: auth0.Float64(0.5)}:      `{"session_lifetime_in_minutes":30}`,
 		{SessionLifetime: auth0.Float64(0.99)}:     `{"session_lifetime_in_minutes":59}`,
 		{IdleSessionLifetime: auth0.Float64(0.25)}: `{"idle_session_lifetime_in_minutes":15}`,
+		{AllowedLogoutURLs: nil}:                   `{}`,
+		{AllowedLogoutURLs: &[]string{}}:           `{"allowed_logout_urls":[]}`,
 	} {
 		payload, err := json.Marshal(tenant)
 		assert.NoError(t, err)

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -154,7 +154,7 @@ func TestUserManager_Permissions(t *testing.T) {
 	resourceServer := givenAResourceServer(t)
 	permissions := []*Permission{
 		{
-			Name:                     resourceServer.Scopes[0].Value,
+			Name:                     resourceServer.GetScopes()[0].Value,
 			ResourceServerIdentifier: resourceServer.Identifier,
 		},
 	}


### PR DESCRIPTION
## Description

There are some fields that are unable to be explicitly set to empty when making requests. This occurs with fields that are tagged with `omitempty` in their struct definitions; the system has no way to differentiate between explicitly empty and omitted. This shortcoming has been frequently logged as an issue in the Terraform provider repo, cataloged [here](https://github.com/auth0/terraform-provider-auth0/issues/14). This PR attempts to completely rectify this inability by setting the field types to pointers. By doing so, we introduce a tertiary state that we can use to distinguish between omitted and explicitly empty values. 

⚠️ **Note:** These changes introduce breaking changes! However, the intention is for this to be one of the last breaking changes before v1.

## References

- [Related issue in auth0/terraform-provider-auth0](https://github.com/auth0/terraform-provider-auth0/issues/14)

## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [x] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
