### PR TITLE
DXCDT-352: Rename json tag cross_origin_auth to cross_origin_authentication

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -62,7 +62,7 @@ type Client struct {
 
 	// True if this client can be used to make cross-origin authentication
 	// requests, false otherwise (default: false).
-	CrossOriginAuth *bool `json:"cross_origin_auth,omitempty"`
+	CrossOriginAuth *bool `json:"cross_origin_authentication,omitempty"`
 
 	// List of acceptable Grant Types for this Client.
 	GrantTypes *[]string `json:"grant_types,omitempty"`

--- a/management/client.go
+++ b/management/client.go
@@ -62,6 +62,8 @@ type Client struct {
 
 	// True if this client can be used to make cross-origin authentication
 	// requests, false otherwise (default: false).
+	// Requires the 'coa_toggle_enabled' feature flag to be enabled
+	// on the tenant by the support team.
 	CrossOriginAuth *bool `json:"cross_origin_authentication,omitempty"`
 
 	// List of acceptable Grant Types for this Client.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes


Initially raised in https://github.com/auth0/terraform-provider-auth0/issues/450, the `cross_origin_auth` json field is no longer in use within the Management API v2 (this can be verified within the api2 repo). It is replaced by `cross_origin_authentication` instead. To not introduce a breaking change for our users we'll keep the struct name as CrossOriginAuth and only focus on renaming the json tag. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
