### PR TITLE
Remove vulncheck step from lint workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Check for linting errors
         run: make lint
 
-      - name: Check for go vulnerabilities
-        run: make check-vuln
-
   tests:
     name: Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
### 🔧 Changes
We no longer need to run this in the lint workflow as it has its own dedicated workflow

