### PR TITLE
Add support for Ping Federate connection

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -950,7 +950,6 @@ type ConnectionOptionsADFS struct {
 // ConnectionOptionsPingFederate is used to configure a Ping Federate Connection.
 type ConnectionOptionsPingFederate struct {
 	SigningCert         *string                            `json:"signingCert,omitempty"`
-	Expires             *string                            `json:"expires,omitempty"`
 	LogoURL             *string                            `json:"icon_url,omitempty"`
 	IdpInitiated        *ConnectionOptionsSAMLIdpInitiated `json:"idpinitiated,omitempty"`
 	TenantDomain        *string                            `json:"tenant_domain,omitempty"`
@@ -962,7 +961,6 @@ type ConnectionOptionsPingFederate struct {
 	PingFederateBaseUrl *string                            `json:"pingFederateBaseUrl,omitempty"`
 	NonPersistentAttrs  *[]string                          `json:"non_persistent_attrs,omitempty"`
 	UpstreamParams      map[string]interface{}             `json:"upstream_params,omitempty"`
-	Thumbprints         *[]string                          `json:"thumbprints,omitempty"`
 	SetUserAttributes   *string                            `json:"set_user_root_attributes,omitempty"`
 }
 

--- a/management/connection.go
+++ b/management/connection.go
@@ -952,9 +952,11 @@ type ConnectionOptionsPingFederate struct {
 	// SigningCert should be used when creating or updating the public key for the Ping Federate server, it will not be
 	// present when reading a connection and instead you should use the Cert field to check the value.
 	SigningCert *string `json:"signingCert,omitempty"`
+
 	// Cert should only be used when reading the connection. It should not be set on creation or update of a connection, instead
 	// SigningCert should be used to update the public key for the Ping Federate server.
-	Cert                *string                            `json:"cert,omitempty"`
+	Cert *string `json:"cert,omitempty"`
+
 	LogoURL             *string                            `json:"icon_url,omitempty"`
 	IdpInitiated        *ConnectionOptionsSAMLIdpInitiated `json:"idpinitiated,omitempty"`
 	TenantDomain        *string                            `json:"tenant_domain,omitempty"`

--- a/management/connection.go
+++ b/management/connection.go
@@ -86,6 +86,8 @@ const (
 	ConnectionStrategyVimeo = "vimeo"
 	// ConnectionStrategyCustom constant.
 	ConnectionStrategyCustom = "custom"
+	// ConnectionStrategyPingFederate constant.
+	ConnectionStrategyPingFederate = "pingfederate"
 )
 
 // Connection is the relationship between Auth0 and a source of users.
@@ -234,6 +236,8 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 			v = &ConnectionOptionsAzureAD{}
 		case ConnectionStrategyADFS:
 			v = &ConnectionOptionsADFS{}
+		case ConnectionStrategyPingFederate:
+			v = &ConnectionOptionsPingFederate{}
 		case ConnectionStrategySAML:
 			v = &ConnectionOptionsSAML{}
 		case ConnectionStrategyGoogleApps:
@@ -941,6 +945,25 @@ type ConnectionOptionsADFS struct {
 
 	// Set to on_first_login to avoid setting user attributes at each login.
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
+}
+
+// ConnectionOptionsPingFederate is used to configure a Ping Federate Connection.
+type ConnectionOptionsPingFederate struct {
+	SigningCert         *string                            `json:"signingCert,omitempty"`
+	Expires             *string                            `json:"expires,omitempty"`
+	LogoURL             *string                            `json:"icon_url,omitempty"`
+	IdpInitiated        *ConnectionOptionsSAMLIdpInitiated `json:"idpinitiated,omitempty"`
+	TenantDomain        *string                            `json:"tenant_domain,omitempty"`
+	DomainAliases       *[]string                          `json:"domain_aliases,omitempty"`
+	SignInEndpoint      *string                            `json:"signInEndpoint,omitempty"`
+	DigestAlgorithm     *string                            `json:"digestAlgorithm,omitempty"`
+	SignSAMLRequest     *bool                              `json:"signSAMLRequest,omitempty"`
+	SignatureAlgorithm  *string                            `json:"signatureAlgorithm,omitempty"`
+	PingFederateBaseUrl *string                            `json:"pingFederateBaseUrl,omitempty"`
+	NonPersistentAttrs  *[]string                          `json:"non_persistent_attrs,omitempty"`
+	UpstreamParams      map[string]interface{}             `json:"upstream_params,omitempty"`
+	Thumbprints         *[]string                          `json:"thumbprints,omitempty"`
+	SetUserAttributes   *string                            `json:"set_user_root_attributes,omitempty"`
 }
 
 // ConnectionOptionsSAML is used to configure a SAML Connection.

--- a/management/connection.go
+++ b/management/connection.go
@@ -949,7 +949,12 @@ type ConnectionOptionsADFS struct {
 
 // ConnectionOptionsPingFederate is used to configure a Ping Federate Connection.
 type ConnectionOptionsPingFederate struct {
-	SigningCert         *string                            `json:"signingCert,omitempty"`
+	// SigningCert should be used when creating or updating the public key for the Ping Federate server, it will not be
+	// present when reading a connection and instead you should use the Cert field to check the value.
+	SigningCert *string `json:"signingCert,omitempty"`
+	// Cert should only be used when reading the connection. It should not be set on creation or update of a connection, instead
+	// SigningCert should be used to update the public key for the Ping Federate server.
+	Cert                *string                            `json:"cert,omitempty"`
 	LogoURL             *string                            `json:"icon_url,omitempty"`
 	IdpInitiated        *ConnectionOptionsSAMLIdpInitiated `json:"idpinitiated,omitempty"`
 	TenantDomain        *string                            `json:"tenant_domain,omitempty"`

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -389,6 +389,42 @@ ZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g
 			},
 		},
 	},
+	{
+		name: "Ping Federate Connection",
+		connection: Connection{
+			Name:     auth0.Stringf("Test-Ping-Federate-Connection-%d", time.Now().Unix()),
+			Strategy: auth0.String("pingfederate"),
+		},
+		options: &ConnectionOptionsPingFederate{
+			PingFederateBaseUrl: auth0.String("https://ping.example.com"),
+			SigningCert: auth0.String(`-----BEGIN CERTIFICATE-----
+MIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD
+VQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQK
+EwtHb29nbGUgSW5jLjEMMAoGA1UECxMDRW5nMQwwCgYDVQQDEwNhZ2wxHTAbBgkq
+hkiG9w0BCQEWDmFnbEBnb29nbGUuY29tMB4XDTA5MDkwOTIyMDU0M1oXDTEwMDkw
+OTIyMDU0M1owajELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAf
+BgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEjMCEGA1UEAxMaZXVyb3Bh
+LnNmby5jb3JwLmdvb2dsZS5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK
+AoICAQC6pgYt7/EibBDumASF+S0qvqdL/f+nouJw2T1Qc8GmXF/iiUcrsgzh/Fd8
+pDhz/T96Qg9IyR4ztuc2MXrmPra+zAuSf5bevFReSqvpIt8Duv0HbDbcqs/XKPfB
+uMDe+of7a9GCywvAZ4ZUJcp0thqD9fKTTjUWOBzHY1uNE4RitrhmJCrbBGXbJ249
+bvgmb7jgdInH2PU7PT55hujvOoIsQW2osXBFRur4pF1wmVh4W4lTLD6pjfIMUcML
+ICHEXEN73PDic8KS3EtNYCwoIld+tpIBjE1QOb1KOyuJBNW6Esw9ALZn7stWdYcE
+qAwvv20egN2tEXqj7Q4/1ccyPZc3PQgC3FJ8Be2mtllM+80qf4dAaQ/fWvCtOrQ5
+pnfe9juQvCo8Y0VGlFcrSys/MzSg9LJ/24jZVgzQved/Qupsp89wVidwIzjt+WdS
+fyWfH0/v1aQLvu5cMYuW//C0W2nlYziL5blETntM8My2ybNARy3ICHxCBv2RNtPI
+WQVm+E9/W5rwh2IJR4DHn2LHwUVmT/hHNTdBLl5Uhwr4Wc7JhE7AVqb14pVNz1lr
+5jxsp//ncIwftb7mZQ3DF03Yna+jJhpzx8CQoeLT6aQCHyzmH68MrHHT4MALPyUs
+Pomjn71GNTtDeWAXibjCgdL6iHACCF6Htbl0zGlG0OAK+bdn0QIDAQABMA0GCSqG
+SIb3DQEBBQUAA4GBAOKnQDtqBV24vVqvesL5dnmyFpFPXBn3WdFfwD6DzEb21UVG
+5krmJiu+ViipORJPGMkgoL6BjU21XI95VQbun5P8vvg8Z+FnFsvRFY3e1CCzAVQY
+ZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g
+-----END CERTIFICATE-----`),
+			SignSAMLRequest:    auth0.Bool(true),
+			SignatureAlgorithm: auth0.String("rsa-sha256"),
+			DigestAlgorithm:    auth0.String("sha256"),
+		},
+	},
 }
 
 type connectionTestCase struct {
@@ -475,8 +511,9 @@ func TestConnectionManager_Update(t *testing.T) {
 			if testCase.connection.GetStrategy() == "oidc" ||
 				testCase.connection.GetStrategy() == "samlp" ||
 				testCase.connection.GetStrategy() == "okta" ||
-				testCase.connection.GetStrategy() == "adfs" {
-				t.Skip("Skipping because we can't create an oidc, okta, samlp or adfs connection with no options")
+				testCase.connection.GetStrategy() == "adfs" ||
+				testCase.connection.GetStrategy() == "pingfederate" {
+				t.Skip("Skipping because we can't create an oidc, okta, samlp, adfs, or pingfederate connection with no options")
 			}
 
 			configureHTTPTestRecordings(t)

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3482,6 +3482,14 @@ func (c *ConnectionOptionsOTP) String() string {
 	return Stringify(c)
 }
 
+// GetCert returns the Cert field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetCert() string {
+	if c == nil || c.Cert == nil {
+		return ""
+	}
+	return *c.Cert
+}
+
 // GetDigestAlgorithm returns the DigestAlgorithm field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsPingFederate) GetDigestAlgorithm() string {
 	if c == nil || c.DigestAlgorithm == nil {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3482,6 +3482,107 @@ func (c *ConnectionOptionsOTP) String() string {
 	return Stringify(c)
 }
 
+// GetDigestAlgorithm returns the DigestAlgorithm field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetDigestAlgorithm() string {
+	if c == nil || c.DigestAlgorithm == nil {
+		return ""
+	}
+	return *c.DigestAlgorithm
+}
+
+// GetDomainAliases returns the DomainAliases field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetDomainAliases() []string {
+	if c == nil || c.DomainAliases == nil {
+		return nil
+	}
+	return *c.DomainAliases
+}
+
+// GetIdpInitiated returns the IdpInitiated field.
+func (c *ConnectionOptionsPingFederate) GetIdpInitiated() *ConnectionOptionsSAMLIdpInitiated {
+	if c == nil {
+		return nil
+	}
+	return c.IdpInitiated
+}
+
+// GetLogoURL returns the LogoURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetLogoURL() string {
+	if c == nil || c.LogoURL == nil {
+		return ""
+	}
+	return *c.LogoURL
+}
+
+// GetNonPersistentAttrs returns the NonPersistentAttrs field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetNonPersistentAttrs() []string {
+	if c == nil || c.NonPersistentAttrs == nil {
+		return nil
+	}
+	return *c.NonPersistentAttrs
+}
+
+// GetPingFederateBaseUrl returns the PingFederateBaseUrl field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetPingFederateBaseUrl() string {
+	if c == nil || c.PingFederateBaseUrl == nil {
+		return ""
+	}
+	return *c.PingFederateBaseUrl
+}
+
+// GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetSetUserAttributes() string {
+	if c == nil || c.SetUserAttributes == nil {
+		return ""
+	}
+	return *c.SetUserAttributes
+}
+
+// GetSignatureAlgorithm returns the SignatureAlgorithm field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetSignatureAlgorithm() string {
+	if c == nil || c.SignatureAlgorithm == nil {
+		return ""
+	}
+	return *c.SignatureAlgorithm
+}
+
+// GetSignInEndpoint returns the SignInEndpoint field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetSignInEndpoint() string {
+	if c == nil || c.SignInEndpoint == nil {
+		return ""
+	}
+	return *c.SignInEndpoint
+}
+
+// GetSigningCert returns the SigningCert field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetSigningCert() string {
+	if c == nil || c.SigningCert == nil {
+		return ""
+	}
+	return *c.SigningCert
+}
+
+// GetSignSAMLRequest returns the SignSAMLRequest field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetSignSAMLRequest() bool {
+	if c == nil || c.SignSAMLRequest == nil {
+		return false
+	}
+	return *c.SignSAMLRequest
+}
+
+// GetTenantDomain returns the TenantDomain field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetTenantDomain() string {
+	if c == nil || c.TenantDomain == nil {
+		return ""
+	}
+	return *c.TenantDomain
+}
+
+// String returns a string representation of ConnectionOptionsPingFederate.
+func (c *ConnectionOptionsPingFederate) String() string {
+	return Stringify(c)
+}
+
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSalesforce) GetClientID() string {
 	if c == nil || c.ClientID == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -4406,6 +4406,16 @@ func TestConnectionOptionsOTP_String(t *testing.T) {
 	}
 }
 
