### PR TITLE
DXCDT-255: Add new email provider manager and deprecate old one

### DIFF
--- a/management/email.go
+++ b/management/email.go
@@ -3,6 +3,7 @@ package management
 // Email is used to configure Email Providers.
 //
 // See: https://auth0.com/docs/customize/email
+// Deprecated: Use EmailProvider instead.
 type Email struct {
 	// The name of the email provider. Can be one of "mandrill", "sendgrid",
 	// "sparkpost", "ses" or "smtp".
@@ -19,6 +20,7 @@ type Email struct {
 }
 
 // EmailCredentials are used for authenticating Email Providers.
+// Deprecated: Use EmailProvider instead.
 type EmailCredentials struct {
 	// API User
 	APIUser *string `json:"api_user,omitempty"`
@@ -43,6 +45,7 @@ type EmailCredentials struct {
 }
 
 // EmailManager manages Auth0 Email resources.
+// Deprecated: Use EmailProviderManager instead.
 type EmailManager struct {
 	*Management
 }

--- a/management/email_provider.go
+++ b/management/email_provider.go
@@ -1,0 +1,288 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const (
+	// EmailProviderMandrill constant.
+	EmailProviderMandrill = "mandrill"
+
+	// EmailProviderSES constant.
+	EmailProviderSES = "ses"
+
+	// EmailProviderSendGrid constant.
+	EmailProviderSendGrid = "sendgrid"
+
+	// EmailProviderSparkPost constant.
+	EmailProviderSparkPost = "sparkpost"
+
+	// EmailProviderMailgun constant.
+	EmailProviderMailgun = "mailgun"
+
+	// EmailProviderSmtp constant.
+	EmailProviderSmtp = "smtp"
+)
+
+// EmailProvider is used to configure Email Providers.
+//
+// See: https://auth0.com/docs/customize/email
+type EmailProvider struct {
+	// The name of the email provider.
+	// Can be one of "mandrill", "ses", "sendgrid", "sparkpost", "mailgun"  or "smtp".
+	Name *string `json:"name,omitempty"`
+
+	// Indicates whether the email provider is enabled or not.
+	// Defaults to true.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// The default FROM address.
+	DefaultFromAddress *string `json:"default_from_address,omitempty"`
+
+	// Credentials required to use the provider.
+	Credentials interface{} `json:"-"`
+
+	// Specific provider setting.
+	Settings interface{} `json:"-"`
+}
+
+// EmailProviderCredentialsMandrill represent the
+// credentials required to use the mandrill provider.
+type EmailProviderCredentialsMandrill struct {
+	APIKey *string `json:"api_key,omitempty"`
+}
+
+// EmailProviderCredentialsSES represent the
+// credentials required to use the ses provider.
+type EmailProviderCredentialsSES struct {
+	AccessKeyID     *string `json:"accessKeyId,omitempty"`
+	SecretAccessKey *string `json:"secretAccessKey,omitempty"`
+	Region          *string `json:"region,omitempty"`
+}
+
+// EmailProviderCredentialsSendGrid represent the
+// credentials required to use the sendgrid provider.
+type EmailProviderCredentialsSendGrid struct {
+	APIKey *string `json:"api_key,omitempty"`
+}
+
+// EmailProviderCredentialsSparkPost represent the
+// credentials required to use the sparkpost provider.
+type EmailProviderCredentialsSparkPost struct {
+	APIKey *string `json:"api_key,omitempty"`
+	Region *string `json:"region,omitempty"`
+}
+
+// EmailProviderCredentialsMailgun represent the
+// credentials required to use the mailgun provider.
+type EmailProviderCredentialsMailgun struct {
+	APIKey *string `json:"api_key,omitempty"`
+	Domain *string `json:"domain,omitempty"`
+	Region *string `json:"region,omitempty"`
+}
+
+// EmailProviderCredentialsSmtp represent the
+// credentials required to use the smtp provider.
+type EmailProviderCredentialsSmtp struct {
+	SMTPHost *string `json:"smtp_host,omitempty"`
+	SMTPPort *int    `json:"smtp_port,omitempty"`
+	SMTPUser *string `json:"smtp_user,omitempty"`
+	SMTPPass *string `json:"smtp_pass,omitempty"`
+}
+
+// EmailProviderSettingsMandrill are the provider
+// specific settings used by the mandrill provider.
+type EmailProviderSettingsMandrill struct {
+	Message *EmailProviderSettingsMandrillMessage `json:"message,omitempty"`
+}
+
+// EmailProviderSettingsMandrillMessage contains the
+// message setting content for the mandrill provider.
+type EmailProviderSettingsMandrillMessage struct {
+	ViewContentLink *bool `json:"view_content_link,omitempty"`
+}
+
+// EmailProviderSettingsSES are the provider
+// specific settings used by the ses provider.
+type EmailProviderSettingsSES struct {
+	Message *EmailProviderSettingsSESMessage `json:"message,omitempty"`
+}
+
+// EmailProviderSettingsSESMessage contains the
+// message setting content for the ses provider.
+type EmailProviderSettingsSESMessage struct {
+	ConfigurationSetName *string `json:"configuration_set_name,omitempty"`
+}
+
+// EmailProviderSettingsSmtp are the provider
+// specific settings used by the smtp provider.
+type EmailProviderSettingsSmtp struct {
+	Headers *EmailProviderSettingsSmtpHeaders `json:"headers,omitempty"`
+}
+
+// EmailProviderSettingsSmtpHeaders contains the
+// headers setting content for the smtp provider.
+type EmailProviderSettingsSmtpHeaders struct {
+	XMCViewContentLink   *string `json:"X-MC-ViewContentLink,omitempty"`
+	XSESConfigurationSet *string `json:"X-SES-Configuration-Set,omitempty"`
+}
+
+// MarshalJSON is a custom serializer for the EmailProvider type.
+func (ep *EmailProvider) MarshalJSON() ([]byte, error) {
+	type emailProvider EmailProvider
+	type emailProviderWrapper struct {
+		*emailProvider
+		RawCredentials json.RawMessage `json:"credentials,omitempty"`
+		RawSettings    json.RawMessage `json:"settings,omitempty"`
+	}
+
+	wrapper := &emailProviderWrapper{(*emailProvider)(ep), nil, nil}
+
+	if ep.Credentials != nil {
+		credentialsJSON, err := json.Marshal(ep.Credentials)
+		if err != nil {
+			return nil, err
+		}
+		wrapper.RawCredentials = credentialsJSON
+	}
+
+	if ep.Settings != nil {
+		settingsJSON, err := json.Marshal(ep.Settings)
+		if err != nil {
+			return nil, err
+		}
+		wrapper.RawSettings = settingsJSON
+	}
+
+	return json.Marshal(wrapper)
+}
+
+// UnmarshalJSON is a custom deserializer for the EmailProvider type.
+func (ep *EmailProvider) UnmarshalJSON(b []byte) error {
+	type emailProvider EmailProvider
+	type emailProviderWrapper struct {
+		*emailProvider
+		RawCredentials json.RawMessage `json:"credentials,omitempty"`
+		RawSettings    json.RawMessage `json:"settings,omitempty"`
+	}
+
+	wrapper := &emailProviderWrapper{(*emailProvider)(ep), nil, nil}
+
+	if err := json.Unmarshal(b, wrapper); err != nil {
+		return err
+	}
+
+	var credentials, settings interface{}
+
+	switch ep.GetName() {
+	case EmailProviderMandrill:
+		credentials = &EmailProviderCredentialsMandrill{}
+		settings = &EmailProviderSettingsMandrill{}
+	case EmailProviderSES:
+		credentials = &EmailProviderCredentialsSES{}
+		settings = &EmailProviderSettingsSES{}
+	case EmailProviderSendGrid:
+		credentials = &EmailProviderCredentialsSendGrid{}
+		// No settings for sendgrid.
+		settings = nil
+	case EmailProviderSparkPost:
+		credentials = &EmailProviderCredentialsSparkPost{}
+		// No settings for sparkpost.
+		settings = nil
+	case EmailProviderMailgun:
+		credentials = &EmailProviderCredentialsMailgun{}
+		// No settings for mailgun.
+		settings = nil
+	case EmailProviderSmtp:
+		credentials = &EmailProviderCredentialsSmtp{}
+		settings = &EmailProviderSettingsSmtp{}
+	case "":
+		credentials = nil
+		settings = nil
+	default:
+		// Just making sure we're covered if
+		// new email providers are introduced.
+		credentials = make(map[string]interface{})
+		settings = make(map[string]interface{})
+	}
+
+	if wrapper.RawCredentials != nil {
+		if err := json.Unmarshal(wrapper.RawCredentials, &credentials); err != nil {
+			return err
+		}
+	}
+
+	if wrapper.RawSettings != nil {
+		if err := json.Unmarshal(wrapper.RawSettings, &settings); err != nil {
+			return err
+		}
+	}
+
+	ep.Credentials = credentials
+	ep.Settings = settings
+
+	return nil
+}
+
+// EmailProviderManager manages the Auth0 EmailProvider.
+type EmailProviderManager struct {
+	*Management
+}
+
+func newEmailProviderManager(m *Management) *EmailProviderManager {
+	return &EmailProviderManager{m}
+}
+
+// Create an email provider.
+//
+// The credentials object requires different properties depending on the email
+// provider (which is specified using the name property):
+//
+// - `mandrill` requires `api_key`
+// - `sendgrid` requires `api_key`
+// - `sparkpost` requires `api_key`. Optionally, set `region` to `eu` to use the
+// SparkPost service hosted in Western Europe; set to `null` to use the
+// SparkPost service hosted in North America. `eu` or `null` are the only valid
+// values for `region`.
+// - ses requires accessKeyId, secretAccessKey, and region
+// - smtp requires smtp_host, smtp_port, smtp_user, and smtp_pass
+// - `mailgun` requires `api_key` and `domain`. Optionally, set region to eu to
+// use the Mailgun service hosted in Europe; set to null otherwise. "eu" or null
+// are the only valid values for region.
+//
+// Depending on the type of provider it is possible to specify settings object
+// with different configuration options, which will be used when sending an
+// email:
+//
+// - `smtp` provider, `settings` may contain `headers` object. When using AWS
+// SES SMTP host, you may provide a name of configuration set in an
+// `X-SES-Configuration-Set` header. The value must be a string.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Emails/post_provider
+func (m *EmailProviderManager) Create(ep *EmailProvider, opts ...RequestOption) error {
+	return m.Request(http.MethodPost, m.URI("emails", "provider"), ep, opts...)
+}
+
+// Read email provider details.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Emails/get_provider
+func (m *EmailProviderManager) Read(opts ...RequestOption) (ep *EmailProvider, err error) {
+	opts = append(opts, IncludeFields("name", "enabled", "default_from_address", "credentials", "settings"))
+	err = m.Request(http.MethodGet, m.URI("emails", "provider"), &ep, opts...)
+	return
+}
+
+// Update an email provider.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Emails/patch_provider
+func (m *EmailProviderManager) Update(ep *EmailProvider, opts ...RequestOption) (err error) {
+	return m.Request(http.MethodPatch, m.URI("emails", "provider"), ep, opts...)
+}
+
+// Delete the email provider.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Emails/delete_provider
+func (m *EmailProviderManager) Delete(opts ...RequestOption) (err error) {
+	return m.Request(http.MethodDelete, m.URI("emails", "provider"), nil, opts...)
+}

--- a/management/email_provider.go
+++ b/management/email_provider.go
@@ -110,7 +110,7 @@ type EmailProviderSettingsSES struct {
 }
 
 // EmailProviderSettingsSESMessage contains the
-// message setting content for the ses provider.
+// message settings content for the ses provider.
 type EmailProviderSettingsSESMessage struct {
 	ConfigurationSetName *string `json:"configuration_set_name,omitempty"`
 }

--- a/management/email_provider.go
+++ b/management/email_provider.go
@@ -21,8 +21,8 @@ const (
 	// EmailProviderMailgun constant.
 	EmailProviderMailgun = "mailgun"
 
-	// EmailProviderSmtp constant.
-	EmailProviderSmtp = "smtp"
+	// EmailProviderSMTP constant.
+	EmailProviderSMTP = "smtp"
 )
 
 // EmailProvider is used to configure Email Providers.
@@ -82,9 +82,9 @@ type EmailProviderCredentialsMailgun struct {
 	Region *string `json:"region,omitempty"`
 }
 
-// EmailProviderCredentialsSmtp represent the
+// EmailProviderCredentialsSMTP represent the
 // credentials required to use the smtp provider.
-type EmailProviderCredentialsSmtp struct {
+type EmailProviderCredentialsSMTP struct {
 	SMTPHost *string `json:"smtp_host,omitempty"`
 	SMTPPort *int    `json:"smtp_port,omitempty"`
 	SMTPUser *string `json:"smtp_user,omitempty"`
@@ -115,15 +115,15 @@ type EmailProviderSettingsSESMessage struct {
 	ConfigurationSetName *string `json:"configuration_set_name,omitempty"`
 }
 
-// EmailProviderSettingsSmtp are the provider
+// EmailProviderSettingsSMTP are the provider
 // specific settings used by the smtp provider.
-type EmailProviderSettingsSmtp struct {
-	Headers *EmailProviderSettingsSmtpHeaders `json:"headers,omitempty"`
+type EmailProviderSettingsSMTP struct {
+	Headers *EmailProviderSettingsSMTPHeaders `json:"headers,omitempty"`
 }
 
-// EmailProviderSettingsSmtpHeaders contains the
+// EmailProviderSettingsSMTPHeaders contains the
 // headers setting content for the smtp provider.
-type EmailProviderSettingsSmtpHeaders struct {
+type EmailProviderSettingsSMTPHeaders struct {
 	XMCViewContentLink   *string `json:"X-MC-ViewContentLink,omitempty"`
 	XSESConfigurationSet *string `json:"X-SES-Configuration-Set,omitempty"`
 }
@@ -194,9 +194,9 @@ func (ep *EmailProvider) UnmarshalJSON(b []byte) error {
 		credentials = &EmailProviderCredentialsMailgun{}
 		// No settings for mailgun.
 		settings = nil
-	case EmailProviderSmtp:
-		credentials = &EmailProviderCredentialsSmtp{}
-		settings = &EmailProviderSettingsSmtp{}
+	case EmailProviderSMTP:
+		credentials = &EmailProviderCredentialsSMTP{}
+		settings = &EmailProviderSettingsSMTP{}
 	case "":
 		credentials = nil
 		settings = nil

--- a/management/email_provider.go
+++ b/management/email_provider.go
@@ -122,7 +122,7 @@ type EmailProviderSettingsSMTP struct {
 }
 
 // EmailProviderSettingsSMTPHeaders contains the
-// headers setting content for the smtp provider.
+// headers settings content for the smtp provider.
 type EmailProviderSettingsSMTPHeaders struct {
 	XMCViewContentLink   *string `json:"X-MC-ViewContentLink,omitempty"`
 	XSESConfigurationSet *string `json:"X-SES-Configuration-Set,omitempty"`

--- a/management/email_provider.go
+++ b/management/email_provider.go
@@ -43,7 +43,7 @@ type EmailProvider struct {
 	// Credentials required to use the provider.
 	Credentials interface{} `json:"-"`
 
-	// Specific provider setting.
+	// Specific provider settings.
 	Settings interface{} `json:"-"`
 }
 

--- a/management/email_provider.go
+++ b/management/email_provider.go
@@ -128,15 +128,16 @@ type EmailProviderSettingsSMTPHeaders struct {
 	XSESConfigurationSet *string `json:"X-SES-Configuration-Set,omitempty"`
 }
 
+type emailProvider EmailProvider
+
+type emailProviderWrapper struct {
+	*emailProvider
+	RawCredentials json.RawMessage `json:"credentials,omitempty"`
+	RawSettings    json.RawMessage `json:"settings,omitempty"`
+}
+
 // MarshalJSON is a custom serializer for the EmailProvider type.
 func (ep *EmailProvider) MarshalJSON() ([]byte, error) {
-	type emailProvider EmailProvider
-	type emailProviderWrapper struct {
-		*emailProvider
-		RawCredentials json.RawMessage `json:"credentials,omitempty"`
-		RawSettings    json.RawMessage `json:"settings,omitempty"`
-	}
-
 	wrapper := &emailProviderWrapper{(*emailProvider)(ep), nil, nil}
 
 	if ep.Credentials != nil {
@@ -160,13 +161,6 @@ func (ep *EmailProvider) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON is a custom deserializer for the EmailProvider type.
 func (ep *EmailProvider) UnmarshalJSON(b []byte) error {
-	type emailProvider EmailProvider
-	type emailProviderWrapper struct {
-		*emailProvider
-		RawCredentials json.RawMessage `json:"credentials,omitempty"`
-		RawSettings    json.RawMessage `json:"settings,omitempty"`
-	}
-
 	wrapper := &emailProviderWrapper{(*emailProvider)(ep), nil, nil}
 
 	if err := json.Unmarshal(b, wrapper); err != nil {

--- a/management/email_provider.go
+++ b/management/email_provider.go
@@ -98,7 +98,7 @@ type EmailProviderSettingsMandrill struct {
 }
 
 // EmailProviderSettingsMandrillMessage contains the
-// message setting content for the mandrill provider.
+// message settings content for the mandrill provider.
 type EmailProviderSettingsMandrillMessage struct {
 	ViewContentLink *bool `json:"view_content_link,omitempty"`
 }

--- a/management/email_provider_test.go
+++ b/management/email_provider_test.go
@@ -104,14 +104,14 @@ func TestEmailProviderJSON(t *testing.T) {
 				Name:               auth0.String("smtp"),
 				Enabled:            auth0.Bool(true),
 				DefaultFromAddress: auth0.String("accounts@example.com"),
-				Credentials: &EmailProviderCredentialsSmtp{
+				Credentials: &EmailProviderCredentialsSMTP{
 					SMTPHost: auth0.String("example.com"),
 					SMTPPort: auth0.Int(3000),
 					SMTPUser: auth0.String("user"),
 					SMTPPass: auth0.String("pass"),
 				},
-				Settings: &EmailProviderSettingsSmtp{
-					Headers: &EmailProviderSettingsSmtpHeaders{
+				Settings: &EmailProviderSettingsSMTP{
+					Headers: &EmailProviderSettingsSMTPHeaders{
 						XMCViewContentLink:   auth0.String("true"),
 						XSESConfigurationSet: auth0.String("example"),
 					},
@@ -146,7 +146,7 @@ func TestEmailProviderManager_Create(t *testing.T) {
 		Name:               auth0.String("smtp"),
 		Enabled:            auth0.Bool(true),
 		DefaultFromAddress: auth0.String("no-reply@example.com"),
-		Credentials: &EmailProviderCredentialsSmtp{
+		Credentials: &EmailProviderCredentialsSMTP{
 			SMTPHost: auth0.String("smtp.example.com"),
 			SMTPPort: auth0.Int(587),
 			SMTPUser: auth0.String("user"),
@@ -173,7 +173,7 @@ func TestEmailProviderManager_Read(t *testing.T) {
 	assert.Equal(t, expectedEmailProvider.GetName(), actualEmailProvider.GetName())
 	assert.Equal(t, expectedEmailProvider.GetEnabled(), actualEmailProvider.GetEnabled())
 	assert.Equal(t, expectedEmailProvider.GetDefaultFromAddress(), actualEmailProvider.GetDefaultFromAddress())
-	assert.IsType(t, &EmailProviderCredentialsSmtp{}, expectedEmailProvider.Credentials)
+	assert.IsType(t, &EmailProviderCredentialsSMTP{}, expectedEmailProvider.Credentials)
 }
 
 func TestEmailProviderManager_Update(t *testing.T) {
@@ -215,7 +215,7 @@ func givenAnEmailProvider(t *testing.T) *EmailProvider {
 		Name:               auth0.String("smtp"),
 		Enabled:            auth0.Bool(true),
 		DefaultFromAddress: auth0.String("no-reply@example.com"),
-		Credentials: &EmailProviderCredentialsSmtp{
+		Credentials: &EmailProviderCredentialsSMTP{
 			SMTPHost: auth0.String("smtp.example.com"),
 			SMTPPort: auth0.Int(587),
 			SMTPUser: auth0.String("user"),

--- a/management/email_provider_test.go
+++ b/management/email_provider_test.go
@@ -1,0 +1,245 @@
+package management
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/auth0/go-auth0"
+)
+
+func TestEmailProviderJSON(t *testing.T) {
+	var jsonTestCases = []struct {
+		name          string
+		emailProvider *EmailProvider
+		json          string
+	}{
+		{
+			name:          "it can %s an empty string",
+			emailProvider: &EmailProvider{},
+			json:          `{}`,
+		},
+		{
+			name: "it can %s a mandrill email provider",
+			emailProvider: &EmailProvider{
+				Name:               auth0.String("mandrill"),
+				Enabled:            auth0.Bool(true),
+				DefaultFromAddress: auth0.String("accounts@example.com"),
+				Credentials: &EmailProviderCredentialsMandrill{
+					APIKey: auth0.String("secretApiKey"),
+				},
+				Settings: &EmailProviderSettingsMandrill{
+					Message: &EmailProviderSettingsMandrillMessage{
+						ViewContentLink: auth0.Bool(true),
+					},
+				},
+			},
+			json: `{"name":"mandrill","enabled":true,"default_from_address":"accounts@example.com","credentials":{"api_key":"secretApiKey"},"settings":{"message":{"view_content_link":true}}}`,
+		},
+		{
+			name: "it can %s an ses email provider",
+			emailProvider: &EmailProvider{
+				Name:               auth0.String("ses"),
+				Enabled:            auth0.Bool(true),
+				DefaultFromAddress: auth0.String("accounts@example.com"),
+				Credentials: &EmailProviderCredentialsSES{
+					AccessKeyID:     auth0.String("accessKey"),
+					SecretAccessKey: auth0.String("secret"),
+					Region:          auth0.String("eu-west-2"),
+				},
+				Settings: &EmailProviderSettingsSES{
+					Message: &EmailProviderSettingsSESMessage{
+						ConfigurationSetName: auth0.String("example"),
+					},
+				},
+			},
+			json: `{"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"accessKeyId":"accessKey","secretAccessKey":"secret","region":"eu-west-2"},"settings":{"message":{"configuration_set_name":"example"}}}`,
+		},
+		{
+			name: "it can %s a sendgrid email provider",
+			emailProvider: &EmailProvider{
+				Name:               auth0.String("sendgrid"),
+				Enabled:            auth0.Bool(true),
+				DefaultFromAddress: auth0.String("accounts@example.com"),
+				Credentials: &EmailProviderCredentialsSendGrid{
+					APIKey: auth0.String("apiKey"),
+				},
+			},
+			json: `{"name":"sendgrid","enabled":true,"default_from_address":"accounts@example.com","credentials":{"api_key":"apiKey"}}`,
+		},
+		{
+			name: "it can %s a sparkpost email provider",
+			emailProvider: &EmailProvider{
+				Name:               auth0.String("sparkpost"),
+				Enabled:            auth0.Bool(true),
+				DefaultFromAddress: auth0.String("accounts@example.com"),
+				Credentials: &EmailProviderCredentialsSparkPost{
+					APIKey: auth0.String("apiKey"),
+					Region: auth0.String("eu"),
+				},
+			},
+			json: `{"name":"sparkpost","enabled":true,"default_from_address":"accounts@example.com","credentials":{"api_key":"apiKey","region":"eu"}}`,
+		},
+		{
+			name: "it can %s a mailgun email provider",
+			emailProvider: &EmailProvider{
+				Name:               auth0.String("mailgun"),
+				Enabled:            auth0.Bool(true),
+				DefaultFromAddress: auth0.String("accounts@example.com"),
+				Credentials: &EmailProviderCredentialsMailgun{
+					APIKey: auth0.String("apiKey"),
+					Region: auth0.String("eu"),
+					Domain: auth0.String("example.com"),
+				},
+			},
+			json: `{"name":"mailgun","enabled":true,"default_from_address":"accounts@example.com","credentials":{"api_key":"apiKey","domain":"example.com","region":"eu"}}`,
+		},
+		{
+			name: "it can %s an smtp email provider",
+			emailProvider: &EmailProvider{
+				Name:               auth0.String("smtp"),
+				Enabled:            auth0.Bool(true),
+				DefaultFromAddress: auth0.String("accounts@example.com"),
+				Credentials: &EmailProviderCredentialsSmtp{
+					SMTPHost: auth0.String("example.com"),
+					SMTPPort: auth0.Int(3000),
+					SMTPUser: auth0.String("user"),
+					SMTPPass: auth0.String("pass"),
+				},
+				Settings: &EmailProviderSettingsSmtp{
+					Headers: &EmailProviderSettingsSmtpHeaders{
+						XMCViewContentLink:   auth0.String("true"),
+						XSESConfigurationSet: auth0.String("example"),
+					},
+				},
+			},
+			json: `{"name":"smtp","enabled":true,"default_from_address":"accounts@example.com","credentials":{"smtp_host":"example.com","smtp_port":3000,"smtp_user":"user","smtp_pass":"pass"},"settings":{"headers":{"X-MC-ViewContentLink":"true","X-SES-Configuration-Set":"example"}}}`,
+		},
+	}
+
+	for _, testCase := range jsonTestCases {
+		t.Run(fmt.Sprintf(testCase.name, "marshal"), func(t *testing.T) {
+			actualJSON, err := json.Marshal(testCase.emailProvider)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.json, string(actualJSON))
+		})
+	}
+
+	for _, testCase := range jsonTestCases {
+		t.Run(fmt.Sprintf(testCase.name, "unmarshal"), func(t *testing.T) {
+			var actualEmailProvider EmailProvider
+			err := json.Unmarshal([]byte(testCase.json), &actualEmailProvider)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.emailProvider, &actualEmailProvider)
+		})
+	}
+}
+
+func TestEmailProviderManager_Create(t *testing.T) {
+	setupHTTPRecordings(t)
+
+	emailProvider := &EmailProvider{
+		Name:               auth0.String("smtp"),
+		Enabled:            auth0.Bool(true),
+		DefaultFromAddress: auth0.String("no-reply@example.com"),
+		Credentials: &EmailProviderCredentialsSmtp{
+			SMTPHost: auth0.String("smtp.example.com"),
+			SMTPPort: auth0.Int(587),
+			SMTPUser: auth0.String("user"),
+			SMTPPass: auth0.String("pass"),
+		},
+	}
+
+	err := m.EmailProvider.Create(emailProvider)
+	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		cleanupEmailProvider(t)
+	})
+}
+
+func TestEmailProviderManager_Read(t *testing.T) {
+	setupHTTPRecordings(t)
+
+	expectedEmailProvider := givenAnEmailProvider(t)
+
+	actualEmailProvider, err := m.EmailProvider.Read()
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedEmailProvider.GetName(), actualEmailProvider.GetName())
+	assert.Equal(t, expectedEmailProvider.GetEnabled(), actualEmailProvider.GetEnabled())
+	assert.Equal(t, expectedEmailProvider.GetDefaultFromAddress(), actualEmailProvider.GetDefaultFromAddress())
+	assert.IsType(t, &EmailProviderCredentialsSmtp{}, expectedEmailProvider.Credentials)
+}
+
+func TestEmailProviderManager_Update(t *testing.T) {
+	setupHTTPRecordings(t)
+
+	emailProvider := givenAnEmailProvider(t)
+
+	emailProvider.Enabled = auth0.Bool(false)
+	emailProvider.DefaultFromAddress = auth0.String("info@example.com")
+
+	err := m.EmailProvider.Update(emailProvider)
+	assert.NoError(t, err)
+
+	actualEmailProvider, err := m.EmailProvider.Read()
+	assert.NoError(t, err)
+
+	assert.False(t, actualEmailProvider.GetEnabled())
+	assert.Equal(t, "info@example.com", actualEmailProvider.GetDefaultFromAddress())
+}
+
+func TestEmailProviderManager_Delete(t *testing.T) {
+	setupHTTPRecordings(t)
+
+	givenAnEmailProvider(t)
+
+	err := m.Email.Delete()
+	assert.NoError(t, err)
+
+	_, err = m.Email.Read()
+	assert.Error(t, err)
+	assert.Implements(t, (*Error)(nil), err)
+	assert.Equal(t, http.StatusNotFound, err.(Error).Status())
+}
+
+func givenAnEmailProvider(t *testing.T) *EmailProvider {
+	t.Helper()
+
+	emailProvider := &EmailProvider{
+		Name:               auth0.String("smtp"),
+		Enabled:            auth0.Bool(true),
+		DefaultFromAddress: auth0.String("no-reply@example.com"),
+		Credentials: &EmailProviderCredentialsSmtp{
+			SMTPHost: auth0.String("smtp.example.com"),
+			SMTPPort: auth0.Int(587),
+			SMTPUser: auth0.String("user"),
+			SMTPPass: auth0.String("pass"),
+		},
+	}
+
+	err := m.EmailProvider.Create(emailProvider)
+	if err != nil {
+		if err.(Error).Status() != http.StatusConflict {
+			t.Error(err)
+		}
+	}
+
+	t.Cleanup(func() {
+		cleanupEmailProvider(t)
+	})
+
+	return emailProvider
+}
+
+func cleanupEmailProvider(t *testing.T) {
+	t.Helper()
+
+	err := m.EmailProvider.Delete()
+	require.NoError(t, err)
+}

--- a/management/email_test.go
+++ b/management/email_test.go
@@ -29,14 +29,14 @@ func TestEmailManager_Create(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Cleanup(func() {
-		cleanupEmailProvider(t)
+		cleanupEmail(t)
 	})
 }
 
 func TestEmailManager_Read(t *testing.T) {
 	setupHTTPRecordings(t)
 
-	expectedEmailProvider := givenAnEmailProvider(t)
+	expectedEmailProvider := givenAnEmail(t)
 
 	actualEmailProvider, err := m.Email.Read()
 
@@ -59,7 +59,7 @@ func TestEmailManager_Read(t *testing.T) {
 func TestEmailManager_Update(t *testing.T) {
 	setupHTTPRecordings(t)
 
-	emailProvider := givenAnEmailProvider(t)
+	emailProvider := givenAnEmail(t)
 
 	emailProvider.Enabled = auth0.Bool(false)
 	emailProvider.DefaultFromAddress = auth0.String("info@example.com")
@@ -77,7 +77,7 @@ func TestEmailManager_Update(t *testing.T) {
 func TestEmailManager_Delete(t *testing.T) {
 	setupHTTPRecordings(t)
 
-	givenAnEmailProvider(t)
+	givenAnEmail(t)
 
 	err := m.Email.Delete()
 	assert.NoError(t, err)
@@ -88,7 +88,7 @@ func TestEmailManager_Delete(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, err.(Error).Status())
 }
 
-func givenAnEmailProvider(t *testing.T) *Email {
+func givenAnEmail(t *testing.T) *Email {
 	t.Helper()
 
 	emailProvider := &Email{
@@ -111,13 +111,13 @@ func givenAnEmailProvider(t *testing.T) *Email {
 	}
 
 	t.Cleanup(func() {
-		cleanupEmailProvider(t)
+		cleanupEmail(t)
 	})
 
 	return emailProvider
 }
 
-func cleanupEmailProvider(t *testing.T) {
+func cleanupEmail(t *testing.T) {
 	t.Helper()
 
 	err := m.Email.Delete()

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -4345,7 +4345,7 @@ func (e *EmailProviderCredentialsSES) String() string {
 }
 
 // GetSMTPHost returns the SMTPHost field if it's non-nil, zero value otherwise.
-func (e *EmailProviderCredentialsSmtp) GetSMTPHost() string {
+func (e *EmailProviderCredentialsSMTP) GetSMTPHost() string {
 	if e == nil || e.SMTPHost == nil {
 		return ""
 	}
@@ -4353,7 +4353,7 @@ func (e *EmailProviderCredentialsSmtp) GetSMTPHost() string {
 }
 
 // GetSMTPPass returns the SMTPPass field if it's non-nil, zero value otherwise.
-func (e *EmailProviderCredentialsSmtp) GetSMTPPass() string {
+func (e *EmailProviderCredentialsSMTP) GetSMTPPass() string {
 	if e == nil || e.SMTPPass == nil {
 		return ""
 	}
@@ -4361,7 +4361,7 @@ func (e *EmailProviderCredentialsSmtp) GetSMTPPass() string {
 }
 
 // GetSMTPPort returns the SMTPPort field if it's non-nil, zero value otherwise.
-func (e *EmailProviderCredentialsSmtp) GetSMTPPort() int {
+func (e *EmailProviderCredentialsSMTP) GetSMTPPort() int {
 	if e == nil || e.SMTPPort == nil {
 		return 0
 	}
@@ -4369,15 +4369,15 @@ func (e *EmailProviderCredentialsSmtp) GetSMTPPort() int {
 }
 
 // GetSMTPUser returns the SMTPUser field if it's non-nil, zero value otherwise.
-func (e *EmailProviderCredentialsSmtp) GetSMTPUser() string {
+func (e *EmailProviderCredentialsSMTP) GetSMTPUser() string {
 	if e == nil || e.SMTPUser == nil {
 		return ""
 	}
 	return *e.SMTPUser
 }
 
-// String returns a string representation of EmailProviderCredentialsSmtp.
-func (e *EmailProviderCredentialsSmtp) String() string {
+// String returns a string representation of EmailProviderCredentialsSMTP.
+func (e *EmailProviderCredentialsSMTP) String() string {
 	return Stringify(e)
 }
 
@@ -4455,20 +4455,20 @@ func (e *EmailProviderSettingsSESMessage) String() string {
 }
 
 // GetHeaders returns the Headers field.
-func (e *EmailProviderSettingsSmtp) GetHeaders() *EmailProviderSettingsSmtpHeaders {
+func (e *EmailProviderSettingsSMTP) GetHeaders() *EmailProviderSettingsSMTPHeaders {
 	if e == nil {
 		return nil
 	}
 	return e.Headers
 }
 
-// String returns a string representation of EmailProviderSettingsSmtp.
-func (e *EmailProviderSettingsSmtp) String() string {
+// String returns a string representation of EmailProviderSettingsSMTP.
+func (e *EmailProviderSettingsSMTP) String() string {
 	return Stringify(e)
 }
 
 // GetXMCViewContentLink returns the XMCViewContentLink field if it's non-nil, zero value otherwise.
-func (e *EmailProviderSettingsSmtpHeaders) GetXMCViewContentLink() string {
+func (e *EmailProviderSettingsSMTPHeaders) GetXMCViewContentLink() string {
 	if e == nil || e.XMCViewContentLink == nil {
 		return ""
 	}
@@ -4476,15 +4476,15 @@ func (e *EmailProviderSettingsSmtpHeaders) GetXMCViewContentLink() string {
 }
 
 // GetXSESConfigurationSet returns the XSESConfigurationSet field if it's non-nil, zero value otherwise.
-func (e *EmailProviderSettingsSmtpHeaders) GetXSESConfigurationSet() string {
+func (e *EmailProviderSettingsSMTPHeaders) GetXSESConfigurationSet() string {
 	if e == nil || e.XSESConfigurationSet == nil {
 		return ""
 	}
 	return *e.XSESConfigurationSet
 }
 
-// String returns a string representation of EmailProviderSettingsSmtpHeaders.
-func (e *EmailProviderSettingsSmtpHeaders) String() string {
+// String returns a string representation of EmailProviderSettingsSMTPHeaders.
+func (e *EmailProviderSettingsSMTPHeaders) String() string {
 	return Stringify(e)
 }
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -4231,6 +4231,263 @@ func (e *EmailCredentials) String() string {
 	return Stringify(e)
 }
 
+// GetDefaultFromAddress returns the DefaultFromAddress field if it's non-nil, zero value otherwise.
+func (e *EmailProvider) GetDefaultFromAddress() string {
+	if e == nil || e.DefaultFromAddress == nil {
+		return ""
+	}
+	return *e.DefaultFromAddress
+}
+
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (e *EmailProvider) GetEnabled() bool {
+	if e == nil || e.Enabled == nil {
+		return false
+	}
+	return *e.Enabled
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (e *EmailProvider) GetName() string {
+	if e == nil || e.Name == nil {
+		return ""
+	}
+	return *e.Name
+}
+
+// String returns a string representation of EmailProvider.
+func (e *EmailProvider) String() string {
+	return Stringify(e)
+}
+
+// GetAPIKey returns the APIKey field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsMailgun) GetAPIKey() string {
+	if e == nil || e.APIKey == nil {
+		return ""
+	}
+	return *e.APIKey
+}
+
+// GetDomain returns the Domain field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsMailgun) GetDomain() string {
+	if e == nil || e.Domain == nil {
+		return ""
+	}
+	return *e.Domain
+}
+
+// GetRegion returns the Region field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsMailgun) GetRegion() string {
+	if e == nil || e.Region == nil {
+		return ""
+	}
+	return *e.Region
+}
+
+// String returns a string representation of EmailProviderCredentialsMailgun.
+func (e *EmailProviderCredentialsMailgun) String() string {
+	return Stringify(e)
+}
+
+// GetAPIKey returns the APIKey field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsMandrill) GetAPIKey() string {
+	if e == nil || e.APIKey == nil {
+		return ""
+	}
+	return *e.APIKey
+}
+
+// String returns a string representation of EmailProviderCredentialsMandrill.
+func (e *EmailProviderCredentialsMandrill) String() string {
+	return Stringify(e)
+}
+
+// GetAPIKey returns the APIKey field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsSendGrid) GetAPIKey() string {
+	if e == nil || e.APIKey == nil {
+		return ""
+	}
+	return *e.APIKey
+}
+
+// String returns a string representation of EmailProviderCredentialsSendGrid.
+func (e *EmailProviderCredentialsSendGrid) String() string {
+	return Stringify(e)
+}
+
+// GetAccessKeyID returns the AccessKeyID field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsSES) GetAccessKeyID() string {
+	if e == nil || e.AccessKeyID == nil {
+		return ""
+	}
+	return *e.AccessKeyID
+}
+
+// GetRegion returns the Region field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsSES) GetRegion() string {
+	if e == nil || e.Region == nil {
+		return ""
+	}
+	return *e.Region
+}
+
+// GetSecretAccessKey returns the SecretAccessKey field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsSES) GetSecretAccessKey() string {
+	if e == nil || e.SecretAccessKey == nil {
+		return ""
+	}
+	return *e.SecretAccessKey
+}
+
+// String returns a string representation of EmailProviderCredentialsSES.
+func (e *EmailProviderCredentialsSES) String() string {
+	return Stringify(e)
+}
+
+// GetSMTPHost returns the SMTPHost field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsSmtp) GetSMTPHost() string {
+	if e == nil || e.SMTPHost == nil {
+		return ""
+	}
+	return *e.SMTPHost
+}
+
+// GetSMTPPass returns the SMTPPass field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsSmtp) GetSMTPPass() string {
+	if e == nil || e.SMTPPass == nil {
+		return ""
+	}
+	return *e.SMTPPass
+}
+
+// GetSMTPPort returns the SMTPPort field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsSmtp) GetSMTPPort() int {
+	if e == nil || e.SMTPPort == nil {
+		return 0
+	}
+	return *e.SMTPPort
+}
+
+// GetSMTPUser returns the SMTPUser field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsSmtp) GetSMTPUser() string {
+	if e == nil || e.SMTPUser == nil {
+		return ""
+	}
+	return *e.SMTPUser
+}
+
+// String returns a string representation of EmailProviderCredentialsSmtp.
+func (e *EmailProviderCredentialsSmtp) String() string {
+	return Stringify(e)
+}
+
+// GetAPIKey returns the APIKey field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsSparkPost) GetAPIKey() string {
+	if e == nil || e.APIKey == nil {
+		return ""
+	}
+	return *e.APIKey
+}
+
+// GetRegion returns the Region field if it's non-nil, zero value otherwise.
+func (e *EmailProviderCredentialsSparkPost) GetRegion() string {
+	if e == nil || e.Region == nil {
+		return ""
+	}
+	return *e.Region
+}
+
+// String returns a string representation of EmailProviderCredentialsSparkPost.
+func (e *EmailProviderCredentialsSparkPost) String() string {
+	return Stringify(e)
+}
+
+// GetMessage returns the Message field.
+func (e *EmailProviderSettingsMandrill) GetMessage() *EmailProviderSettingsMandrillMessage {
+	if e == nil {
+		return nil
+	}
+	return e.Message
+}
+
+// String returns a string representation of EmailProviderSettingsMandrill.
+func (e *EmailProviderSettingsMandrill) String() string {
+	return Stringify(e)
+}
+
+// GetViewContentLink returns the ViewContentLink field if it's non-nil, zero value otherwise.
+func (e *EmailProviderSettingsMandrillMessage) GetViewContentLink() bool {
+	if e == nil || e.ViewContentLink == nil {
+		return false
+	}
+	return *e.ViewContentLink
+}
+
+// String returns a string representation of EmailProviderSettingsMandrillMessage.
+func (e *EmailProviderSettingsMandrillMessage) String() string {
+	return Stringify(e)
+}
+
+// GetMessage returns the Message field.
+func (e *EmailProviderSettingsSES) GetMessage() *EmailProviderSettingsSESMessage {
+	if e == nil {
+		return nil
+	}
+	return e.Message
+}
+
+// String returns a string representation of EmailProviderSettingsSES.
+func (e *EmailProviderSettingsSES) String() string {
+	return Stringify(e)
+}
+
+// GetConfigurationSetName returns the ConfigurationSetName field if it's non-nil, zero value otherwise.
+func (e *EmailProviderSettingsSESMessage) GetConfigurationSetName() string {
+	if e == nil || e.ConfigurationSetName == nil {
+		return ""
+	}
+	return *e.ConfigurationSetName
+}
+
+// String returns a string representation of EmailProviderSettingsSESMessage.
+func (e *EmailProviderSettingsSESMessage) String() string {
+	return Stringify(e)
+}
+
+// GetHeaders returns the Headers field.
+func (e *EmailProviderSettingsSmtp) GetHeaders() *EmailProviderSettingsSmtpHeaders {
+	if e == nil {
+		return nil
+	}
+	return e.Headers
+}
+
+// String returns a string representation of EmailProviderSettingsSmtp.
+func (e *EmailProviderSettingsSmtp) String() string {
+	return Stringify(e)
+}
+
+// GetXMCViewContentLink returns the XMCViewContentLink field if it's non-nil, zero value otherwise.
+func (e *EmailProviderSettingsSmtpHeaders) GetXMCViewContentLink() string {
+	if e == nil || e.XMCViewContentLink == nil {
+		return ""
+	}
+	return *e.XMCViewContentLink
+}
+
+// GetXSESConfigurationSet returns the XSESConfigurationSet field if it's non-nil, zero value otherwise.
+func (e *EmailProviderSettingsSmtpHeaders) GetXSESConfigurationSet() string {
+	if e == nil || e.XSESConfigurationSet == nil {
+		return ""
+	}
+	return *e.XSESConfigurationSet
+}
+
+// String returns a string representation of EmailProviderSettingsSmtpHeaders.
+func (e *EmailProviderSettingsSmtpHeaders) String() string {
+	return Stringify(e)
+}
+
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
 func (e *EmailTemplate) GetBody() string {
 	if e == nil || e.Body == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -5496,49 +5496,49 @@ func TestEmailProviderCredentialsSES_String(t *testing.T) {
 	}
 }
 
-func TestEmailProviderCredentialsSmtp_GetSMTPHost(tt *testing.T) {
+func TestEmailProviderCredentialsSMTP_GetSMTPHost(tt *testing.T) {
 	var zeroValue string
-	e := &EmailProviderCredentialsSmtp{SMTPHost: &zeroValue}
+	e := &EmailProviderCredentialsSMTP{SMTPHost: &zeroValue}
 	e.GetSMTPHost()
-	e = &EmailProviderCredentialsSmtp{}
+	e = &EmailProviderCredentialsSMTP{}
 	e.GetSMTPHost()
 	e = nil
 	e.GetSMTPHost()
 }
 
-func TestEmailProviderCredentialsSmtp_GetSMTPPass(tt *testing.T) {
+func TestEmailProviderCredentialsSMTP_GetSMTPPass(tt *testing.T) {
 	var zeroValue string
-	e := &EmailProviderCredentialsSmtp{SMTPPass: &zeroValue}
+	e := &EmailProviderCredentialsSMTP{SMTPPass: &zeroValue}
 	e.GetSMTPPass()
-	e = &EmailProviderCredentialsSmtp{}
+	e = &EmailProviderCredentialsSMTP{}
 	e.GetSMTPPass()
 	e = nil
 	e.GetSMTPPass()
 }
 
-func TestEmailProviderCredentialsSmtp_GetSMTPPort(tt *testing.T) {
+func TestEmailProviderCredentialsSMTP_GetSMTPPort(tt *testing.T) {
 	var zeroValue int
-	e := &EmailProviderCredentialsSmtp{SMTPPort: &zeroValue}
+	e := &EmailProviderCredentialsSMTP{SMTPPort: &zeroValue}
 	e.GetSMTPPort()
-	e = &EmailProviderCredentialsSmtp{}
+	e = &EmailProviderCredentialsSMTP{}
 	e.GetSMTPPort()
 	e = nil
 	e.GetSMTPPort()
 }
 
-func TestEmailProviderCredentialsSmtp_GetSMTPUser(tt *testing.T) {
+func TestEmailProviderCredentialsSMTP_GetSMTPUser(tt *testing.T) {
 	var zeroValue string
-	e := &EmailProviderCredentialsSmtp{SMTPUser: &zeroValue}
+	e := &EmailProviderCredentialsSMTP{SMTPUser: &zeroValue}
 	e.GetSMTPUser()
-	e = &EmailProviderCredentialsSmtp{}
+	e = &EmailProviderCredentialsSMTP{}
 	e.GetSMTPUser()
 	e = nil
 	e.GetSMTPUser()
 }
 
-func TestEmailProviderCredentialsSmtp_String(t *testing.T) {
+func TestEmailProviderCredentialsSMTP_String(t *testing.T) {
 	var rawJSON json.RawMessage
-	v := &EmailProviderCredentialsSmtp{}
+	v := &EmailProviderCredentialsSMTP{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
@@ -5638,44 +5638,44 @@ func TestEmailProviderSettingsSESMessage_String(t *testing.T) {
 	}
 }
 
-func TestEmailProviderSettingsSmtp_GetHeaders(tt *testing.T) {
-	e := &EmailProviderSettingsSmtp{}
+func TestEmailProviderSettingsSMTP_GetHeaders(tt *testing.T) {
+	e := &EmailProviderSettingsSMTP{}
 	e.GetHeaders()
 	e = nil
 	e.GetHeaders()
 }
 
-func TestEmailProviderSettingsSmtp_String(t *testing.T) {
+func TestEmailProviderSettingsSMTP_String(t *testing.T) {
 	var rawJSON json.RawMessage
-	v := &EmailProviderSettingsSmtp{}
+	v := &EmailProviderSettingsSMTP{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
 }
 
-func TestEmailProviderSettingsSmtpHeaders_GetXMCViewContentLink(tt *testing.T) {
+func TestEmailProviderSettingsSMTPHeaders_GetXMCViewContentLink(tt *testing.T) {
 	var zeroValue string
-	e := &EmailProviderSettingsSmtpHeaders{XMCViewContentLink: &zeroValue}
+	e := &EmailProviderSettingsSMTPHeaders{XMCViewContentLink: &zeroValue}
 	e.GetXMCViewContentLink()
-	e = &EmailProviderSettingsSmtpHeaders{}
+	e = &EmailProviderSettingsSMTPHeaders{}
 	e.GetXMCViewContentLink()
 	e = nil
 	e.GetXMCViewContentLink()
 }
 
-func TestEmailProviderSettingsSmtpHeaders_GetXSESConfigurationSet(tt *testing.T) {
+func TestEmailProviderSettingsSMTPHeaders_GetXSESConfigurationSet(tt *testing.T) {
 	var zeroValue string
-	e := &EmailProviderSettingsSmtpHeaders{XSESConfigurationSet: &zeroValue}
+	e := &EmailProviderSettingsSMTPHeaders{XSESConfigurationSet: &zeroValue}
 	e.GetXSESConfigurationSet()
-	e = &EmailProviderSettingsSmtpHeaders{}
+	e = &EmailProviderSettingsSMTPHeaders{}
 	e.GetXSESConfigurationSet()
 	e = nil
 	e.GetXSESConfigurationSet()
 }
 
-func TestEmailProviderSettingsSmtpHeaders_String(t *testing.T) {
+func TestEmailProviderSettingsSMTPHeaders_String(t *testing.T) {
 	var rawJSON json.RawMessage
-	v := &EmailProviderSettingsSmtpHeaders{}
+	v := &EmailProviderSettingsSMTPHeaders{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -5346,6 +5346,341 @@ func TestEmailCredentials_String(t *testing.T) {
 	}
 }
 
+func TestEmailProvider_GetDefaultFromAddress(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProvider{DefaultFromAddress: &zeroValue}
+	e.GetDefaultFromAddress()
+	e = &EmailProvider{}
+	e.GetDefaultFromAddress()
+	e = nil
+	e.GetDefaultFromAddress()
+}
+
+func TestEmailProvider_GetEnabled(tt *testing.T) {
+	var zeroValue bool
+	e := &EmailProvider{Enabled: &zeroValue}
+	e.GetEnabled()
+	e = &EmailProvider{}
+	e.GetEnabled()
+	e = nil
+	e.GetEnabled()
+}
+
+func TestEmailProvider_GetName(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProvider{Name: &zeroValue}
+	e.GetName()
+	e = &EmailProvider{}
+	e.GetName()
+	e = nil
+	e.GetName()
+}
+
+func TestEmailProvider_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProvider{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderCredentialsMailgun_GetAPIKey(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsMailgun{APIKey: &zeroValue}
+	e.GetAPIKey()
+	e = &EmailProviderCredentialsMailgun{}
+	e.GetAPIKey()
+	e = nil
+	e.GetAPIKey()
+}
+
+func TestEmailProviderCredentialsMailgun_GetDomain(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsMailgun{Domain: &zeroValue}
+	e.GetDomain()
+	e = &EmailProviderCredentialsMailgun{}
+	e.GetDomain()
+	e = nil
+	e.GetDomain()
+}
+
+func TestEmailProviderCredentialsMailgun_GetRegion(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsMailgun{Region: &zeroValue}
+	e.GetRegion()
+	e = &EmailProviderCredentialsMailgun{}
+	e.GetRegion()
+	e = nil
+	e.GetRegion()
+}
+
+func TestEmailProviderCredentialsMailgun_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderCredentialsMailgun{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderCredentialsMandrill_GetAPIKey(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsMandrill{APIKey: &zeroValue}
+	e.GetAPIKey()
+	e = &EmailProviderCredentialsMandrill{}
+	e.GetAPIKey()
+	e = nil
+	e.GetAPIKey()
+}
+
+func TestEmailProviderCredentialsMandrill_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderCredentialsMandrill{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderCredentialsSendGrid_GetAPIKey(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsSendGrid{APIKey: &zeroValue}
+	e.GetAPIKey()
+	e = &EmailProviderCredentialsSendGrid{}
+	e.GetAPIKey()
+	e = nil
+	e.GetAPIKey()
+}
+
+func TestEmailProviderCredentialsSendGrid_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderCredentialsSendGrid{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderCredentialsSES_GetAccessKeyID(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsSES{AccessKeyID: &zeroValue}
+	e.GetAccessKeyID()
+	e = &EmailProviderCredentialsSES{}
+	e.GetAccessKeyID()
+	e = nil
+	e.GetAccessKeyID()
+}
+
+func TestEmailProviderCredentialsSES_GetRegion(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsSES{Region: &zeroValue}
+	e.GetRegion()
+	e = &EmailProviderCredentialsSES{}
+	e.GetRegion()
+	e = nil
+	e.GetRegion()
+}
+
+func TestEmailProviderCredentialsSES_GetSecretAccessKey(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsSES{SecretAccessKey: &zeroValue}
+	e.GetSecretAccessKey()
+	e = &EmailProviderCredentialsSES{}
+	e.GetSecretAccessKey()
+	e = nil
+	e.GetSecretAccessKey()
+}
+
+func TestEmailProviderCredentialsSES_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderCredentialsSES{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderCredentialsSmtp_GetSMTPHost(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsSmtp{SMTPHost: &zeroValue}
+	e.GetSMTPHost()
+	e = &EmailProviderCredentialsSmtp{}
+	e.GetSMTPHost()
+	e = nil
+	e.GetSMTPHost()
+}
+
+func TestEmailProviderCredentialsSmtp_GetSMTPPass(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsSmtp{SMTPPass: &zeroValue}
+	e.GetSMTPPass()
+	e = &EmailProviderCredentialsSmtp{}
+	e.GetSMTPPass()
+	e = nil
+	e.GetSMTPPass()
+}
+
+func TestEmailProviderCredentialsSmtp_GetSMTPPort(tt *testing.T) {
+	var zeroValue int
+	e := &EmailProviderCredentialsSmtp{SMTPPort: &zeroValue}
+	e.GetSMTPPort()
+	e = &EmailProviderCredentialsSmtp{}
+	e.GetSMTPPort()
+	e = nil
+	e.GetSMTPPort()
+}
+
+func TestEmailProviderCredentialsSmtp_GetSMTPUser(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsSmtp{SMTPUser: &zeroValue}
+	e.GetSMTPUser()
+	e = &EmailProviderCredentialsSmtp{}
+	e.GetSMTPUser()
+	e = nil
+	e.GetSMTPUser()
+}
+
+func TestEmailProviderCredentialsSmtp_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderCredentialsSmtp{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderCredentialsSparkPost_GetAPIKey(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsSparkPost{APIKey: &zeroValue}
+	e.GetAPIKey()
+	e = &EmailProviderCredentialsSparkPost{}
+	e.GetAPIKey()
+	e = nil
+	e.GetAPIKey()
+}
+
+func TestEmailProviderCredentialsSparkPost_GetRegion(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderCredentialsSparkPost{Region: &zeroValue}
+	e.GetRegion()
+	e = &EmailProviderCredentialsSparkPost{}
+	e.GetRegion()
+	e = nil
+	e.GetRegion()
+}
+
+func TestEmailProviderCredentialsSparkPost_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderCredentialsSparkPost{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderSettingsMandrill_GetMessage(tt *testing.T) {
+	e := &EmailProviderSettingsMandrill{}
+	e.GetMessage()
+	e = nil
+	e.GetMessage()
+}
+
+func TestEmailProviderSettingsMandrill_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderSettingsMandrill{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderSettingsMandrillMessage_GetViewContentLink(tt *testing.T) {
+	var zeroValue bool
+	e := &EmailProviderSettingsMandrillMessage{ViewContentLink: &zeroValue}
+	e.GetViewContentLink()
+	e = &EmailProviderSettingsMandrillMessage{}
+	e.GetViewContentLink()
+	e = nil
+	e.GetViewContentLink()
+}
+
+func TestEmailProviderSettingsMandrillMessage_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderSettingsMandrillMessage{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderSettingsSES_GetMessage(tt *testing.T) {
+	e := &EmailProviderSettingsSES{}
+	e.GetMessage()
+	e = nil
+	e.GetMessage()
+}
+
+func TestEmailProviderSettingsSES_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderSettingsSES{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderSettingsSESMessage_GetConfigurationSetName(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderSettingsSESMessage{ConfigurationSetName: &zeroValue}
+	e.GetConfigurationSetName()
+	e = &EmailProviderSettingsSESMessage{}
+	e.GetConfigurationSetName()
+	e = nil
+	e.GetConfigurationSetName()
+}
+
+func TestEmailProviderSettingsSESMessage_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderSettingsSESMessage{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderSettingsSmtp_GetHeaders(tt *testing.T) {
+	e := &EmailProviderSettingsSmtp{}
+	e.GetHeaders()
+	e = nil
+	e.GetHeaders()
+}
+
+func TestEmailProviderSettingsSmtp_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderSettingsSmtp{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestEmailProviderSettingsSmtpHeaders_GetXMCViewContentLink(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderSettingsSmtpHeaders{XMCViewContentLink: &zeroValue}
+	e.GetXMCViewContentLink()
+	e = &EmailProviderSettingsSmtpHeaders{}
+	e.GetXMCViewContentLink()
+	e = nil
+	e.GetXMCViewContentLink()
+}
+
+func TestEmailProviderSettingsSmtpHeaders_GetXSESConfigurationSet(tt *testing.T) {
+	var zeroValue string
+	e := &EmailProviderSettingsSmtpHeaders{XSESConfigurationSet: &zeroValue}
+	e.GetXSESConfigurationSet()
+	e = &EmailProviderSettingsSmtpHeaders{}
+	e.GetXSESConfigurationSet()
+	e = nil
+	e.GetXSESConfigurationSet()
+}
+
+func TestEmailProviderSettingsSmtpHeaders_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &EmailProviderSettingsSmtpHeaders{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestEmailTemplate_GetBody(tt *testing.T) {
 	var zeroValue string
 	e := &EmailTemplate{Body: &zeroValue}

--- a/management/management.go
+++ b/management/management.go
@@ -105,6 +105,9 @@ type Management struct {
 	// BrandingTheme manages Auth0 Branding Themes.
 	BrandingTheme *BrandingThemeManager
 
+	// EmailProvider manages Auth0 Email Providers.
+	EmailProvider *EmailProviderManager
+
 	url         *url.URL
 	basePath    string
 	userAgent   string
@@ -179,6 +182,7 @@ func New(domain string, options ...Option) (*Management, error) {
 	m.Organization = newOrganizationManager(m)
 	m.AttackProtection = newAttackProtectionManager(m)
 	m.BrandingTheme = newBrandingThemeManager(m)
+	m.EmailProvider = newEmailProviderManager(m)
 
 	return m, nil
 }

--- a/management/management.go
+++ b/management/management.go
@@ -54,6 +54,7 @@ type Management struct {
 	RuleConfig *RuleConfigManager
 
 	// Email manages Auth0 Email Providers.
+	// Deprecated: Use EmailProvider instead.
 	Email *EmailManager
 
 	// EmailTemplate manages Auth0 Email Templates.

--- a/management/testdata/recordings/TestEmailProviderManager_Create.yaml
+++ b/management/testdata/recordings/TestEmailProviderManager_Create.yaml
@@ -1,0 +1,46 @@
+---
+version: 1
+interactions:
+    - request:
+        body: |
+            {"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user","smtp_pass":"pass"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+        method: POST
+      response:
+        body: '{"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user"}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Length:
+                - "158"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1ms
+    - request:
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+        method: DELETE
+      response:
+        body: ""
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms

--- a/management/testdata/recordings/TestEmailProviderManager_Delete.yaml
+++ b/management/testdata/recordings/TestEmailProviderManager_Delete.yaml
@@ -1,0 +1,87 @@
+---
+version: 1
+interactions:
+    - request:
+        body: |
+            {"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user","smtp_pass":"pass"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+        method: POST
+      response:
+        body: '{"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user"}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Length:
+                - "158"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1ms
+    - request:
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+        method: DELETE
+      response:
+        body: ""
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms
+    - request:
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+        method: GET
+      response:
+        body: '{"statusCode":404,"error":"Not Found","message":"There is not a configured email provider","errorCode":"inexistent_email_provider"}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 404 Not Found
+        code: 404
+        duration: 1ms
+    - request:
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+        method: DELETE
+      response:
+        body: ""
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms

--- a/management/testdata/recordings/TestEmailProviderManager_Read.yaml
+++ b/management/testdata/recordings/TestEmailProviderManager_Read.yaml
@@ -1,0 +1,67 @@
+---
+version: 1
+interactions:
+    - request:
+        body: |
+            {"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user","smtp_pass":"pass"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+        method: POST
+      response:
+        body: '{"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user"}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Length:
+                - "158"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1ms
+    - request:
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+        method: GET
+      response:
+        body: '{"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user"}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+        method: DELETE
+      response:
+        body: ""
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms

--- a/management/testdata/recordings/TestEmailProviderManager_Update.yaml
+++ b/management/testdata/recordings/TestEmailProviderManager_Update.yaml
@@ -1,0 +1,88 @@
+---
+version: 1
+interactions:
+    - request:
+        body: |
+            {"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user","smtp_pass":"pass"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+        method: POST
+      response:
+        body: '{"name":"smtp","enabled":true,"default_from_address":"no-reply@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user"}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Length:
+                - "158"
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1ms
+    - request:
+        body: |
+            {"name":"smtp","enabled":false,"default_from_address":"info@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user"},"settings":{}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+        method: PATCH
+      response:
+        body: '{"name":"smtp","enabled":false,"default_from_address":"info@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user"},"settings":{}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+        method: GET
+      response:
+        body: '{"name":"smtp","enabled":false,"default_from_address":"info@example.com","credentials":{"smtp_host":"smtp.example.com","smtp_port":587,"smtp_user":"user"},"settings":{}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/emails/provider
+        method: DELETE
+      response:
+        body: ""
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Support for email provider settings has been requested through https://github.com/auth0/terraform-provider-auth0/issues/384.

As we started adding this setting to the old `Email` struct, it was noted that the DX wasn't good enough to be able to distinguish between what settings and even what credentials are specific to each email provider.

To solve that we're introducing a brand new `EmailProvider` struct with specific credentials and settings for each email provider type. 

Also to avoid doing breaking changes we're just marking the old `Email` as deprecated and it will be removed in a future version.

### 📚 References

- https://github.com/auth0/terraform-provider-auth0/issues/384
- https://github.com/auth0/terraform-provider-auth0/pull/393
- https://github.com/auth0/terraform-provider-auth0/pull/394

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
