### PR TITLE
Handle difference in allowed_audiences field in GoogleOauth2 connection

### DIFF
--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -564,6 +565,41 @@ func TestConnectionOptionsScopes(t *testing.T) {
 
 		options.SetScopes(false, "foo", "baz")
 		assert.Equal(t, []string{"bar"}, options.Scopes())
+	})
+}
+
+func TestGoogleOauth2Connection_MarshalJSON(t *testing.T) {
+	var emptySlice []string
+	for connection, expected := range map[*ConnectionOptionsGoogleOAuth2]string{
+		{AllowedAudiences: nil}:                     `{}`,
+		{AllowedAudiences: &emptySlice}:             `{"allowed_audiences":null}`,
+		{AllowedAudiences: &[]string{}}:             `{"allowed_audiences":[]}`,
+		{AllowedAudiences: &[]string{"foo", "bar"}}: `{"allowed_audiences":["foo","bar"]}`,
+	} {
+		payload, err := json.Marshal(connection)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(payload))
+	}
+}
+
+func TestGoogleOauth2Connection_UnmarshalJSON(t *testing.T) {
+	for expectedAsString, expected := range map[string]*ConnectionOptionsGoogleOAuth2{
+		`{}`:                                    {},
+		`{"allowed_audiences": null}`:           {},
+		`{"allowed_audiences": ""}`:             {AllowedAudiences: &[]string{}},
+		`{"allowed_audiences": []}`:             {AllowedAudiences: &[]string{}},
+		`{"allowed_audiences": ["foo", "bar"]}`: {AllowedAudiences: &[]string{"foo", "bar"}},
+	} {
+		var actual *ConnectionOptionsGoogleOAuth2
+		err := json.Unmarshal([]byte(expectedAsString), &actual)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	}
+
+	t.Run("Throws an unexpected type error", func(t *testing.T) {
+		var actual *ConnectionOptionsGoogleOAuth2
+		err := json.Unmarshal([]byte(`{"allowed_audiences": 1}`), &actual)
+		assert.EqualError(t, err, "unexpected type for field allowed_audiences: float64")
 	})
 }
 

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -571,10 +571,11 @@ func TestConnectionOptionsScopes(t *testing.T) {
 func TestGoogleOauth2Connection_MarshalJSON(t *testing.T) {
 	var emptySlice []string
 	for connection, expected := range map[*ConnectionOptionsGoogleOAuth2]string{
-		{AllowedAudiences: nil}:                     `{}`,
-		{AllowedAudiences: &emptySlice}:             `{"allowed_audiences":null}`,
-		{AllowedAudiences: &[]string{}}:             `{"allowed_audiences":[]}`,
-		{AllowedAudiences: &[]string{"foo", "bar"}}: `{"allowed_audiences":["foo","bar"]}`,
+		{AllowedAudiences: nil}:                                              `{}`,
+		{AllowedAudiences: &emptySlice}:                                      `{"allowed_audiences":null}`,
+		{AllowedAudiences: &[]string{}}:                                      `{"allowed_audiences":[]}`,
+		{AllowedAudiences: &[]string{"foo", "bar"}}:                          `{"allowed_audiences":["foo","bar"]}`,
+		{AllowedAudiences: &[]string{"foo", "bar"}, Email: auth0.Bool(true)}: `{"email":true,"allowed_audiences":["foo","bar"]}`,
 	} {
 		payload, err := json.Marshal(connection)
 		assert.NoError(t, err)
@@ -584,11 +585,11 @@ func TestGoogleOauth2Connection_MarshalJSON(t *testing.T) {
 
 func TestGoogleOauth2Connection_UnmarshalJSON(t *testing.T) {
 	for expectedAsString, expected := range map[string]*ConnectionOptionsGoogleOAuth2{
-		`{}`:                                    {},
-		`{"allowed_audiences": null}`:           {},
-		`{"allowed_audiences": ""}`:             {AllowedAudiences: &[]string{}},
-		`{"allowed_audiences": []}`:             {AllowedAudiences: &[]string{}},
-		`{"allowed_audiences": ["foo", "bar"]}`: {AllowedAudiences: &[]string{"foo", "bar"}},
+		`{}`:                          {},
+		`{"allowed_audiences": null}`: {},
+		`{"allowed_audiences": ""}`:   {AllowedAudiences: &[]string{}},
+		`{"allowed_audiences": []}`:   {AllowedAudiences: &[]string{}},
+		`{"allowed_audiences": ["foo", "bar"], "scope": ["email"] }`: {AllowedAudiences: &[]string{"foo", "bar"}, Scope: []interface{}{"email"}},
 	} {
 		var actual *ConnectionOptionsGoogleOAuth2
 		err := json.Unmarshal([]byte(expectedAsString), &actual)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

allowed_audiences can be null, an empty string, or an array of strings. In order to handle this we have to implement a custom marshaller that will map to the expected value to avoid errors.

### 📚 References

Fixes #14

### 🔬 Testing

Unit tests and tested setting the connection to have the listed values and using `Connection.List()` and `Connection.Read("<id>")` are able to return these values correctly

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
