### PR TITLE
DXCDT-350: Add EnableScriptContext to Connection Options

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -277,6 +277,10 @@ type ConnectionOptions struct {
 	// Options for password complexity options.
 	PasswordComplexityOptions map[string]interface{} `json:"password_complexity_options,omitempty"`
 
+	// Set to true to inject context into custom DB scripts (warning: cannot be disabled once enabled).
+	EnableScriptContext *bool `json:"enable_script_context,omitempty"`
+
+	// Set to true to use a legacy user store.
 	EnabledDatabaseCustomization *bool `json:"enabledDatabaseCustomization,omitempty"`
 
 	BruteForceProtection *bool `json:"brute_force_protection,omitempty"`
@@ -288,7 +292,7 @@ type ConnectionOptions struct {
 	RequiresUsername *bool `json:"requires_username,omitempty"`
 
 	// Scripts for the connection.
-	// Allowed keys are: "get_user", "login", "create", "verify", "change_password", "delete" or "change_email".
+	// Allowed keys are: "get_user", "login", "create", "verify", "change_password", "delete"".
 	CustomScripts *map[string]string `json:"customScripts,omitempty"`
 
 	// Configuration variables that can be used in custom scripts.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1474,6 +1474,14 @@ func (c *ConnectionOptions) GetEnabledDatabaseCustomization() bool {
 	return *c.EnabledDatabaseCustomization
 }
 
+// GetEnableScriptContext returns the EnableScriptContext field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptions) GetEnableScriptContext() bool {
+	if c == nil || c.EnableScriptContext == nil {
+		return false
+	}
+	return *c.EnableScriptContext
+}
+
 // GetImportMode returns the ImportMode field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptions) GetImportMode() bool {
 	if c == nil || c.ImportMode == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -1874,6 +1874,16 @@ func TestConnectionOptions_GetEnabledDatabaseCustomization(tt *testing.T) {
 	c.GetEnabledDatabaseCustomization()
 }
 
+func TestConnectionOptions_GetEnableScriptContext(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptions{EnableScriptContext: &zeroValue}
+	c.GetEnableScriptContext()
+	c = &ConnectionOptions{}
+	c.GetEnableScriptContext()
+	c = nil
+	c.GetEnableScriptContext()
+}
+
 func TestConnectionOptions_GetImportMode(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptions{ImportMode: &zeroValue}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adding support for `enable_script_context` boolean parameter on the `options` block of an Auth0 DB Connection. Without it, users that have this enabled for their connection will constantly get `│ Error: 400 Bad Request: once enabled, options.enable_script_context can not be disabled` because the options property needs to be sent with all its values even on `PATCH` requests.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

- https://github.com/auth0/terraform-provider-auth0/issues/410

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
