### PR TITLE
DXCDT-353: Add missing switch case for adfs conn

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -231,6 +231,8 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 			v = &ConnectionOptionsAD{}
 		case ConnectionStrategyAzureAD:
 			v = &ConnectionOptionsAzureAD{}
+		case ConnectionStrategyADFS:
+			v = &ConnectionOptionsADFS{}
 		case ConnectionStrategySAML:
 			v = &ConnectionOptionsSAML{}
 		case ConnectionStrategyGoogleApps:


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

While investigating https://github.com/auth0/terraform-provider-auth0/issues/455 it turns out we never actually correctly unmarshal the option types for ADFS connections, causing the terraform provider to not recognize `*management.ConnectionOptionsADFS`.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

This will get tested through the terraform provider for now. We can follow up with tests on the go-auth0 SDK after we implement passing the metadata_xml through the field instead of getting it from a url. 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
