### PR TITLE
Pin installed golangci-lint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ deps: ## Download dependencies
 
 $(GO_BIN)/golangci-lint:
 	${call print, "Installing golangci-lint"}
-	@go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
 $(GO_BIN)/govulncheck:
 	@go install -v golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Pins the version of golangci-lint to a known working version rather than latest so that CI starts working again. I took this option rather than upgrading to go 1.20 to unblock the broken CI for the following reasons:

* Upgrading to go 1.20 and using latest golangci-lint causes some new issues when running `make lint`, these need reviewing and fixing
* go 1.20 isn't available on homebrew yet, so whilst possible to use it's not ideal to upgrade until that is available

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Whether CI passes again, and I tested the relevant make commands work fine locally

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
