### PR TITLE
DXCDT-354: Enhance ADFS Connection Options

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -873,18 +873,20 @@ func (c *ConnectionOptionsAzureAD) SetScopes(enable bool, scopes ...string) {
 
 // ConnectionOptionsADFS is used to configure an ADFS Connection.
 type ConnectionOptionsADFS struct {
-	TenantDomain  *string   `json:"tenant_domain,omitempty"`
-	DomainAliases *[]string `json:"domain_aliases,omitempty"`
-	LogoURL       *string   `json:"icon_url,omitempty"`
-	ADFSServer    *string   `json:"adfs_server,omitempty"`
-
-	EnableUsersAPI *bool `json:"api_enable_users,omitempty"`
+	TenantDomain       *string                `json:"tenant_domain,omitempty"`
+	DomainAliases      *[]string              `json:"domain_aliases,omitempty"`
+	LogoURL            *string                `json:"icon_url,omitempty"`
+	ADFSServer         *string                `json:"adfs_server,omitempty"`
+	FedMetadataXML     *string                `json:"fedMetadataXml,omitempty"`
+	EnableUsersAPI     *bool                  `json:"api_enable_users,omitempty"`
+	NonPersistentAttrs *[]string              `json:"non_persistent_attrs,omitempty"`
+	UpstreamParams     map[string]interface{} `json:"upstream_params,omitempty"`
+	Thumbprints        *[]string              `json:"thumbprints,omitempty"`
+	SignInEndpoint     *string                `json:"signInEndpoint,omitempty"`
+	TrustEmailVerified *string                `json:"should_trust_email_verified_connection,omitempty"`
 
 	// Set to on_first_login to avoid setting user attributes at each login.
-	SetUserAttributes  *string   `json:"set_user_root_attributes,omitempty"`
-	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`
-
-	UpstreamParams map[string]interface{} `json:"upstream_params,omitempty"`
+	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
 }
 
 // ConnectionOptionsSAML is used to configure a SAML Connection.

--- a/management/connection.go
+++ b/management/connection.go
@@ -231,6 +231,8 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 			v = &ConnectionOptionsAD{}
 		case ConnectionStrategyAzureAD:
 			v = &ConnectionOptionsAzureAD{}
+		case ConnectionStrategyADFS:
+			v = &ConnectionOptionsADFS{}
 		case ConnectionStrategySAML:
 			v = &ConnectionOptionsSAML{}
 		case ConnectionStrategyGoogleApps:

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -220,6 +220,51 @@ ZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g
 		},
 	},
 	{
+		name: "ADFS Connection",
+		connection: Connection{
+			Name:     auth0.Stringf("Test-ADFS-Connection-%d", time.Now().Unix()),
+			Strategy: auth0.String("adfs"),
+		},
+		options: &ConnectionOptionsADFS{
+			FedMetadataXML: auth0.String(`<?xml version="1.0" encoding="utf-8"?>
+<EntityDescriptor entityID="https://example.com"
+                  xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+    <RoleDescriptor xsi:type="fed:ApplicationServiceType"
+                    protocolSupportEnumeration="http://docs.oasis-open.org/wsfed/federation/200706"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xmlns:fed="http://docs.oasis-open.org/wsfed/federation/200706">
+        <fed:TargetScopes>
+            <wsa:EndpointReference xmlns:wsa="http://www.w3.org/2005/08/addressing">
+                <wsa:Address>https://adfs.provider/</wsa:Address>
+            </wsa:EndpointReference>
+        </fed:TargetScopes>
+        <fed:ApplicationServiceEndpoint>
+            <wsa:EndpointReference xmlns:wsa="http://www.w3.org/2005/08/addressing">
+                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>
+            </wsa:EndpointReference>
+        </fed:ApplicationServiceEndpoint>
+        <fed:PassiveRequestorEndpoint>
+            <wsa:EndpointReference xmlns:wsa="http://www.w3.org/2005/08/addressing">
+                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>
+            </wsa:EndpointReference>
+        </fed:PassiveRequestorEndpoint>
+    </RoleDescriptor>
+    <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                             Location="https://adfs.provider/sign_out"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                             Location="https://adfs.provider/sign_in"/>
+    </IDPSSODescriptor>
+</EntityDescriptor>
+`),
+			UpstreamParams: map[string]interface{}{
+				"screen_name": map[string]interface{}{
+					"alias": "login_hint",
+				},
+			},
+		},
+	},
+	{
 		name: "Facebook Connection",
 		connection: Connection{
 			Name:     auth0.Stringf("Test-Facebook-Connection-%d", time.Now().Unix()),
@@ -428,8 +473,9 @@ func TestConnectionManager_Update(t *testing.T) {
 		t.Run("It can successfully update a "+testCase.name, func(t *testing.T) {
 			if testCase.connection.GetStrategy() == "oidc" ||
 				testCase.connection.GetStrategy() == "samlp" ||
-				testCase.connection.GetStrategy() == "okta" {
-				t.Skip("Skipping because we can't create an oidc, okta or samlp connection with no options")
+				testCase.connection.GetStrategy() == "okta" ||
+				testCase.connection.GetStrategy() == "adfs" {
+				t.Skip("Skipping because we can't create an oidc, okta, samlp or adfs connection with no options")
 			}
 
 			configureHTTPTestRecordings(t)

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1644,6 +1644,14 @@ func (c *ConnectionOptionsADFS) GetEnableUsersAPI() bool {
 	return *c.EnableUsersAPI
 }
 
+// GetFedMetadataXML returns the FedMetadataXML field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetFedMetadataXML() string {
+	if c == nil || c.FedMetadataXML == nil {
+		return ""
+	}
+	return *c.FedMetadataXML
+}
+
 // GetLogoURL returns the LogoURL field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsADFS) GetLogoURL() string {
 	if c == nil || c.LogoURL == nil {
@@ -1668,12 +1676,36 @@ func (c *ConnectionOptionsADFS) GetSetUserAttributes() string {
 	return *c.SetUserAttributes
 }
 
+// GetSignInEndpoint returns the SignInEndpoint field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetSignInEndpoint() string {
+	if c == nil || c.SignInEndpoint == nil {
+		return ""
+	}
+	return *c.SignInEndpoint
+}
+
 // GetTenantDomain returns the TenantDomain field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsADFS) GetTenantDomain() string {
 	if c == nil || c.TenantDomain == nil {
 		return ""
 	}
 	return *c.TenantDomain
+}
+
+// GetThumbprints returns the Thumbprints field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetThumbprints() []string {
+	if c == nil || c.Thumbprints == nil {
+		return nil
+	}
+	return *c.Thumbprints
+}
+
+// GetTrustEmailVerified returns the TrustEmailVerified field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetTrustEmailVerified() string {
+	if c == nil || c.TrustEmailVerified == nil {
+		return ""
+	}
+	return *c.TrustEmailVerified
 }
 
 // String returns a string representation of ConnectionOptionsADFS.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2090,6 +2090,16 @@ func TestConnectionOptionsADFS_GetEnableUsersAPI(tt *testing.T) {
 	c.GetEnableUsersAPI()
 }
 
+func TestConnectionOptionsADFS_GetFedMetadataXML(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsADFS{FedMetadataXML: &zeroValue}
+	c.GetFedMetadataXML()
+	c = &ConnectionOptionsADFS{}
+	c.GetFedMetadataXML()
+	c = nil
+	c.GetFedMetadataXML()
+}
+
 func TestConnectionOptionsADFS_GetLogoURL(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsADFS{LogoURL: &zeroValue}
@@ -2120,6 +2130,16 @@ func TestConnectionOptionsADFS_GetSetUserAttributes(tt *testing.T) {
 	c.GetSetUserAttributes()
 }
 
+func TestConnectionOptionsADFS_GetSignInEndpoint(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsADFS{SignInEndpoint: &zeroValue}
+	c.GetSignInEndpoint()
+	c = &ConnectionOptionsADFS{}
+	c.GetSignInEndpoint()
+	c = nil
+	c.GetSignInEndpoint()
+}
+
 func TestConnectionOptionsADFS_GetTenantDomain(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsADFS{TenantDomain: &zeroValue}
@@ -2128,6 +2148,26 @@ func TestConnectionOptionsADFS_GetTenantDomain(tt *testing.T) {
 	c.GetTenantDomain()
 	c = nil
 	c.GetTenantDomain()
+}
+
+func TestConnectionOptionsADFS_GetThumbprints(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsADFS{Thumbprints: &zeroValue}
+	c.GetThumbprints()
+	c = &ConnectionOptionsADFS{}
+	c.GetThumbprints()
+	c = nil
+	c.GetThumbprints()
+}
+
+func TestConnectionOptionsADFS_GetTrustEmailVerified(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsADFS{TrustEmailVerified: &zeroValue}
+	c.GetTrustEmailVerified()
+	c = &ConnectionOptionsADFS{}
+	c.GetTrustEmailVerified()
+	c = nil
+	c.GetTrustEmailVerified()
 }
 
 func TestConnectionOptionsADFS_String(t *testing.T) {

--- a/test/data/recordings/TestConnectionManager_Create/It_can_successfully_create_a_ADFS_Connection.yaml
+++ b/test/data/recordings/TestConnectionManager_Create/It_can_successfully_create_a_ADFS_Connection.yaml
@@ -1,0 +1,74 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2221
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-ADFS-Connection-1675099550","strategy":"adfs","options":{"fedMetadataXml":"\u003c?xml version=\"1.0\" encoding=\"utf-8\"?\u003e\n\u003cEntityDescriptor entityID=\"https://example.com\"\n                  xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\"\u003e\n    \u003cRoleDescriptor xsi:type=\"fed:ApplicationServiceType\"\n                    protocolSupportEnumeration=\"http://docs.oasis-open.org/wsfed/federation/200706\"\n                    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n                    xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\"\u003e\n        \u003cfed:TargetScopes\u003e\n            \u003cwsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"\u003e\n                \u003cwsa:Address\u003ehttps://adfs.provider/\u003c/wsa:Address\u003e\n            \u003c/wsa:EndpointReference\u003e\n        \u003c/fed:TargetScopes\u003e\n        \u003cfed:ApplicationServiceEndpoint\u003e\n            \u003cwsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"\u003e\n                \u003cwsa:Address\u003ehttps://adfs.provider/wsfed\u003c/wsa:Address\u003e\n            \u003c/wsa:EndpointReference\u003e\n        \u003c/fed:ApplicationServiceEndpoint\u003e\n        \u003cfed:PassiveRequestorEndpoint\u003e\n            \u003cwsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"\u003e\n                \u003cwsa:Address\u003ehttps://adfs.provider/wsfed\u003c/wsa:Address\u003e\n            \u003c/wsa:EndpointReference\u003e\n        \u003c/fed:PassiveRequestorEndpoint\u003e\n    \u003c/RoleDescriptor\u003e\n    \u003cIDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"\u003e\n        \u003cSingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_out\"/\u003e\n        \u003cSingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_in\"/\u003e\n    \u003c/IDPSSODescriptor\u003e\n\u003c/EntityDescriptor\u003e\n","upstream_params":{"screen_name":{"alias":"login_hint"}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_3E5pG3gpHoOgvFIY","options":{"fedMetadataXml":"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<EntityDescriptor entityID=\"https://example.com\"\n                  xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\">\n    <RoleDescriptor xsi:type=\"fed:ApplicationServiceType\"\n                    protocolSupportEnumeration=\"http://docs.oasis-open.org/wsfed/federation/200706\"\n                    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n                    xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\">\n        <fed:TargetScopes>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:TargetScopes>\n        <fed:ApplicationServiceEndpoint>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:ApplicationServiceEndpoint>\n        <fed:PassiveRequestorEndpoint>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:PassiveRequestorEndpoint>\n    </RoleDescriptor>\n    <IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">\n        <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_out\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_in\"/>\n    </IDPSSODescriptor>\n</EntityDescriptor>\n","upstream_params":{"screen_name":{"alias":"login_hint"}},"thumbprints":[],"signInEndpoint":"https://adfs.provider/wsfed","should_trust_email_verified_connection":"always_set_emails_as_verified"},"strategy":"adfs","name":"Test-ADFS-Connection-1675099550","provisioning_ticket_url":"https://go-auth0-dev.eu.auth0.com.eu.auth0.com/p/adfs/UfydMqWU","is_domain_connection":false,"show_as_button":false,"enabled_clients":[],"realms":["Test-ADFS-Connection-1675099550"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 444.808542ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_3E5pG3gpHoOgvFIY
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 171.074334ms

--- a/test/data/recordings/TestConnectionManager_Read/It_can_successfully_read_a_ADFS_Connection.yaml
+++ b/test/data/recordings/TestConnectionManager_Read/It_can_successfully_read_a_ADFS_Connection.yaml
@@ -1,0 +1,145 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2221
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-ADFS-Connection-1675099558","strategy":"adfs","options":{"fedMetadataXml":"\u003c?xml version=\"1.0\" encoding=\"utf-8\"?\u003e\n\u003cEntityDescriptor entityID=\"https://example.com\"\n                  xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\"\u003e\n    \u003cRoleDescriptor xsi:type=\"fed:ApplicationServiceType\"\n                    protocolSupportEnumeration=\"http://docs.oasis-open.org/wsfed/federation/200706\"\n                    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n                    xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\"\u003e\n        \u003cfed:TargetScopes\u003e\n            \u003cwsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"\u003e\n                \u003cwsa:Address\u003ehttps://adfs.provider/\u003c/wsa:Address\u003e\n            \u003c/wsa:EndpointReference\u003e\n        \u003c/fed:TargetScopes\u003e\n        \u003cfed:ApplicationServiceEndpoint\u003e\n            \u003cwsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"\u003e\n                \u003cwsa:Address\u003ehttps://adfs.provider/wsfed\u003c/wsa:Address\u003e\n            \u003c/wsa:EndpointReference\u003e\n        \u003c/fed:ApplicationServiceEndpoint\u003e\n        \u003cfed:PassiveRequestorEndpoint\u003e\n            \u003cwsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"\u003e\n                \u003cwsa:Address\u003ehttps://adfs.provider/wsfed\u003c/wsa:Address\u003e\n            \u003c/wsa:EndpointReference\u003e\n        \u003c/fed:PassiveRequestorEndpoint\u003e\n    \u003c/RoleDescriptor\u003e\n    \u003cIDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"\u003e\n        \u003cSingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_out\"/\u003e\n        \u003cSingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_in\"/\u003e\n    \u003c/IDPSSODescriptor\u003e\n\u003c/EntityDescriptor\u003e\n","upstream_params":{"screen_name":{"alias":"login_hint"}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_vfghlk5WOESlXbdR","options":{"fedMetadataXml":"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<EntityDescriptor entityID=\"https://example.com\"\n                  xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\">\n    <RoleDescriptor xsi:type=\"fed:ApplicationServiceType\"\n                    protocolSupportEnumeration=\"http://docs.oasis-open.org/wsfed/federation/200706\"\n                    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n                    xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\">\n        <fed:TargetScopes>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:TargetScopes>\n        <fed:ApplicationServiceEndpoint>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:ApplicationServiceEndpoint>\n        <fed:PassiveRequestorEndpoint>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:PassiveRequestorEndpoint>\n    </RoleDescriptor>\n    <IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">\n        <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_out\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_in\"/>\n    </IDPSSODescriptor>\n</EntityDescriptor>\n","upstream_params":{"screen_name":{"alias":"login_hint"}},"thumbprints":[],"signInEndpoint":"https://adfs.provider/wsfed","should_trust_email_verified_connection":"always_set_emails_as_verified"},"strategy":"adfs","name":"Test-ADFS-Connection-1675099558","provisioning_ticket_url":"https://go-auth0-dev.eu.auth0.com.eu.auth0.com/p/adfs/mjtVfNWe","is_domain_connection":false,"show_as_button":false,"enabled_clients":[],"realms":["Test-ADFS-Connection-1675099558"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1.757118375s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_vfghlk5WOESlXbdR
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_vfghlk5WOESlXbdR","options":{"thumbprints":[],"fedMetadataXml":"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<EntityDescriptor entityID=\"https://example.com\"\n                  xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\">\n    <RoleDescriptor xsi:type=\"fed:ApplicationServiceType\"\n                    protocolSupportEnumeration=\"http://docs.oasis-open.org/wsfed/federation/200706\"\n                    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n                    xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\">\n        <fed:TargetScopes>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:TargetScopes>\n        <fed:ApplicationServiceEndpoint>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:ApplicationServiceEndpoint>\n        <fed:PassiveRequestorEndpoint>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:PassiveRequestorEndpoint>\n    </RoleDescriptor>\n    <IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">\n        <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_out\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_in\"/>\n    </IDPSSODescriptor>\n</EntityDescriptor>\n","signInEndpoint":"https://adfs.provider/wsfed","upstream_params":{"screen_name":{"alias":"login_hint"}},"should_trust_email_verified_connection":"always_set_emails_as_verified"},"strategy":"adfs","name":"Test-ADFS-Connection-1675099558","provisioning_ticket_url":"https://go-auth0-dev.eu.auth0.com.eu.auth0.com/p/adfs/mjtVfNWe","is_domain_connection":false,"show_as_button":false,"enabled_clients":[],"realms":["Test-ADFS-Connection-1675099558"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 167.136542ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_vfghlk5WOESlXbdR
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 225.648125ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_vfghlk5WOESlXbdR
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 143.929333ms

--- a/test/data/recordings/TestConnectionManager_ReadByName/It_can_successfully_find_a_ADFS_Connection_by_its_name.yaml
+++ b/test/data/recordings/TestConnectionManager_ReadByName/It_can_successfully_find_a_ADFS_Connection_by_its_name.yaml
@@ -1,0 +1,145 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2221
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-ADFS-Connection-1675099580","strategy":"adfs","options":{"fedMetadataXml":"\u003c?xml version=\"1.0\" encoding=\"utf-8\"?\u003e\n\u003cEntityDescriptor entityID=\"https://example.com\"\n                  xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\"\u003e\n    \u003cRoleDescriptor xsi:type=\"fed:ApplicationServiceType\"\n                    protocolSupportEnumeration=\"http://docs.oasis-open.org/wsfed/federation/200706\"\n                    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n                    xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\"\u003e\n        \u003cfed:TargetScopes\u003e\n            \u003cwsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"\u003e\n                \u003cwsa:Address\u003ehttps://adfs.provider/\u003c/wsa:Address\u003e\n            \u003c/wsa:EndpointReference\u003e\n        \u003c/fed:TargetScopes\u003e\n        \u003cfed:ApplicationServiceEndpoint\u003e\n            \u003cwsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"\u003e\n                \u003cwsa:Address\u003ehttps://adfs.provider/wsfed\u003c/wsa:Address\u003e\n            \u003c/wsa:EndpointReference\u003e\n        \u003c/fed:ApplicationServiceEndpoint\u003e\n        \u003cfed:PassiveRequestorEndpoint\u003e\n            \u003cwsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\"\u003e\n                \u003cwsa:Address\u003ehttps://adfs.provider/wsfed\u003c/wsa:Address\u003e\n            \u003c/wsa:EndpointReference\u003e\n        \u003c/fed:PassiveRequestorEndpoint\u003e\n    \u003c/RoleDescriptor\u003e\n    \u003cIDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"\u003e\n        \u003cSingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_out\"/\u003e\n        \u003cSingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_in\"/\u003e\n    \u003c/IDPSSODescriptor\u003e\n\u003c/EntityDescriptor\u003e\n","upstream_params":{"screen_name":{"alias":"login_hint"}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_wAZKUoBsNHD1lKjJ","options":{"fedMetadataXml":"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<EntityDescriptor entityID=\"https://example.com\"\n                  xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\">\n    <RoleDescriptor xsi:type=\"fed:ApplicationServiceType\"\n                    protocolSupportEnumeration=\"http://docs.oasis-open.org/wsfed/federation/200706\"\n                    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n                    xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\">\n        <fed:TargetScopes>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:TargetScopes>\n        <fed:ApplicationServiceEndpoint>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:ApplicationServiceEndpoint>\n        <fed:PassiveRequestorEndpoint>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:PassiveRequestorEndpoint>\n    </RoleDescriptor>\n    <IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">\n        <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_out\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_in\"/>\n    </IDPSSODescriptor>\n</EntityDescriptor>\n","upstream_params":{"screen_name":{"alias":"login_hint"}},"thumbprints":[],"signInEndpoint":"https://adfs.provider/wsfed","should_trust_email_verified_connection":"always_set_emails_as_verified"},"strategy":"adfs","name":"Test-ADFS-Connection-1675099580","provisioning_ticket_url":"https://go-auth0-dev.eu.auth0.com.eu.auth0.com/p/adfs/fAHx3pNz","is_domain_connection":false,"show_as_button":false,"enabled_clients":[],"realms":["Test-ADFS-Connection-1675099580"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 468.490959ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections?include_totals=true&name=Test-ADFS-Connection-1675099580&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"total":1,"start":0,"limit":50,"connections":[{"id":"con_wAZKUoBsNHD1lKjJ","options":{"thumbprints":[],"fedMetadataXml":"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<EntityDescriptor entityID=\"https://example.com\"\n                  xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\">\n    <RoleDescriptor xsi:type=\"fed:ApplicationServiceType\"\n                    protocolSupportEnumeration=\"http://docs.oasis-open.org/wsfed/federation/200706\"\n                    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n                    xmlns:fed=\"http://docs.oasis-open.org/wsfed/federation/200706\">\n        <fed:TargetScopes>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:TargetScopes>\n        <fed:ApplicationServiceEndpoint>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:ApplicationServiceEndpoint>\n        <fed:PassiveRequestorEndpoint>\n            <wsa:EndpointReference xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\n                <wsa:Address>https://adfs.provider/wsfed</wsa:Address>\n            </wsa:EndpointReference>\n        </fed:PassiveRequestorEndpoint>\n    </RoleDescriptor>\n    <IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">\n        <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_out\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"\n                             Location=\"https://adfs.provider/sign_in\"/>\n    </IDPSSODescriptor>\n</EntityDescriptor>\n","signInEndpoint":"https://adfs.provider/wsfed","upstream_params":{"screen_name":{"alias":"login_hint"}},"should_trust_email_verified_connection":"always_set_emails_as_verified"},"strategy":"adfs","name":"Test-ADFS-Connection-1675099580","provisioning_ticket_url":"https://go-auth0-dev.eu.auth0.com.eu.auth0.com/p/adfs/fAHx3pNz","is_domain_connection":false,"show_as_button":false,"realms":["Test-ADFS-Connection-1675099580"],"enabled_clients":[]}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 167.675208ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_wAZKUoBsNHD1lKjJ
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2023-01-30T17:26:21.392Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 153.464792ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_wAZKUoBsNHD1lKjJ
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 249.92475ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

In this PR we are adding a couple of missed options for the ADFS Connection type:

- FedMetadataXML
- Thumbprints
- SignInEndpoint
- TrustEmailVerified

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

- https://github.com/auth0/terraform-provider-auth0/issues/454

### 🔬 Testing

Tests are added as well. 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
