### PR TITLE
DXCDT-250: Add ability to retrieve default branding theme

### DIFF
--- a/management/branding_theme.go
+++ b/management/branding_theme.go
@@ -18,15 +18,15 @@ type BrandingTheme struct {
 
 // BrandingThemeBorders contains borders settings for the BrandingTheme.
 type BrandingThemeBorders struct {
-	ButtonBorderRadius int    `json:"button_border_radius"`
-	ButtonBorderWeight int    `json:"button_border_weight"`
-	ButtonsStyle       string `json:"buttons_style"`
-	InputBorderRadius  int    `json:"input_border_radius"`
-	InputBorderWeight  int    `json:"input_border_weight"`
-	InputsStyle        string `json:"inputs_style"`
-	ShowWidgetShadow   bool   `json:"show_widget_shadow"`
-	WidgetBorderWeight int    `json:"widget_border_weight"`
-	WidgetCornerRadius int    `json:"widget_corner_radius"`
+	ButtonBorderRadius float64 `json:"button_border_radius"`
+	ButtonBorderWeight float64 `json:"button_border_weight"`
+	ButtonsStyle       string  `json:"buttons_style"`
+	InputBorderRadius  float64 `json:"input_border_radius"`
+	InputBorderWeight  float64 `json:"input_border_weight"`
+	InputsStyle        string  `json:"inputs_style"`
+	ShowWidgetShadow   bool    `json:"show_widget_shadow"`
+	WidgetBorderWeight float64 `json:"widget_border_weight"`
+	WidgetCornerRadius float64 `json:"widget_corner_radius"`
 }
 
 // BrandingThemeColors contains colors settings for the BrandingTheme.
@@ -59,7 +59,7 @@ type BrandingThemeFonts struct {
 	InputLabels       BrandingThemeText `json:"input_labels"`
 	Links             BrandingThemeText `json:"links"`
 	LinksStyle        string            `json:"links_style"`
-	ReferenceTextSize int               `json:"reference_text_size"`
+	ReferenceTextSize float64           `json:"reference_text_size"`
 	Subtitle          BrandingThemeText `json:"subtitle"`
 	Title             BrandingThemeText `json:"title"`
 }
@@ -67,8 +67,8 @@ type BrandingThemeFonts struct {
 // BrandingThemeText contains text settings
 // for the BrandingThemeFonts.
 type BrandingThemeText struct {
-	Bold bool `json:"bold"`
-	Size int  `json:"size"`
+	Bold bool    `json:"bold"`
+	Size float64 `json:"size"`
 }
 
 // BrandingThemePageBackground contains page
@@ -81,11 +81,11 @@ type BrandingThemePageBackground struct {
 
 // BrandingThemeWidget contains widget settings for the BrandingTheme.
 type BrandingThemeWidget struct {
-	HeaderTextAlignment string `json:"header_text_alignment"`
-	LogoHeight          int    `json:"logo_height"`
-	LogoPosition        string `json:"logo_position"`
-	LogoURL             string `json:"logo_url"`
-	SocialButtonsLayout string `json:"social_buttons_layout"`
+	HeaderTextAlignment string  `json:"header_text_alignment"`
+	LogoHeight          float64 `json:"logo_height"`
+	LogoPosition        string  `json:"logo_position"`
+	LogoURL             string  `json:"logo_url"`
+	SocialButtonsLayout string  `json:"social_buttons_layout"`
 }
 
 // BrandingThemeManager manages Auth0 BrandingTheme resources.

--- a/management/branding_theme.go
+++ b/management/branding_theme.go
@@ -97,6 +97,14 @@ func newBrandingThemeManager(m *Management) *BrandingThemeManager {
 	return &BrandingThemeManager{m}
 }
 
+// Default retrieves the default BrandingTheme.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Branding/get_default_branding_theme
+func (m *BrandingThemeManager) Default(opts ...RequestOption) (theme *BrandingTheme, err error) {
+	err = m.Request(http.MethodGet, m.URI("branding", "themes", "default"), &theme, opts...)
+	return
+}
+
 // Create a new BrandingTheme.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/post_branding_theme

--- a/management/branding_theme_test.go
+++ b/management/branding_theme_test.go
@@ -10,6 +10,17 @@ import (
 	"github.com/auth0/go-auth0"
 )
 
+func TestBrandingThemeManager_Default(t *testing.T) {
+	setupHTTPRecordings(t)
+
+	expectedTheme := givenABrandingTheme(t)
+
+	actualTheme, err := m.BrandingTheme.Default()
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTheme.GetDisplayName(), actualTheme.GetDisplayName())
+}
+
 func TestBrandingThemeManager_Create(t *testing.T) {
 	setupHTTPRecordings(t)
 

--- a/management/testdata/recordings/TestBrandingThemeManager_Default.yaml
+++ b/management/testdata/recordings/TestBrandingThemeManager_Default.yaml
@@ -1,0 +1,65 @@
+---
+version: 1
+interactions:
+    - request:
+        body: |
+            {"borders":{"button_border_radius":2,"button_border_weight":2,"buttons_style":"pill","input_border_radius":2,"input_border_weight":2,"inputs_style":"pill","show_widget_shadow":true,"widget_border_weight":2,"widget_corner_radius":2},"colors":{"body_text":"#00FF00","error":"#00FF00","header":"#00FF00","icons":"#00FF00","input_background":"#00FF00","input_border":"#00FF00","input_filled_text":"#00FF00","input_labels_placeholders":"#00FF00","links_focused_components":"#00FF00","primary_button":"#00FF00","primary_button_label":"#00FF00","secondary_button_border":"#00FF00","secondary_button_label":"#00FF00","success":"#00FF00","widget_background":"#00FF00","widget_border":"#00FF00"},"fonts":{"body_text":{"bold":true,"size":100},"buttons_text":{"bold":true,"size":100},"font_url":"https://google.com/font.woff","input_labels":{"bold":true,"size":100},"links":{"bold":true,"size":100},"links_style":"normal","reference_text_size":12,"subtitle":{"bold":true,"size":100},"title":{"bold":true,"size":100}},"page_background":{"background_color":"#000000","background_image_url":"https://google.com/background.png","page_layout":"center"},"widget":{"header_text_alignment":"center","logo_height":55,"logo_position":"center","logo_url":"https://google.com/logo.png","social_buttons_layout":"top"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/themes
+        method: POST
+      response:
+        body: '{"borders":{"button_border_radius":2,"button_border_weight":2,"buttons_style":"pill","input_border_radius":2,"input_border_weight":2,"inputs_style":"pill","show_widget_shadow":true,"widget_border_weight":2,"widget_corner_radius":2},"colors":{"body_text":"#00FF00","error":"#00FF00","header":"#00FF00","icons":"#00FF00","input_background":"#00FF00","input_border":"#00FF00","input_filled_text":"#00FF00","input_labels_placeholders":"#00FF00","links_focused_components":"#00FF00","primary_button":"#00FF00","primary_button_label":"#00FF00","secondary_button_border":"#00FF00","secondary_button_label":"#00FF00","success":"#00FF00","widget_background":"#00FF00","widget_border":"#00FF00"},"fonts":{"body_text":{"bold":true,"size":100},"buttons_text":{"bold":true,"size":100},"font_url":"https://google.com/font.woff","input_labels":{"bold":true,"size":100},"links":{"bold":true,"size":100},"links_style":"normal","reference_text_size":12,"subtitle":{"bold":true,"size":100},"title":{"bold":true,"size":100}},"page_background":{"background_color":"#000000","background_image_url":"https://google.com/background.png","page_layout":"center"},"widget":{"header_text_alignment":"center","logo_height":55,"logo_position":"center","logo_url":"https://google.com/logo.png","social_buttons_layout":"top"},"themeId":"W1hDtZNvDZ1rm4aPFt5KOFnmsB2OJ2Zh"}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/themes/default
+        method: GET
+      response:
+        body: '{"borders":{"button_border_radius":2,"button_border_weight":2,"buttons_style":"pill","input_border_radius":2,"input_border_weight":2,"inputs_style":"pill","show_widget_shadow":true,"widget_border_weight":2,"widget_corner_radius":2},"colors":{"body_text":"#00FF00","error":"#00FF00","header":"#00FF00","icons":"#00FF00","input_background":"#00FF00","input_border":"#00FF00","input_filled_text":"#00FF00","input_labels_placeholders":"#00FF00","links_focused_components":"#00FF00","primary_button":"#00FF00","primary_button_label":"#00FF00","secondary_button_border":"#00FF00","secondary_button_label":"#00FF00","success":"#00FF00","widget_background":"#00FF00","widget_border":"#00FF00"},"fonts":{"body_text":{"bold":true,"size":100},"buttons_text":{"bold":true,"size":100},"font_url":"https://google.com/font.woff","input_labels":{"bold":true,"size":100},"links":{"bold":true,"size":100},"links_style":"normal","reference_text_size":12,"subtitle":{"bold":true,"size":100},"title":{"bold":true,"size":100}},"page_background":{"background_color":"#000000","background_image_url":"https://google.com/background.png","page_layout":"center"},"widget":{"header_text_alignment":"center","logo_height":55,"logo_position":"center","logo_url":"https://google.com/logo.png","social_buttons_layout":"top"},"themeId":"W1hDtZNvDZ1rm4aPFt5KOFnmsB2OJ2Zh"}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/themes/W1hDtZNvDZ1rm4aPFt5KOFnmsB2OJ2Zh
+        method: DELETE
+      response:
+        body: ""
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

As requested in https://github.com/auth0/go-auth0/issues/110 we're adding the ability to retrieve the default branding theme.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
