### PR TITLE
DXCDT-337: Add support for segment log stream

### DIFF
--- a/management/log_stream.go
+++ b/management/log_stream.go
@@ -19,6 +19,8 @@ const (
 	LogStreamTypeSumo = "sumo"
 	// LogStreamTypeMixpanel constant.
 	LogStreamTypeMixpanel = "mixpanel"
+	// LogStreamTypeSegment constant.
+	LogStreamTypeSegment = "segment"
 )
 
 // LogStream is used to export tenant log
@@ -102,6 +104,8 @@ func (ls *LogStream) UnmarshalJSON(b []byte) error {
 			v = &LogStreamSinkSumo{}
 		case LogStreamTypeMixpanel:
 			v = &LogStreamSinkMixpanel{}
+		case LogStreamTypeSegment:
+			v = &LogStreamSinkSegment{}
 		default:
 			v = make(map[string]interface{})
 		}
@@ -159,6 +163,12 @@ type LogStreamSinkDatadog struct {
 	Region *string `json:"datadogRegion,omitempty"`
 	// Datadog Api Key
 	APIKey *string `json:"datadogApiKey,omitempty"`
+}
+
+// LogStreamSinkSegment is used to export logs to Segment.
+type LogStreamSinkSegment struct {
+	// Segment Api Key
+	APIKey *string `json:"segmentApiKey,omitempty"`
 }
 
 // LogStreamSinkSplunk is used to export logs to Splunk.

