### PR TITLE
[DXEX-2581] Add support for Actions log sessions endpoint

### DIFF
--- a/management/actions.go
+++ b/management/actions.go
@@ -200,16 +200,16 @@ type ActionExecution struct {
 	UpdatedAt *time.Time `json:"updated_at"`
 }
 
-// ActionLogSessionFilter defines a filter for
+// ActionLogSessionFilter defines a filter for the log session.
 type ActionLogSessionFilter struct {
 	Key *string `json:"key,omitempty"`
 	Val *string `json:"val,omitempty"`
 }
 
 // ActionLogSession contains a presigned URL that can be used for tailing realtime
-// logs from Actions
+// logs from Actions.
 type ActionLogSession struct {
-	Url     *string    `json:"url,omitempty"`
+	URL     *string    `json:"url,omitempty"`
 	Expires *time.Time `json:"expires,omitempty"`
 
 	Filters []ActionLogSessionFilter `json:"filters,omitempty"`
@@ -347,7 +347,7 @@ func (m *ActionManager) Execution(executionID string, opts ...RequestOption) (v 
 	return
 }
 
-// Create a log session for tailing Actions logs.
+// LogSession creates a log session for tailing Actions logs.
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Actions/post_actions_log_sessions
 func (m *ActionManager) LogSession(l *ActionLogSession, opts ...RequestOption) (err error) {

--- a/management/actions.go
+++ b/management/actions.go
@@ -200,6 +200,21 @@ type ActionExecution struct {
 	UpdatedAt *time.Time `json:"updated_at"`
 }
 
+// ActionLogSessionFilter defines a filter for
+type ActionLogSessionFilter struct {
+	Key *string `json:"key,omitempty"`
+	Val *string `json:"val,omitempty"`
+}
+
+// ActionLogSession contains a presigned URL that can be used for tailing realtime
+// logs from Actions
+type ActionLogSession struct {
+	Url     *string    `json:"url,omitempty"`
+	Expires *time.Time `json:"expires,omitempty"`
+
+	Filters []ActionLogSessionFilter `json:"filters,omitempty"`
+}
+
 // ActionManager manages Auth0 Action resources.
 type ActionManager struct {
 	*Management
@@ -329,5 +344,13 @@ func (m *ActionManager) Test(id string, payload *ActionTestPayload, opts ...Requ
 // See: https://auth0.com/docs/api/management/v2/#!/Actions/get_execution
 func (m *ActionManager) Execution(executionID string, opts ...RequestOption) (v *ActionExecution, err error) {
 	err = m.Request("GET", m.URI("actions", "executions", executionID), &v, opts...)
+	return
+}
+
+// Create a log session for tailing Actions logs.
+//
+// See: https://auth0.com/docs/api/management/v2/#!/Actions/post_actions_log_sessions
+func (m *ActionManager) LogSession(l *ActionLogSession, opts ...RequestOption) (err error) {
+	err = m.Request("POST", m.URI("actions", "log-sessions"), &l, opts...)
 	return
 }

--- a/management/actions.go
+++ b/management/actions.go
@@ -202,8 +202,8 @@ type ActionExecution struct {
 
 // ActionLogSessionFilter defines a filter for the log session.
 type ActionLogSessionFilter struct {
-	Key *string `json:"key,omitempty"`
-	Val *string `json:"val,omitempty"`
+	Key string `json:"key"`
+	Val string `json:"val"`
 }
 
 // ActionLogSession contains a presigned URL that can be used for tailing realtime

--- a/management/actions_test.go
+++ b/management/actions_test.go
@@ -243,8 +243,8 @@ func TestActionManager_LogSession(t *testing.T) {
 
 	expectedLogSession := &ActionLogSession{
 		Filters: []ActionLogSessionFilter{{
-			Key: auth0.String("action_id"),
-			Val: auth0.String("act_123"),
+			Key: "action_id",
+			Val: "act_123",
 		}},
 	}
 

--- a/management/actions_test.go
+++ b/management/actions_test.go
@@ -251,7 +251,7 @@ func TestActionManager_LogSession(t *testing.T) {
 	err := m.Action.LogSession(expectedLogSession)
 
 	assert.NoError(t, err)
-	assert.Equal(t, *expectedLogSession.Url, "https://go-auth0-dev.eu.auth0.com/actions/log-sessions/tail?token=tkn_123")
+	assert.Equal(t, *expectedLogSession.URL, "https://go-auth0-dev.eu.auth0.com/actions/log-sessions/tail?token=tkn_123")
 	assert.NotEmpty(t, expectedLogSession.Expires)
 }
 

--- a/management/actions_test.go
+++ b/management/actions_test.go
@@ -238,6 +238,23 @@ func TestActionManager_Execution(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, err.(Error).Status())
 }
 
+func TestActionManager_LogSession(t *testing.T) {
+	setupHTTPRecordings(t)
+
+	expectedLogSession := &ActionLogSession{
+		Filters: []ActionLogSessionFilter{{
+			Key: auth0.String("action_id"),
+			Val: auth0.String("act_123"),
+		}},
+	}
+
+	err := m.Action.LogSession(expectedLogSession)
+
+	assert.NoError(t, err)
+	assert.Equal(t, *expectedLogSession.Url, "https://go-auth0-dev.eu.auth0.com/actions/log-sessions/tail?token=tkn_123")
+	assert.NotEmpty(t, expectedLogSession.Expires)
+}
+
 func cleanupAction(t *testing.T, actionID string) {
 	t.Helper()
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -303,12 +303,12 @@ func (a *ActionLogSession) GetExpires() time.Time {
 	return *a.Expires
 }
 
-// GetUrl returns the Url field if it's non-nil, zero value otherwise.
-func (a *ActionLogSession) GetUrl() string {
-	if a == nil || a.Url == nil {
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (a *ActionLogSession) GetURL() string {
+	if a == nil || a.URL == nil {
 		return ""
 	}
-	return *a.Url
+	return *a.URL
 }
 
 // String returns a string representation of ActionLogSession.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -316,22 +316,6 @@ func (a *ActionLogSession) String() string {
 	return Stringify(a)
 }
 
-// GetKey returns the Key field if it's non-nil, zero value otherwise.
-func (a *ActionLogSessionFilter) GetKey() string {
-	if a == nil || a.Key == nil {
-		return ""
-	}
-	return *a.Key
-}
-
-// GetVal returns the Val field if it's non-nil, zero value otherwise.
-func (a *ActionLogSessionFilter) GetVal() string {
-	if a == nil || a.Val == nil {
-		return ""
-	}
-	return *a.Val
-}
-
 // String returns a string representation of ActionLogSessionFilter.
 func (a *ActionLogSessionFilter) String() string {
 	return Stringify(a)

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -295,6 +295,48 @@ func (a *ActionList) String() string {
 	return Stringify(a)
 }
 
+// GetExpires returns the Expires field if it's non-nil, zero value otherwise.
+func (a *ActionLogSession) GetExpires() time.Time {
+	if a == nil || a.Expires == nil {
+		return time.Time{}
+	}
+	return *a.Expires
+}
+
+// GetUrl returns the Url field if it's non-nil, zero value otherwise.
+func (a *ActionLogSession) GetUrl() string {
+	if a == nil || a.Url == nil {
+		return ""
+	}
+	return *a.Url
+}
+
+// String returns a string representation of ActionLogSession.
+func (a *ActionLogSession) String() string {
+	return Stringify(a)
+}
+
+// GetKey returns the Key field if it's non-nil, zero value otherwise.
+func (a *ActionLogSessionFilter) GetKey() string {
+	if a == nil || a.Key == nil {
+		return ""
+	}
+	return *a.Key
+}
+
+// GetVal returns the Val field if it's non-nil, zero value otherwise.
+func (a *ActionLogSessionFilter) GetVal() string {
+	if a == nil || a.Val == nil {
+		return ""
+	}
+	return *a.Val
+}
+
+// String returns a string representation of ActionLogSessionFilter.
+func (a *ActionLogSessionFilter) String() string {
+	return Stringify(a)
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (a *ActionSecret) GetName() string {
 	if a == nil || a.Name == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -384,14 +384,14 @@ func TestActionLogSession_GetExpires(tt *testing.T) {
 	a.GetExpires()
 }
 
-func TestActionLogSession_GetUrl(tt *testing.T) {
+func TestActionLogSession_GetURL(tt *testing.T) {
 	var zeroValue string
-	a := &ActionLogSession{Url: &zeroValue}
-	a.GetUrl()
+	a := &ActionLogSession{URL: &zeroValue}
+	a.GetURL()
 	a = &ActionLogSession{}
-	a.GetUrl()
+	a.GetURL()
 	a = nil
-	a.GetUrl()
+	a.GetURL()
 }
 
 func TestActionLogSession_String(t *testing.T) {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -402,26 +402,6 @@ func TestActionLogSession_String(t *testing.T) {
 	}
 }
 
-func TestActionLogSessionFilter_GetKey(tt *testing.T) {
-	var zeroValue string
-	a := &ActionLogSessionFilter{Key: &zeroValue}
-	a.GetKey()
-	a = &ActionLogSessionFilter{}
-	a.GetKey()
-	a = nil
-	a.GetKey()
-}
-
-func TestActionLogSessionFilter_GetVal(tt *testing.T) {
-	var zeroValue string
-	a := &ActionLogSessionFilter{Val: &zeroValue}
-	a.GetVal()
-	a = &ActionLogSessionFilter{}
-	a.GetVal()
-	a = nil
-	a.GetVal()
-}
-
 func TestActionLogSessionFilter_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ActionLogSessionFilter{}

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -374,6 +374,62 @@ func TestActionList_String(t *testing.T) {
 	}
 }
 
+func TestActionLogSession_GetExpires(tt *testing.T) {
+	var zeroValue time.Time
+	a := &ActionLogSession{Expires: &zeroValue}
+	a.GetExpires()
+	a = &ActionLogSession{}
+	a.GetExpires()
+	a = nil
+	a.GetExpires()
+}
+
+func TestActionLogSession_GetUrl(tt *testing.T) {
+	var zeroValue string
+	a := &ActionLogSession{Url: &zeroValue}
+	a.GetUrl()
+	a = &ActionLogSession{}
+	a.GetUrl()
+	a = nil
+	a.GetUrl()
+}
+
+func TestActionLogSession_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ActionLogSession{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestActionLogSessionFilter_GetKey(tt *testing.T) {
+	var zeroValue string
+	a := &ActionLogSessionFilter{Key: &zeroValue}
+	a.GetKey()
+	a = &ActionLogSessionFilter{}
+	a.GetKey()
+	a = nil
+	a.GetKey()
+}
+
+func TestActionLogSessionFilter_GetVal(tt *testing.T) {
+	var zeroValue string
+	a := &ActionLogSessionFilter{Val: &zeroValue}
+	a.GetVal()
+	a = &ActionLogSessionFilter{}
+	a.GetVal()
+	a = nil
+	a.GetVal()
+}
+
+func TestActionLogSessionFilter_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ActionLogSessionFilter{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestActionSecret_GetName(tt *testing.T) {
 	var zeroValue string
 	a := &ActionSecret{Name: &zeroValue}

--- a/management/testdata/recordings/TestActionManager_LogSession.yaml
+++ b/management/testdata/recordings/TestActionManager_LogSession.yaml
@@ -1,0 +1,22 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://go-auth0-dev.eu.auth0.com/api/v2/actions/log-sessions
+    method: POST
+  response:
+    body: '{"url":"https://go-auth0-dev.eu.auth0.com/actions/log-sessions/tail?token=tkn_123","expires":"2022-10-21T16:48:15.576883302Z"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 201 Created
+    code: 201
+    duration: 1ms


### PR DESCRIPTION
### 🔧 Changes

Adds support for creating a log session via the Management API for tailing Actions Logs.

### 🔬 Testing

Tested against a space with the following steps:

#### Step 1: Generate Log Session

```go
package main

import (
	"fmt"
	"log"

	_ "github.com/auth0/go-auth0"
	"github.com/auth0/go-auth0/management"
)

func main() {
	m, err := management.New(
		"AUTH0_DOMAIN",
		management.WithClientCredentials(
			"AUTH0_CLIENT_ID",
			"AUTH0_CLIENT_SECRET",
		),
	)

	if err != nil {
		log.Fatalf("failed to create client %v\n", err)
		return
	}

	key := "action_id"
	val := "ACTION_ID"
	resp := &management.ActionLogSession{
		Filters: []management.ActionLogSessionFilter{
			{
				Key: &key,
				Val: &val,
			},
		},
	}

	err = m.Action.LogSession(resp)
	if err != nil {
		log.Fatalf("failed to create log session %v\n", err)
		return
	}

	fmt.Printf("created log session URL: \n\nURL: %s\n", *resp.Url)
}
```

#### Step 2: Subscribe to Stream

```js
const onMessage = (event) => {
  console.log(event.data);
};

eventSource = new EventSource(
  "LOG_SESSION_URL"
);

eventSource.onopen = () => {
  console.log("stream opened");
};

eventSource.onmessage = onMessage;
```

#### Step 3: Execute an Action

Execute an Action from the Dashboard or via the Authentication API and observe the event data for the specific Action being filtered.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
