### PR TITLE
DXCDT-232: Add omitempty to IdentityAPI on AzureAD options

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -782,7 +782,7 @@ type ConnectionOptionsAzureAD struct {
 	DomainAliases *[]string `json:"domain_aliases,omitempty"`
 	LogoURL       *string   `json:"icon_url,omitempty"`
 
-	IdentityAPI *string `json:"identity_api"`
+	IdentityAPI *string `json:"identity_api,omitempty"`
 
 	WAADProtocol       *string `json:"waad_protocol,omitempty"`
 	WAADCommonEndpoint *bool   `json:"waad_common_endpoint,omitempty"`


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR adds the omitempty json tag so we prevent sending this field as "null" in case it is not set.

The API only accepts 2 values:

```json
{ "statusCode": 400, "error": "Bad Request", "message": "The identity_api property contains an invalid value. Valid values are 'azure-active-directory-v1.0', 'microsoft-identity-platform-v2.0'", "errorCode": "invalid_body" }
```

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

- https://github.com/auth0/terraform-provider-auth0/pull/361

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
