### PR TITLE
SDK-3949: Introduce sending client information with requests

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -23,24 +23,24 @@ import (
 // UserAgent is the default user agent string.
 var UserAgent = fmt.Sprintf("Go-Auth0-SDK/%s", auth0.Version)
 
-// Telemetry is the structure used to send telemetry data in the "Auth0-Client" header.
-type Telemetry struct {
+// Auth0ClientInfo is the structure used to send client information in the "Auth0-Client" header.
+type Auth0ClientInfo struct {
 	Name    string            `json:"name"`
 	Version string            `json:"version"`
 	Env     map[string]string `json:"env,omitempty"`
 }
 
-// IsEmpty checks whether the provide Telemetry data is nil or has no data to allow
+// IsEmpty checks whether the provided Auth0ClientInfo data is nil or has no data to allow
 // short-circuiting the "Auth0-Client" header configuration.
-func (td *Telemetry) IsEmpty() bool {
+func (td *Auth0ClientInfo) IsEmpty() bool {
 	if td == nil {
 		return true
 	}
 	return td.Name == "" && td.Version == "" && len(td.Env) == 0
 }
 
-// DefaultTelemetryData is the default telemetry data sent by the go-auth0 SDK.
-var DefaultTelemetryData = &Telemetry{Name: "go-auth0", Version: auth0.Version}
+// DefaultAuth0ClientInfo is the default client information sent by the go-auth0 SDK.
+var DefaultAuth0ClientInfo = &Auth0ClientInfo{Name: "go-auth0", Version: auth0.Version}
 
 // RoundTripFunc is an adapter to allow the use of ordinary functions as HTTP
 // round trips.
@@ -91,21 +91,21 @@ func UserAgentTransport(base http.RoundTripper, userAgent string) http.RoundTrip
 	})
 }
 
-// TelemetryTransport wraps base transport with a customized "Auth0-Client" header.
-func TelemetryTransport(base http.RoundTripper, telemetryData *Telemetry) (http.RoundTripper, error) {
+// Auth0ClientInfoTransport wraps base transport with a customized "Auth0-Client" header.
+func Auth0ClientInfoTransport(base http.RoundTripper, auth0ClientInfo *Auth0ClientInfo) (http.RoundTripper, error) {
 	if base == nil {
 		base = http.DefaultTransport
 	}
 
-	telemetryDataJson, err := json.Marshal(telemetryData)
+	auth0ClientJson, err := json.Marshal(auth0ClientInfo)
 	if err != nil {
 		return nil, err
 	}
 
-	encodedTelemetry := base64.StdEncoding.EncodeToString(telemetryDataJson)
+	auth0ClientEncoded := base64.StdEncoding.EncodeToString(auth0ClientJson)
 
 	return RoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		req.Header.Set("Auth0-Client", encodedTelemetry)
+		req.Header.Set("Auth0-Client", auth0ClientEncoded)
 		return base.RoundTrip(req)
 	}), nil
 }
@@ -164,13 +164,13 @@ func WithUserAgent(userAgent string) Option {
 	}
 }
 