+func TestConnectionOptionsPingFederate_GetCert(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{Cert: &zeroValue}
+	c.GetCert()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetCert()
+	c = nil
+	c.GetCert()
+}
+
 func TestConnectionOptionsPingFederate_GetDigestAlgorithm(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsPingFederate{DigestAlgorithm: &zeroValue}

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -4406,6 +4406,131 @@ func TestConnectionOptionsOTP_String(t *testing.T) {
 	}
 }
 
+func TestConnectionOptionsPingFederate_GetDigestAlgorithm(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{DigestAlgorithm: &zeroValue}
+	c.GetDigestAlgorithm()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetDigestAlgorithm()
+	c = nil
+	c.GetDigestAlgorithm()
+}
+
+func TestConnectionOptionsPingFederate_GetDomainAliases(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsPingFederate{DomainAliases: &zeroValue}
+	c.GetDomainAliases()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetDomainAliases()
+	c = nil
+	c.GetDomainAliases()
+}
+
+func TestConnectionOptionsPingFederate_GetIdpInitiated(tt *testing.T) {
+	c := &ConnectionOptionsPingFederate{}
+	c.GetIdpInitiated()
+	c = nil
+	c.GetIdpInitiated()
+}
+
+func TestConnectionOptionsPingFederate_GetLogoURL(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{LogoURL: &zeroValue}
+	c.GetLogoURL()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetLogoURL()
+	c = nil
+	c.GetLogoURL()
+}
+
+func TestConnectionOptionsPingFederate_GetNonPersistentAttrs(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsPingFederate{NonPersistentAttrs: &zeroValue}
+	c.GetNonPersistentAttrs()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetNonPersistentAttrs()
+	c = nil
+	c.GetNonPersistentAttrs()
+}
+
+func TestConnectionOptionsPingFederate_GetPingFederateBaseUrl(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{PingFederateBaseUrl: &zeroValue}
+	c.GetPingFederateBaseUrl()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetPingFederateBaseUrl()
+	c = nil
+	c.GetPingFederateBaseUrl()
+}
+
+func TestConnectionOptionsPingFederate_GetSetUserAttributes(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{SetUserAttributes: &zeroValue}
+	c.GetSetUserAttributes()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetSetUserAttributes()
+	c = nil
+	c.GetSetUserAttributes()
+}
+
+func TestConnectionOptionsPingFederate_GetSignatureAlgorithm(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{SignatureAlgorithm: &zeroValue}
+	c.GetSignatureAlgorithm()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetSignatureAlgorithm()
+	c = nil
+	c.GetSignatureAlgorithm()
+}
+
+func TestConnectionOptionsPingFederate_GetSignInEndpoint(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{SignInEndpoint: &zeroValue}
+	c.GetSignInEndpoint()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetSignInEndpoint()
+	c = nil
+	c.GetSignInEndpoint()
+}
+
+func TestConnectionOptionsPingFederate_GetSigningCert(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{SigningCert: &zeroValue}
+	c.GetSigningCert()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetSigningCert()
+	c = nil
+	c.GetSigningCert()
+}
+
+func TestConnectionOptionsPingFederate_GetSignSAMLRequest(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsPingFederate{SignSAMLRequest: &zeroValue}
+	c.GetSignSAMLRequest()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetSignSAMLRequest()
+	c = nil
+	c.GetSignSAMLRequest()
+}
+
+func TestConnectionOptionsPingFederate_GetTenantDomain(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{TenantDomain: &zeroValue}
+	c.GetTenantDomain()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetTenantDomain()
+	c = nil
+	c.GetTenantDomain()
+}
+
+func TestConnectionOptionsPingFederate_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsPingFederate{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestConnectionOptionsSalesforce_GetClientID(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsSalesforce{ClientID: &zeroValue}

--- a/test/data/recordings/TestConnectionManager_Create/It_can_successfully_create_a_Ping_Federate_Connection.yaml
+++ b/test/data/recordings/TestConnectionManager_Create/It_can_successfully_create_a_Ping_Federate_Connection.yaml
@@ -1,0 +1,74 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1676
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Ping-Federate-Connection-1678372717","strategy":"pingfederate","options":{"signingCert":"-----BEGIN CERTIFICATE-----\nMIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD\nVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQK\nEwtHb29nbGUgSW5jLjEMMAoGA1UECxMDRW5nMQwwCgYDVQQDEwNhZ2wxHTAbBgkq\nhkiG9w0BCQEWDmFnbEBnb29nbGUuY29tMB4XDTA5MDkwOTIyMDU0M1oXDTEwMDkw\nOTIyMDU0M1owajELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAf\nBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEjMCEGA1UEAxMaZXVyb3Bh\nLnNmby5jb3JwLmdvb2dsZS5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK\nAoICAQC6pgYt7/EibBDumASF+S0qvqdL/f+nouJw2T1Qc8GmXF/iiUcrsgzh/Fd8\npDhz/T96Qg9IyR4ztuc2MXrmPra+zAuSf5bevFReSqvpIt8Duv0HbDbcqs/XKPfB\nuMDe+of7a9GCywvAZ4ZUJcp0thqD9fKTTjUWOBzHY1uNE4RitrhmJCrbBGXbJ249\nbvgmb7jgdInH2PU7PT55hujvOoIsQW2osXBFRur4pF1wmVh4W4lTLD6pjfIMUcML\nICHEXEN73PDic8KS3EtNYCwoIld+tpIBjE1QOb1KOyuJBNW6Esw9ALZn7stWdYcE\nqAwvv20egN2tEXqj7Q4/1ccyPZc3PQgC3FJ8Be2mtllM+80qf4dAaQ/fWvCtOrQ5\npnfe9juQvCo8Y0VGlFcrSys/MzSg9LJ/24jZVgzQved/Qupsp89wVidwIzjt+WdS\nfyWfH0/v1aQLvu5cMYuW//C0W2nlYziL5blETntM8My2ybNARy3ICHxCBv2RNtPI\nWQVm+E9/W5rwh2IJR4DHn2LHwUVmT/hHNTdBLl5Uhwr4Wc7JhE7AVqb14pVNz1lr\n5jxsp//ncIwftb7mZQ3DF03Yna+jJhpzx8CQoeLT6aQCHyzmH68MrHHT4MALPyUs\nPomjn71GNTtDeWAXibjCgdL6iHACCF6Htbl0zGlG0OAK+bdn0QIDAQABMA0GCSqG\nSIb3DQEBBQUAA4GBAOKnQDtqBV24vVqvesL5dnmyFpFPXBn3WdFfwD6DzEb21UVG\n5krmJiu+ViipORJPGMkgoL6BjU21XI95VQbun5P8vvg8Z+FnFsvRFY3e1CCzAVQY\nZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g\n-----END CERTIFICATE-----","digestAlgorithm":"sha256","signSAMLRequest":true,"signatureAlgorithm":"rsa-sha256","pingFederateBaseUrl":"https://ping.example.com"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_R96acQao7HOUjVnE","options":{"digestAlgorithm":"sha256","signSAMLRequest":true,"signatureAlgorithm":"rsa-sha256","pingFederateBaseUrl":"https://ping.example.com","signInEndpoint":"https://ping.example.com","expires":"2010-09-09T22:05:43.000Z","subject":{"countryName":"AU","stateOrProvinceName":"Some-State","organizationName":"Internet Widgits Pty Ltd","commonName":"europa.sfo.corp.google.com"},"thumbprints":["b93611bf2cfdb64110c7aae1485718cc9385e151"],"cert":"-----BEGIN CERTIFICATE-----\nMIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD\nVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQK\nEwtHb29nbGUgSW5jLjEMMAoGA1UECxMDRW5nMQwwCgYDVQQDEwNhZ2wxHTAbBgkq\nhkiG9w0BCQEWDmFnbEBnb29nbGUuY29tMB4XDTA5MDkwOTIyMDU0M1oXDTEwMDkw\nOTIyMDU0M1owajELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAf\nBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEjMCEGA1UEAxMaZXVyb3Bh\nLnNmby5jb3JwLmdvb2dsZS5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK\nAoICAQC6pgYt7/EibBDumASF+S0qvqdL/f+nouJw2T1Qc8GmXF/iiUcrsgzh/Fd8\npDhz/T96Qg9IyR4ztuc2MXrmPra+zAuSf5bevFReSqvpIt8Duv0HbDbcqs/XKPfB\nuMDe+of7a9GCywvAZ4ZUJcp0thqD9fKTTjUWOBzHY1uNE4RitrhmJCrbBGXbJ249\nbvgmb7jgdInH2PU7PT55hujvOoIsQW2osXBFRur4pF1wmVh4W4lTLD6pjfIMUcML\nICHEXEN73PDic8KS3EtNYCwoIld+tpIBjE1QOb1KOyuJBNW6Esw9ALZn7stWdYcE\nqAwvv20egN2tEXqj7Q4/1ccyPZc3PQgC3FJ8Be2mtllM+80qf4dAaQ/fWvCtOrQ5\npnfe9juQvCo8Y0VGlFcrSys/MzSg9LJ/24jZVgzQved/Qupsp89wVidwIzjt+WdS\nfyWfH0/v1aQLvu5cMYuW//C0W2nlYziL5blETntM8My2ybNARy3ICHxCBv2RNtPI\nWQVm+E9/W5rwh2IJR4DHn2LHwUVmT/hHNTdBLl5Uhwr4Wc7JhE7AVqb14pVNz1lr\n5jxsp//ncIwftb7mZQ3DF03Yna+jJhpzx8CQoeLT6aQCHyzmH68MrHHT4MALPyUs\nPomjn71GNTtDeWAXibjCgdL6iHACCF6Htbl0zGlG0OAK+bdn0QIDAQABMA0GCSqG\nSIb3DQEBBQUAA4GBAOKnQDtqBV24vVqvesL5dnmyFpFPXBn3WdFfwD6DzEb21UVG\n5krmJiu+ViipORJPGMkgoL6BjU21XI95VQbun5P8vvg8Z+FnFsvRFY3e1CCzAVQY\nZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g\n-----END CERTIFICATE-----"},"strategy":"pingfederate","name":"Test-Ping-Federate-Connection-1678372717","provisioning_ticket_url":"https://go-auth0-dev.eu.auth0.com.eu.auth0.com/p/pingfederate/mw8OUGSy","is_domain_connection":false,"show_as_button":false,"enabled_clients":[],"realms":["Test-Ping-Federate-Connection-1678372717"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 355.842625ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_R96acQao7HOUjVnE
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2023-03-09T14:38:38.467Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 142.75ms

--- a/test/data/recordings/TestConnectionManager_Read/It_can_successfully_read_a_Ping_Federate_Connection.yaml
+++ b/test/data/recordings/TestConnectionManager_Read/It_can_successfully_read_a_Ping_Federate_Connection.yaml
@@ -1,0 +1,145 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1676
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Ping-Federate-Connection-1678372744","strategy":"pingfederate","options":{"signingCert":"-----BEGIN CERTIFICATE-----\nMIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD\nVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQK\nEwtHb29nbGUgSW5jLjEMMAoGA1UECxMDRW5nMQwwCgYDVQQDEwNhZ2wxHTAbBgkq\nhkiG9w0BCQEWDmFnbEBnb29nbGUuY29tMB4XDTA5MDkwOTIyMDU0M1oXDTEwMDkw\nOTIyMDU0M1owajELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAf\nBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEjMCEGA1UEAxMaZXVyb3Bh\nLnNmby5jb3JwLmdvb2dsZS5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK\nAoICAQC6pgYt7/EibBDumASF+S0qvqdL/f+nouJw2T1Qc8GmXF/iiUcrsgzh/Fd8\npDhz/T96Qg9IyR4ztuc2MXrmPra+zAuSf5bevFReSqvpIt8Duv0HbDbcqs/XKPfB\nuMDe+of7a9GCywvAZ4ZUJcp0thqD9fKTTjUWOBzHY1uNE4RitrhmJCrbBGXbJ249\nbvgmb7jgdInH2PU7PT55hujvOoIsQW2osXBFRur4pF1wmVh4W4lTLD6pjfIMUcML\nICHEXEN73PDic8KS3EtNYCwoIld+tpIBjE1QOb1KOyuJBNW6Esw9ALZn7stWdYcE\nqAwvv20egN2tEXqj7Q4/1ccyPZc3PQgC3FJ8Be2mtllM+80qf4dAaQ/fWvCtOrQ5\npnfe9juQvCo8Y0VGlFcrSys/MzSg9LJ/24jZVgzQved/Qupsp89wVidwIzjt+WdS\nfyWfH0/v1aQLvu5cMYuW//C0W2nlYziL5blETntM8My2ybNARy3ICHxCBv2RNtPI\nWQVm+E9/W5rwh2IJR4DHn2LHwUVmT/hHNTdBLl5Uhwr4Wc7JhE7AVqb14pVNz1lr\n5jxsp//ncIwftb7mZQ3DF03Yna+jJhpzx8CQoeLT6aQCHyzmH68MrHHT4MALPyUs\nPomjn71GNTtDeWAXibjCgdL6iHACCF6Htbl0zGlG0OAK+bdn0QIDAQABMA0GCSqG\nSIb3DQEBBQUAA4GBAOKnQDtqBV24vVqvesL5dnmyFpFPXBn3WdFfwD6DzEb21UVG\n5krmJiu+ViipORJPGMkgoL6BjU21XI95VQbun5P8vvg8Z+FnFsvRFY3e1CCzAVQY\nZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g\n-----END CERTIFICATE-----","digestAlgorithm":"sha256","signSAMLRequest":true,"signatureAlgorithm":"rsa-sha256","pingFederateBaseUrl":"https://ping.example.com"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_7q53TRfAGRRMshAO","options":{"digestAlgorithm":"sha256","signSAMLRequest":true,"signatureAlgorithm":"rsa-sha256","pingFederateBaseUrl":"https://ping.example.com","signInEndpoint":"https://ping.example.com","expires":"2010-09-09T22:05:43.000Z","subject":{"countryName":"AU","stateOrProvinceName":"Some-State","organizationName":"Internet Widgits Pty Ltd","commonName":"europa.sfo.corp.google.com"},"thumbprints":["b93611bf2cfdb64110c7aae1485718cc9385e151"],"cert":"-----BEGIN CERTIFICATE-----\nMIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD\nVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQK\nEwtHb29nbGUgSW5jLjEMMAoGA1UECxMDRW5nMQwwCgYDVQQDEwNhZ2wxHTAbBgkq\nhkiG9w0BCQEWDmFnbEBnb29nbGUuY29tMB4XDTA5MDkwOTIyMDU0M1oXDTEwMDkw\nOTIyMDU0M1owajELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAf\nBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEjMCEGA1UEAxMaZXVyb3Bh\nLnNmby5jb3JwLmdvb2dsZS5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK\nAoICAQC6pgYt7/EibBDumASF+S0qvqdL/f+nouJw2T1Qc8GmXF/iiUcrsgzh/Fd8\npDhz/T96Qg9IyR4ztuc2MXrmPra+zAuSf5bevFReSqvpIt8Duv0HbDbcqs/XKPfB\nuMDe+of7a9GCywvAZ4ZUJcp0thqD9fKTTjUWOBzHY1uNE4RitrhmJCrbBGXbJ249\nbvgmb7jgdInH2PU7PT55hujvOoIsQW2osXBFRur4pF1wmVh4W4lTLD6pjfIMUcML\nICHEXEN73PDic8KS3EtNYCwoIld+tpIBjE1QOb1KOyuJBNW6Esw9ALZn7stWdYcE\nqAwvv20egN2tEXqj7Q4/1ccyPZc3PQgC3FJ8Be2mtllM+80qf4dAaQ/fWvCtOrQ5\npnfe9juQvCo8Y0VGlFcrSys/MzSg9LJ/24jZVgzQved/Qupsp89wVidwIzjt+WdS\nfyWfH0/v1aQLvu5cMYuW//C0W2nlYziL5blETntM8My2ybNARy3ICHxCBv2RNtPI\nWQVm+E9/W5rwh2IJR4DHn2LHwUVmT/hHNTdBLl5Uhwr4Wc7JhE7AVqb14pVNz1lr\n5jxsp//ncIwftb7mZQ3DF03Yna+jJhpzx8CQoeLT6aQCHyzmH68MrHHT4MALPyUs\nPomjn71GNTtDeWAXibjCgdL6iHACCF6Htbl0zGlG0OAK+bdn0QIDAQABMA0GCSqG\nSIb3DQEBBQUAA4GBAOKnQDtqBV24vVqvesL5dnmyFpFPXBn3WdFfwD6DzEb21UVG\n5krmJiu+ViipORJPGMkgoL6BjU21XI95VQbun5P8vvg8Z+FnFsvRFY3e1CCzAVQY\nZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g\n-----END CERTIFICATE-----"},"strategy":"pingfederate","name":"Test-Ping-Federate-Connection-1678372744","provisioning_ticket_url":"https://go-auth0-dev.eu.auth0.com.eu.auth0.com/p/pingfederate/psIoTLpq","is_domain_connection":false,"show_as_button":false,"enabled_clients":[],"realms":["Test-Ping-Federate-Connection-1678372744"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 369.499875ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_7q53TRfAGRRMshAO
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_7q53TRfAGRRMshAO","options":{"cert":"-----BEGIN CERTIFICATE-----\nMIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD\nVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQK\nEwtHb29nbGUgSW5jLjEMMAoGA1UECxMDRW5nMQwwCgYDVQQDEwNhZ2wxHTAbBgkq\nhkiG9w0BCQEWDmFnbEBnb29nbGUuY29tMB4XDTA5MDkwOTIyMDU0M1oXDTEwMDkw\nOTIyMDU0M1owajELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAf\nBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEjMCEGA1UEAxMaZXVyb3Bh\nLnNmby5jb3JwLmdvb2dsZS5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK\nAoICAQC6pgYt7/EibBDumASF+S0qvqdL/f+nouJw2T1Qc8GmXF/iiUcrsgzh/Fd8\npDhz/T96Qg9IyR4ztuc2MXrmPra+zAuSf5bevFReSqvpIt8Duv0HbDbcqs/XKPfB\nuMDe+of7a9GCywvAZ4ZUJcp0thqD9fKTTjUWOBzHY1uNE4RitrhmJCrbBGXbJ249\nbvgmb7jgdInH2PU7PT55hujvOoIsQW2osXBFRur4pF1wmVh4W4lTLD6pjfIMUcML\nICHEXEN73PDic8KS3EtNYCwoIld+tpIBjE1QOb1KOyuJBNW6Esw9ALZn7stWdYcE\nqAwvv20egN2tEXqj7Q4/1ccyPZc3PQgC3FJ8Be2mtllM+80qf4dAaQ/fWvCtOrQ5\npnfe9juQvCo8Y0VGlFcrSys/MzSg9LJ/24jZVgzQved/Qupsp89wVidwIzjt+WdS\nfyWfH0/v1aQLvu5cMYuW//C0W2nlYziL5blETntM8My2ybNARy3ICHxCBv2RNtPI\nWQVm+E9/W5rwh2IJR4DHn2LHwUVmT/hHNTdBLl5Uhwr4Wc7JhE7AVqb14pVNz1lr\n5jxsp//ncIwftb7mZQ3DF03Yna+jJhpzx8CQoeLT6aQCHyzmH68MrHHT4MALPyUs\nPomjn71GNTtDeWAXibjCgdL6iHACCF6Htbl0zGlG0OAK+bdn0QIDAQABMA0GCSqG\nSIb3DQEBBQUAA4GBAOKnQDtqBV24vVqvesL5dnmyFpFPXBn3WdFfwD6DzEb21UVG\n5krmJiu+ViipORJPGMkgoL6BjU21XI95VQbun5P8vvg8Z+FnFsvRFY3e1CCzAVQY\nZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g\n-----END CERTIFICATE-----","expires":"2010-09-09T22:05:43.000Z","subject":{"commonName":"europa.sfo.corp.google.com","countryName":"AU","organizationName":"Internet Widgits Pty Ltd","stateOrProvinceName":"Some-State"},"thumbprints":["b93611bf2cfdb64110c7aae1485718cc9385e151"],"signInEndpoint":"https://ping.example.com","digestAlgorithm":"sha256","signSAMLRequest":true,"signatureAlgorithm":"rsa-sha256","pingFederateBaseUrl":"https://ping.example.com"},"strategy":"pingfederate","name":"Test-Ping-Federate-Connection-1678372744","provisioning_ticket_url":"https://go-auth0-dev.eu.auth0.com.eu.auth0.com/p/pingfederate/psIoTLpq","is_domain_connection":false,"show_as_button":false,"enabled_clients":[],"realms":["Test-Ping-Federate-Connection-1678372744"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 172.967209ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_7q53TRfAGRRMshAO
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 153.580917ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_7q53TRfAGRRMshAO
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 116.072625ms

--- a/test/data/recordings/TestConnectionManager_ReadByName/It_can_successfully_find_a_Ping_Federate_Connection_by_its_name.yaml
+++ b/test/data/recordings/TestConnectionManager_ReadByName/It_can_successfully_find_a_Ping_Federate_Connection_by_its_name.yaml
@@ -1,0 +1,145 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1676
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Ping-Federate-Connection-1678372744","strategy":"pingfederate","options":{"signingCert":"-----BEGIN CERTIFICATE-----\nMIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD\nVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQK\nEwtHb29nbGUgSW5jLjEMMAoGA1UECxMDRW5nMQwwCgYDVQQDEwNhZ2wxHTAbBgkq\nhkiG9w0BCQEWDmFnbEBnb29nbGUuY29tMB4XDTA5MDkwOTIyMDU0M1oXDTEwMDkw\nOTIyMDU0M1owajELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAf\nBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEjMCEGA1UEAxMaZXVyb3Bh\nLnNmby5jb3JwLmdvb2dsZS5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK\nAoICAQC6pgYt7/EibBDumASF+S0qvqdL/f+nouJw2T1Qc8GmXF/iiUcrsgzh/Fd8\npDhz/T96Qg9IyR4ztuc2MXrmPra+zAuSf5bevFReSqvpIt8Duv0HbDbcqs/XKPfB\nuMDe+of7a9GCywvAZ4ZUJcp0thqD9fKTTjUWOBzHY1uNE4RitrhmJCrbBGXbJ249\nbvgmb7jgdInH2PU7PT55hujvOoIsQW2osXBFRur4pF1wmVh4W4lTLD6pjfIMUcML\nICHEXEN73PDic8KS3EtNYCwoIld+tpIBjE1QOb1KOyuJBNW6Esw9ALZn7stWdYcE\nqAwvv20egN2tEXqj7Q4/1ccyPZc3PQgC3FJ8Be2mtllM+80qf4dAaQ/fWvCtOrQ5\npnfe9juQvCo8Y0VGlFcrSys/MzSg9LJ/24jZVgzQved/Qupsp89wVidwIzjt+WdS\nfyWfH0/v1aQLvu5cMYuW//C0W2nlYziL5blETntM8My2ybNARy3ICHxCBv2RNtPI\nWQVm+E9/W5rwh2IJR4DHn2LHwUVmT/hHNTdBLl5Uhwr4Wc7JhE7AVqb14pVNz1lr\n5jxsp//ncIwftb7mZQ3DF03Yna+jJhpzx8CQoeLT6aQCHyzmH68MrHHT4MALPyUs\nPomjn71GNTtDeWAXibjCgdL6iHACCF6Htbl0zGlG0OAK+bdn0QIDAQABMA0GCSqG\nSIb3DQEBBQUAA4GBAOKnQDtqBV24vVqvesL5dnmyFpFPXBn3WdFfwD6DzEb21UVG\n5krmJiu+ViipORJPGMkgoL6BjU21XI95VQbun5P8vvg8Z+FnFsvRFY3e1CCzAVQY\nZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g\n-----END CERTIFICATE-----","digestAlgorithm":"sha256","signSAMLRequest":true,"signatureAlgorithm":"rsa-sha256","pingFederateBaseUrl":"https://ping.example.com"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_F0lHxIBUHlskwlKP","options":{"digestAlgorithm":"sha256","signSAMLRequest":true,"signatureAlgorithm":"rsa-sha256","pingFederateBaseUrl":"https://ping.example.com","signInEndpoint":"https://ping.example.com","expires":"2010-09-09T22:05:43.000Z","subject":{"countryName":"AU","stateOrProvinceName":"Some-State","organizationName":"Internet Widgits Pty Ltd","commonName":"europa.sfo.corp.google.com"},"thumbprints":["b93611bf2cfdb64110c7aae1485718cc9385e151"],"cert":"-----BEGIN CERTIFICATE-----\nMIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD\nVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQK\nEwtHb29nbGUgSW5jLjEMMAoGA1UECxMDRW5nMQwwCgYDVQQDEwNhZ2wxHTAbBgkq\nhkiG9w0BCQEWDmFnbEBnb29nbGUuY29tMB4XDTA5MDkwOTIyMDU0M1oXDTEwMDkw\nOTIyMDU0M1owajELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAf\nBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEjMCEGA1UEAxMaZXVyb3Bh\nLnNmby5jb3JwLmdvb2dsZS5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK\nAoICAQC6pgYt7/EibBDumASF+S0qvqdL/f+nouJw2T1Qc8GmXF/iiUcrsgzh/Fd8\npDhz/T96Qg9IyR4ztuc2MXrmPra+zAuSf5bevFReSqvpIt8Duv0HbDbcqs/XKPfB\nuMDe+of7a9GCywvAZ4ZUJcp0thqD9fKTTjUWOBzHY1uNE4RitrhmJCrbBGXbJ249\nbvgmb7jgdInH2PU7PT55hujvOoIsQW2osXBFRur4pF1wmVh4W4lTLD6pjfIMUcML\nICHEXEN73PDic8KS3EtNYCwoIld+tpIBjE1QOb1KOyuJBNW6Esw9ALZn7stWdYcE\nqAwvv20egN2tEXqj7Q4/1ccyPZc3PQgC3FJ8Be2mtllM+80qf4dAaQ/fWvCtOrQ5\npnfe9juQvCo8Y0VGlFcrSys/MzSg9LJ/24jZVgzQved/Qupsp89wVidwIzjt+WdS\nfyWfH0/v1aQLvu5cMYuW//C0W2nlYziL5blETntM8My2ybNARy3ICHxCBv2RNtPI\nWQVm+E9/W5rwh2IJR4DHn2LHwUVmT/hHNTdBLl5Uhwr4Wc7JhE7AVqb14pVNz1lr\n5jxsp//ncIwftb7mZQ3DF03Yna+jJhpzx8CQoeLT6aQCHyzmH68MrHHT4MALPyUs\nPomjn71GNTtDeWAXibjCgdL6iHACCF6Htbl0zGlG0OAK+bdn0QIDAQABMA0GCSqG\nSIb3DQEBBQUAA4GBAOKnQDtqBV24vVqvesL5dnmyFpFPXBn3WdFfwD6DzEb21UVG\n5krmJiu+ViipORJPGMkgoL6BjU21XI95VQbun5P8vvg8Z+FnFsvRFY3e1CCzAVQY\nZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g\n-----END CERTIFICATE-----"},"strategy":"pingfederate","name":"Test-Ping-Federate-Connection-1678372744","provisioning_ticket_url":"https://go-auth0-dev.eu.auth0.com.eu.auth0.com/p/pingfederate/D1GyTN05","is_domain_connection":false,"show_as_button":false,"enabled_clients":[],"realms":["Test-Ping-Federate-Connection-1678372744"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 170.465166ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections?include_totals=true&name=Test-Ping-Federate-Connection-1678372744&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"total":1,"start":0,"limit":50,"connections":[{"id":"con_F0lHxIBUHlskwlKP","options":{"cert":"-----BEGIN CERTIFICATE-----\nMIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD\nVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQK\nEwtHb29nbGUgSW5jLjEMMAoGA1UECxMDRW5nMQwwCgYDVQQDEwNhZ2wxHTAbBgkq\nhkiG9w0BCQEWDmFnbEBnb29nbGUuY29tMB4XDTA5MDkwOTIyMDU0M1oXDTEwMDkw\nOTIyMDU0M1owajELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAf\nBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEjMCEGA1UEAxMaZXVyb3Bh\nLnNmby5jb3JwLmdvb2dsZS5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK\nAoICAQC6pgYt7/EibBDumASF+S0qvqdL/f+nouJw2T1Qc8GmXF/iiUcrsgzh/Fd8\npDhz/T96Qg9IyR4ztuc2MXrmPra+zAuSf5bevFReSqvpIt8Duv0HbDbcqs/XKPfB\nuMDe+of7a9GCywvAZ4ZUJcp0thqD9fKTTjUWOBzHY1uNE4RitrhmJCrbBGXbJ249\nbvgmb7jgdInH2PU7PT55hujvOoIsQW2osXBFRur4pF1wmVh4W4lTLD6pjfIMUcML\nICHEXEN73PDic8KS3EtNYCwoIld+tpIBjE1QOb1KOyuJBNW6Esw9ALZn7stWdYcE\nqAwvv20egN2tEXqj7Q4/1ccyPZc3PQgC3FJ8Be2mtllM+80qf4dAaQ/fWvCtOrQ5\npnfe9juQvCo8Y0VGlFcrSys/MzSg9LJ/24jZVgzQved/Qupsp89wVidwIzjt+WdS\nfyWfH0/v1aQLvu5cMYuW//C0W2nlYziL5blETntM8My2ybNARy3ICHxCBv2RNtPI\nWQVm+E9/W5rwh2IJR4DHn2LHwUVmT/hHNTdBLl5Uhwr4Wc7JhE7AVqb14pVNz1lr\n5jxsp//ncIwftb7mZQ3DF03Yna+jJhpzx8CQoeLT6aQCHyzmH68MrHHT4MALPyUs\nPomjn71GNTtDeWAXibjCgdL6iHACCF6Htbl0zGlG0OAK+bdn0QIDAQABMA0GCSqG\nSIb3DQEBBQUAA4GBAOKnQDtqBV24vVqvesL5dnmyFpFPXBn3WdFfwD6DzEb21UVG\n5krmJiu+ViipORJPGMkgoL6BjU21XI95VQbun5P8vvg8Z+FnFsvRFY3e1CCzAVQY\nZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g\n-----END CERTIFICATE-----","expires":"2010-09-09T22:05:43.000Z","subject":{"commonName":"europa.sfo.corp.google.com","countryName":"AU","organizationName":"Internet Widgits Pty Ltd","stateOrProvinceName":"Some-State"},"thumbprints":["b93611bf2cfdb64110c7aae1485718cc9385e151"],"signInEndpoint":"https://ping.example.com","digestAlgorithm":"sha256","signSAMLRequest":true,"signatureAlgorithm":"rsa-sha256","pingFederateBaseUrl":"https://ping.example.com"},"strategy":"pingfederate","name":"Test-Ping-Federate-Connection-1678372744","provisioning_ticket_url":"https://go-auth0-dev.eu.auth0.com.eu.auth0.com/p/pingfederate/D1GyTN05","is_domain_connection":false,"show_as_button":false,"realms":["Test-Ping-Federate-Connection-1678372744"],"enabled_clients":[]}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 99.817875ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_F0lHxIBUHlskwlKP
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 143.339042ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_F0lHxIBUHlskwlKP
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 93.1565ms


### PR DESCRIPTION
### 🔧 Changes

This adds support for the Ping Federate connection, it does not expose the `expires`, `subject`, or `thumbprints` properties as these are populated on creation/update by the backend based on the provided cert (which can be a string representing the contents of a pem file, or a base64 representation of the contents of a pem file).

In v1 we could potentially look into providing read-only properties such as these in a way that disallows a developer from overriding them.

### 📚 References

terraform-provider-auth0/issues/428

### 🔬 Testing

Test creating and updating the properties of a Ping Federate connection locally alongside the unit tests added

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
