### PR TITLE
Add go version to env object on Auth0Client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,4 +82,9 @@ test-record: ## Run tests and record http interactions. To run a specific test p
 
 test-e2e: ## Run tests without http recordings. To run a specific test pass the FILTER var. Usage `make test-e2e FILTER="TestResourceServer_Read"`
 	@echo "==> Running tests against a real Auth0 tenant..."
-	@go test -run "$(FILTER)"-cover -covermode=atomic -coverprofile=coverage.out ./...
+	@go test \
+		-run "$(FILTER)" \
+		-cover \
+		-covermode=atomic \
+		-coverprofile=coverage.out \
+		./...

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -40,7 +41,13 @@ func (td *Auth0ClientInfo) IsEmpty() bool {
 }
 
 // DefaultAuth0ClientInfo is the default client information sent by the go-auth0 SDK.
-var DefaultAuth0ClientInfo = &Auth0ClientInfo{Name: "go-auth0", Version: auth0.Version}
+var DefaultAuth0ClientInfo = &Auth0ClientInfo{
+	Name:    "go-auth0",
+	Version: auth0.Version,
+	Env: map[string]string{
+		"go": runtime.Version(),
+	},
+}
 
 // RoundTripFunc is an adapter to allow the use of ordinary functions as HTTP
 // round trips.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -105,7 +105,7 @@ func TestWrapAuth0ClientInfo(t *testing.T) {
 		{
 			name:     "Default client",
 			given:    *DefaultAuth0ClientInfo,
-			expected: "eyJuYW1lIjoiZ28tYXV0aDAiLCJ2ZXJzaW9uIjoibGF0ZXN0In0=",
+			expected: "", // As the default contains dynamic data (runtime.Version) we just assert the value is set.
 		},
 		{
 			name:     "Custom client",
@@ -123,7 +123,11 @@ func TestWrapAuth0ClientInfo(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				header := r.Header.Get("Auth0-Client")
-				assert.Equal(t, testCase.expected, header)
+				if testCase.expected == "" {
+					assert.NotEmpty(t, header)
+				} else {
+					assert.Equal(t, testCase.expected, header)
+				}
 			})
 
 			testServer := httptest.NewServer(testHandler)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -146,11 +146,7 @@ func TestWrapAuth0ClientInfo(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				header := r.Header.Get("Auth0-Client")
-				if testCase.expected == "" {
-					assert.NotEmpty(t, header)
-				} else {
-					assert.Equal(t, testCase.expected, header)
-				}
+				assert.Equal(t, testCase.expected, header)
 			})
 
 			testServer := httptest.NewServer(testHandler)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2,10 +2,13 @@ package client
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
@@ -97,16 +100,36 @@ func TestOAuth2ClientCredentialsAndAudience(t *testing.T) {
 }
 
 func TestWrapAuth0ClientInfo(t *testing.T) {
+	t.Run("Default client", func(t *testing.T) {
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			header := r.Header.Get("Auth0-Client")
+			auth0ClientDecoded, err := base64.StdEncoding.DecodeString(header)
+			assert.NoError(t, err)
+
+			var auth0Client Auth0ClientInfo
+			err = json.Unmarshal(auth0ClientDecoded, &auth0Client)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "go-auth0", auth0Client.Name)
+			assert.Equal(t, "latest", auth0Client.Version)
+			assert.Equal(t, runtime.Version(), auth0Client.Env["go"])
+		})
+
+		testServer := httptest.NewServer(testHandler)
+		t.Cleanup(func() {
+			testServer.Close()
+		})
+
+		httpClient := Wrap(testServer.Client(), StaticToken(""), WithAuth0ClientInfo(DefaultAuth0ClientInfo))
+		_, err := httpClient.Get(testServer.URL)
+		assert.NoError(t, err)
+	})
+
 	var testCases = []struct {
 		name     string
 		given    Auth0ClientInfo
 		expected string
 	}{
-		{
-			name:     "Default client",
-			given:    *DefaultAuth0ClientInfo,
-			expected: "", // As the default contains dynamic data (runtime.Version) we just assert the value is set.
-		},
 		{
 			name:     "Custom client",
 			given:    Auth0ClientInfo{"foo", "1.0.0", map[string]string{"os": "windows"}},

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -2,11 +2,14 @@ package management
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -261,8 +264,16 @@ func TestAuth0Client(t *testing.T) {
 	t.Run("Defaults to the default data", func(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			header := r.Header.Get("Auth0-Client")
-			// As the default contains dynamic data (runtime.Version) we just assert the value is set.
-			assert.NotEmpty(t, header)
+			auth0ClientDecoded, err := base64.StdEncoding.DecodeString(header)
+			assert.NoError(t, err)
+
+			var auth0Client client.Auth0ClientInfo
+			err = json.Unmarshal(auth0ClientDecoded, &auth0Client)
+
+			assert.NoError(t, err)
+			assert.Equal(t, "go-auth0", auth0Client.Name)
+			assert.Equal(t, "latest", auth0Client.Version)
+			assert.Equal(t, runtime.Version(), auth0Client.Env["go"])
 		})
 		s := httptest.NewServer(h)
 

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -261,7 +261,8 @@ func TestAuth0Client(t *testing.T) {
 	t.Run("Defaults to the default data", func(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			header := r.Header.Get("Auth0-Client")
-			assert.Equal(t, "eyJuYW1lIjoiZ28tYXV0aDAiLCJ2ZXJzaW9uIjoibGF0ZXN0In0=", header)
+			// As the default contains dynamic data (runtime.Version) we just assert the value is set.
+			assert.NotEmpty(t, header)
 		})
 		s := httptest.NewServer(h)
 


### PR DESCRIPTION
### 🔧 Changes

Adds the Go version being used into the `env` property of the `auth0-client` data. This will allow us to have some insight into the Go versions being used and ensure that our supported versions of Go reflect real usage.

I wasn't sure whether it's worthwhile removing the `go` prefix on the return value of `runtime.Version()` and figured it was probably safer to leave the value untouched.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Tested manually that the `env` property includes the correct data (see below for a snippet from the management logs of my tenant)

```json
  "auth0_client": {
    "name": "go-auth0",
    "version": "latest",
    "env": {
      "go": "go1.20.1"
    }
  }
```


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