--- a/management/log_stream.go
+++ b/management/log_stream.go
@@ -36,7 +36,7 @@ type LogStream struct {
 	Name *string `json:"name,omitempty"`
 
 	// The type of the log-stream. Can be one of "http", "eventbridge",
-	// "eventgrid", "datadog" or "splunk".
+	// "eventgrid", "datadog", "splunk", "sumo", "mixpanel", "segment.
 	Type *string `json:"type,omitempty"`
 
 	// The status of the log-stream. Can be one of "active", "paused", or "suspended".
@@ -167,8 +167,8 @@ type LogStreamSinkDatadog struct {
 
 // LogStreamSinkSegment is used to export logs to Segment.
 type LogStreamSinkSegment struct {
-	// Segment Api Key
-	APIKey *string `json:"segmentApiKey,omitempty"`
+	// Segment Write Key
+	WriteKey *string `json:"segmentWriteKey,omitempty"`
 }
 
 // LogStreamSinkSplunk is used to export logs to Splunk.

--- a/management/log_stream_test.go
+++ b/management/log_stream_test.go
@@ -65,7 +65,7 @@ var logStreamTestCases = []logStreamTestCase{
 			Name: auth0.Stringf("Test-LogStream-%d", time.Now().Unix()),
 			Type: auth0.String(LogStreamTypeSegment),
 			Sink: &LogStreamSinkSegment{
-				APIKey: auth0.String("121233123455"),
+				WriteKey: auth0.String("121233123455"),
 			},
 		},
 	},

--- a/management/log_stream_test.go
+++ b/management/log_stream_test.go
@@ -60,6 +60,16 @@ var logStreamTestCases = []logStreamTestCase{
 		},
 	},
 	{
+		name: "Segment LogStream",
+		logStream: LogStream{
+			Name: auth0.Stringf("Test-LogStream-%d", time.Now().Unix()),
+			Type: auth0.String(LogStreamTypeSegment),
+			Sink: &LogStreamSinkSegment{
+				APIKey: auth0.String("121233123455"),
+			},
+		},
+	},
+	{
 		name: "Splunk LogStream",
 		logStream: LogStream{
 			Name: auth0.Stringf("Test-LogStream-%d", time.Now().Unix()),

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5388,6 +5388,19 @@ func (l *LogStreamSinkMixpanel) String() string {
 	return Stringify(l)
 }
 
+// GetWriteKey returns the WriteKey field if it's non-nil, zero value otherwise.
+func (l *LogStreamSinkSegment) GetWriteKey() string {
+	if l == nil || l.WriteKey == nil {
+		return ""
+	}
+	return *l.WriteKey
+}
+
+// String returns a string representation of LogStreamSinkSegment.
+func (l *LogStreamSinkSegment) String() string {
+	return Stringify(l)
+}
+
 // GetDomain returns the Domain field if it's non-nil, zero value otherwise.
 func (l *LogStreamSinkSplunk) GetDomain() string {
 	if l == nil || l.Domain == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -6838,6 +6838,24 @@ func TestLogStreamSinkMixpanel_String(t *testing.T) {
 	}
 }
 
+func TestLogStreamSinkSegment_GetWriteKey(tt *testing.T) {
+	var zeroValue string
+	l := &LogStreamSinkSegment{WriteKey: &zeroValue}
+	l.GetWriteKey()
+	l = &LogStreamSinkSegment{}
+	l.GetWriteKey()
+	l = nil
+	l.GetWriteKey()
+}
+
+func TestLogStreamSinkSegment_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &LogStreamSinkSegment{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestLogStreamSinkSplunk_GetDomain(tt *testing.T) {
 	var zeroValue string
 	l := &LogStreamSinkSplunk{Domain: &zeroValue}

--- a/management/testdata/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_Segment_LogStream.yaml
+++ b/management/testdata/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_Segment_LogStream.yaml
@@ -1,0 +1,44 @@
+---
+version: 1
+interactions:
+    - request:
+        body: |
+            {"name":"Test-LogStream-1674586425","type":"segment","sink":{"segmentWriteKey":"121233123455"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
+        method: POST
+      response:
+        body: '{"id":"lst_0000000000011465","name":"Test-LogStream-1674586425","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000011465
+        method: DELETE
+      response:
+        body: ""
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms

--- a/management/testdata/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_Segment_LogStream.yaml
+++ b/management/testdata/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_Segment_LogStream.yaml
@@ -1,0 +1,85 @@
+---
+version: 1
+interactions:
+    - request:
+        body: |
+            {"name":"Test-LogStream-1674586425","type":"segment","sink":{"segmentWriteKey":"121233123455"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
+        method: POST
+      response:
+        body: '{"id":"lst_0000000000011468","name":"Test-LogStream-1674586425","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000011468
+        method: DELETE
+      response:
+        body: ""
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms
+    - request:
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000011468
+        method: GET
+      response:
+        body: '{"statusCode":404,"error":"Not Found","message":"The log stream does not exist."}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 404 Not Found
+        code: 404
+        duration: 1ms
+    - request:
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000011468
+        method: DELETE
+      response:
+        body: ""
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms

--- a/management/testdata/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_Segment_LogStream.yaml
+++ b/management/testdata/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_Segment_LogStream.yaml
@@ -1,0 +1,65 @@
+---
+version: 1
+interactions:
+    - request:
+        body: |
+            {"name":"Test-LogStream-1674586425","type":"segment","sink":{"segmentWriteKey":"121233123455"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
+        method: POST
+      response:
+        body: '{"id":"lst_0000000000011466","name":"Test-LogStream-1674586425","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000011466
+        method: GET
+      response:
+        body: '{"id":"lst_0000000000011466","name":"Test-LogStream-1674586425","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000011466
+        method: DELETE
+      response:
+        body: ""
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms

--- a/management/testdata/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_Segment_LogStream.yaml
+++ b/management/testdata/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_Segment_LogStream.yaml
@@ -1,0 +1,86 @@
+---
+version: 1
+interactions:
+    - request:
+        body: |
+            {"name":"Test-LogStream-1674586425","type":"segment","sink":{"segmentWriteKey":"121233123455"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
+        method: POST
+      response:
+        body: '{"id":"lst_0000000000011467","name":"Test-LogStream-1674586425","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"}}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: |
+            {"filters":[{"name":"auth.login.fail","type":"category"}]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000011467
+        method: PATCH
+      response:
+        body: '{"id":"lst_0000000000011467","name":"Test-LogStream-1674586425","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"name":"auth.login.fail","type":"category"}]}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000011467
+        method: GET
+      response:
+        body: '{"id":"lst_0000000000011467","name":"Test-LogStream-1674586425","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"name":"auth.login.fail","type":"category"}]}'
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - request:
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000011467
+        method: DELETE
+      response:
+        body: ""
+        headers:
+            Access-Control-Expose-Headers:
+                - WWW-Authenticate,Server-Authorization
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This change adds a log stream type and sink for Segment.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

Required in:

https://github.com/auth0/terraform-provider-auth0/pull/437

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

**NOTE**: I wrote the tests but was unable to run the test locally. Can you please run to make sure it works?

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