-// WithTelemetry configures the client to overwrite the "Auth0-Client" header.
-func WithTelemetry(telemetryData *Telemetry) Option {
+// WithAuth0ClientInfo configures the client to overwrite the "Auth0-Client" header.
+func WithAuth0ClientInfo(auth0ClientInfo *Auth0ClientInfo) Option {
 	return func(c *http.Client) {
-		if telemetryData.IsEmpty() {
+		if auth0ClientInfo.IsEmpty() {
 			return
 		}
-		transport, err := TelemetryTransport(c.Transport, telemetryData)
+		transport, err := Auth0ClientInfoTransport(c.Transport, auth0ClientInfo)
 		if err != nil {
 			return
 		}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -14,11 +14,33 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 
+	"encoding/base64"
+	"encoding/json"
+
 	"github.com/auth0/go-auth0"
 )
 
 // UserAgent is the default user agent string.
 var UserAgent = fmt.Sprintf("Go-Auth0-SDK/%s", auth0.Version)
+
+// Telemetry is the structure used to send telemetry data in the "Auth0-Client" header.
+type Telemetry struct {
+	Name    string            `json:"name"`
+	Version string            `json:"version"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// IsEmpty checks whether the provide Telemetry data is nil or has no data to allow
+// short-circuiting the "Auth0-Client" header configuration.
+func (td *Telemetry) IsEmpty() bool {
+	if td == nil {
+		return true
+	}
+	return td.Name == "" && td.Version == "" && len(td.Env) == 0
+}
+
+// DefaultTelemetryData is the default telemetry data sent by the go-auth0 SDK.
+var DefaultTelemetryData = &Telemetry{Name: "go-auth0", Version: auth0.Version}
 
 // RoundTripFunc is an adapter to allow the use of ordinary functions as HTTP
 // round trips.
@@ -67,6 +89,25 @@ func UserAgentTransport(base http.RoundTripper, userAgent string) http.RoundTrip
 		req.Header.Set("User-Agent", userAgent)
 		return base.RoundTrip(req)
 	})
+}
+
+// TelemetryTransport wraps base transport with a customized "Auth0-Client" header.
+func TelemetryTransport(base http.RoundTripper, telemetryData *Telemetry) (http.RoundTripper, error) {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	telemetryDataJson, err := json.Marshal(telemetryData)
+	if err != nil {
+		return nil, err
+	}
+
+	encodedTelemetry := base64.StdEncoding.EncodeToString(telemetryDataJson)
+
+	return RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		req.Header.Set("Auth0-Client", encodedTelemetry)
+		return base.RoundTrip(req)
+	}), nil
 }
 
 func dumpRequest(r *http.Request) {
@@ -120,6 +161,20 @@ func WithRateLimit() Option {
 func WithUserAgent(userAgent string) Option {
 	return func(c *http.Client) {
 		c.Transport = UserAgentTransport(c.Transport, userAgent)
+	}
+}
+
+// WithTelemetry configures the client to overwrite the "Auth0-Client" header.
+func WithTelemetry(telemetryData *Telemetry) Option {
+	return func(c *http.Client) {
+		if telemetryData.IsEmpty() {
+			return
+		}
+		transport, err := TelemetryTransport(c.Transport, telemetryData)
+		if err != nil {
+			return
+		}
+		c.Transport = transport
 	}
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -95,3 +95,45 @@ func TestOAuth2ClientCredentialsAndAudience(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "someToken", token.AccessToken)
 }
+
+func TestWrapTelemetry(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		given    Telemetry
+		expected string
+	}{
+		{
+			name:     "Default client",
+			given:    *DefaultTelemetryData,
+			expected: "eyJuYW1lIjoiZ28tYXV0aDAiLCJ2ZXJzaW9uIjoibGF0ZXN0In0=",
+		},
+		{
+			name:     "Custom client",
+			given:    Telemetry{"foo", "1.0.0", map[string]string{"os": "windows"}},
+			expected: "eyJuYW1lIjoiZm9vIiwidmVyc2lvbiI6IjEuMC4wIiwiZW52Ijp7Im9zIjoid2luZG93cyJ9fQ==",
+		},
+		{
+			name:     "Missing information",
+			given:    Telemetry{Name: "foo"},
+			expected: "eyJuYW1lIjoiZm9vIiwidmVyc2lvbiI6IiJ9",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				header := r.Header.Get("Auth0-Client")
+				assert.Equal(t, testCase.expected, header)
+			})
+
+			testServer := httptest.NewServer(testHandler)
+			t.Cleanup(func() {
+				testServer.Close()
+			})
+
+			httpClient := Wrap(testServer.Client(), StaticToken(""), WithTelemetry(&testCase.given))
+			_, err := httpClient.Get(testServer.URL)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -96,25 +96,25 @@ func TestOAuth2ClientCredentialsAndAudience(t *testing.T) {
 	assert.Equal(t, "someToken", token.AccessToken)
 }
 
-func TestWrapTelemetry(t *testing.T) {
+func TestWrapAuth0ClientInfo(t *testing.T) {
 	var testCases = []struct {
 		name     string
-		given    Telemetry
+		given    Auth0ClientInfo
 		expected string
 	}{
 		{
 			name:     "Default client",
-			given:    *DefaultTelemetryData,
+			given:    *DefaultAuth0ClientInfo,
 			expected: "eyJuYW1lIjoiZ28tYXV0aDAiLCJ2ZXJzaW9uIjoibGF0ZXN0In0=",
 		},
 		{
 			name:     "Custom client",
-			given:    Telemetry{"foo", "1.0.0", map[string]string{"os": "windows"}},
+			given:    Auth0ClientInfo{"foo", "1.0.0", map[string]string{"os": "windows"}},
 			expected: "eyJuYW1lIjoiZm9vIiwidmVyc2lvbiI6IjEuMC4wIiwiZW52Ijp7Im9zIjoid2luZG93cyJ9fQ==",
 		},
 		{
 			name:     "Missing information",
-			given:    Telemetry{Name: "foo"},
+			given:    Auth0ClientInfo{Name: "foo"},
 			expected: "eyJuYW1lIjoiZm9vIiwidmVyc2lvbiI6IiJ9",
 		},
 	}
@@ -131,7 +131,7 @@ func TestWrapTelemetry(t *testing.T) {
 				testServer.Close()
 			})
 
-			httpClient := Wrap(testServer.Client(), StaticToken(""), WithTelemetry(&testCase.given))
+			httpClient := Wrap(testServer.Client(), StaticToken(""), WithAuth0ClientInfo(&testCase.given))
 			_, err := httpClient.Get(testServer.URL)
 			assert.NoError(t, err)
 		})

--- a/management/management.go
+++ b/management/management.go
@@ -115,6 +115,7 @@ type Management struct {
 	ctx         context.Context
 	tokenSource oauth2.TokenSource
 	http        *http.Client
+	telemetry   *client.Telemetry
 }
 
 // New creates a new Auth0 Management client by authenticating using the
@@ -139,6 +140,7 @@ func New(domain string, options ...Option) (*Management, error) {
 		debug:     false,
 		ctx:       context.Background(),
 		http:      http.DefaultClient,
+		telemetry: client.DefaultTelemetryData,
 	}
 
 	for _, option := range options {
@@ -151,6 +153,7 @@ func New(domain string, options ...Option) (*Management, error) {
 		client.WithDebug(m.debug),
 		client.WithUserAgent(m.userAgent),
 		client.WithRateLimit(),
+		client.WithTelemetry(m.telemetry),
 	)
 
 	m.Client = newClientManager(m)

--- a/management/management.go
+++ b/management/management.go
@@ -108,14 +108,14 @@ type Management struct {
 	// EmailProvider manages Auth0 Email Providers.
 	EmailProvider *EmailProviderManager
 
-	url         *url.URL
-	basePath    string
-	userAgent   string
-	debug       bool
-	ctx         context.Context
-	tokenSource oauth2.TokenSource
-	http        *http.Client
-	telemetry   *client.Telemetry
+	url             *url.URL
+	basePath        string
+	userAgent       string
+	debug           bool
+	ctx             context.Context
+	tokenSource     oauth2.TokenSource
+	http            *http.Client
+	auth0ClientInfo *client.Auth0ClientInfo
 }
 
 // New creates a new Auth0 Management client by authenticating using the
@@ -134,13 +134,13 @@ func New(domain string, options ...Option) (*Management, error) {
 	}
 
 	m := &Management{
-		url:       u,
-		basePath:  "api/v2",
-		userAgent: client.UserAgent,
-		debug:     false,
-		ctx:       context.Background(),
-		http:      http.DefaultClient,
-		telemetry: client.DefaultTelemetryData,
+		url:             u,
+		basePath:        "api/v2",
+		userAgent:       client.UserAgent,
+		debug:           false,
+		ctx:             context.Background(),
+		http:            http.DefaultClient,
+		auth0ClientInfo: client.DefaultAuth0ClientInfo,
 	}
 
 	for _, option := range options {
@@ -153,7 +153,7 @@ func New(domain string, options ...Option) (*Management, error) {
 		client.WithDebug(m.debug),
 		client.WithUserAgent(m.userAgent),
 		client.WithRateLimit(),
-		client.WithTelemetry(m.telemetry),
+		client.WithAuth0ClientInfo(m.auth0ClientInfo),
 	)
 
 	m.Client = newClientManager(m)

--- a/management/management_option.go
+++ b/management/management_option.go
@@ -83,20 +83,20 @@ func WithClient(client *http.Client) Option {
 	}
 }
 
-// WithTelemetry configures the management client to use the provided telemetry data
+// WithAuth0ClientInfo configures the management client to use the provided client information
 // instead of the default one.
-func WithTelemetry(telemetry client.Telemetry) Option {
+func WithAuth0ClientInfo(auth0ClientInfo client.Auth0ClientInfo) Option {
 	return func(m *Management) {
-		if !telemetry.IsEmpty() {
-			m.telemetry = &telemetry
+		if !auth0ClientInfo.IsEmpty() {
+			m.auth0ClientInfo = &auth0ClientInfo
 		}
 	}
 }
 
-// WithNoTelemetry configures the management client to not send the "Auth0-Client" header
+// WithNoAuth0ClientInfo configures the management client to not send the "Auth0-Client" header
 // at all.
-func WithNoTelemetry() Option {
+func WithNoAuth0ClientInfo() Option {
 	return func(m *Management) {
-		m.telemetry = nil
+		m.auth0ClientInfo = nil
 	}
 }

--- a/management/management_option.go
+++ b/management/management_option.go
@@ -82,3 +82,21 @@ func WithClient(client *http.Client) Option {
 		m.http = client
 	}
 }
+
+// WithTelemetry configures the management client to use the provided telemetry data
+// instead of the default one.
+func WithTelemetry(telemetry client.Telemetry) Option {
+	return func(m *Management) {
+		if !telemetry.IsEmpty() {
+			m.telemetry = &telemetry
+		}
+	}
+}
+
+// WithNoTelemetry configures the management client to not send the "Auth0-Client" header
+// at all.
+func WithNoTelemetry() Option {
+	return func(m *Management) {
+		m.telemetry = nil
+	}
+}

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -257,7 +257,7 @@ func TestManagement_URI(t *testing.T) {
 	}
 }
 
-func TestTelemetry(t *testing.T) {
+func TestAuth0Client(t *testing.T) {
 	t.Run("Defaults to the default data", func(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			header := r.Header.Get("Auth0-Client")
@@ -276,8 +276,8 @@ func TestTelemetry(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Allows passing a custom telemetry data", func(t *testing.T) {
-		customClient := client.Telemetry{Name: "test-client", Version: "1.0.0"}
+	t.Run("Allows passing custom Auth0ClientInfo", func(t *testing.T) {
+		customClient := client.Auth0ClientInfo{Name: "test-client", Version: "1.0.0"}
 
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			header := r.Header.Get("Auth0-Client")
@@ -288,7 +288,7 @@ func TestTelemetry(t *testing.T) {
 		m, err := New(
 			s.URL,
 			WithInsecure(),
-			WithTelemetry(customClient),
+			WithAuth0ClientInfo(customClient),
 		)
 		assert.NoError(t, err)
 
@@ -297,7 +297,7 @@ func TestTelemetry(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Allows disabling telemetry", func(t *testing.T) {
+	t.Run("Allows disabling Auth0ClientInfo", func(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			rawHeader := r.Header.Get("Auth0-Client")
 			assert.Empty(t, rawHeader)
@@ -307,7 +307,7 @@ func TestTelemetry(t *testing.T) {
 		m, err := New(
 			s.URL,
 			WithInsecure(),
-			WithNoTelemetry(),
+			WithNoAuth0ClientInfo(),
 		)
 		assert.NoError(t, err)
 		_, err = m.User.Read("123")


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Introduces telemetry to the package which is being sent in the (new) `Auth0-Client` header.

By default the telemetry data sent is for the go-auth0 package however, it can be overridden by passing a custom Telemetry to the `WithTelemetry` function on `API.New`. The structure is as follows:
* name: A string that is name of the "thing" the telemetry data is for
* version: A string that is version of the "thing" the telemetry data is for
* env: A object of strings that is a grab-bag for any other data that the consumer of go-auth0 wishes to send, like OS version for example

By calling `WithNoTelemetry` the `Auth0-Client` header is not sent at all

### 📚 References

### 🔬 Testing

I'm working on figuring out how to test this to make sure the data shows up as expected (rather than works in theory)

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
