### PR TITLE
Support setting disable_self_service_change_password on database connections

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -311,6 +311,9 @@ type ConnectionOptions struct {
 	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`
 
 	UpstreamParams map[string]interface{} `json:"upstream_params,omitempty"`
+
+	// Set to true to stop the "Forgot Password" being displayed on login pages
+	DisableSelfServiceChangePassword *bool `json:"disable_self_service_change_password,omitempty"`
 }
 
 // ConnectionOptionsOkta is used to configure an Okta Workforce Connection.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1617,6 +1617,14 @@ func (c *ConnectionOptions) GetCustomScripts() map[string]string {
 	return *c.CustomScripts
 }
 
+// GetDisableSelfServiceChangePassword returns the DisableSelfServiceChangePassword field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptions) GetDisableSelfServiceChangePassword() bool {
+	if c == nil || c.DisableSelfServiceChangePassword == nil {
+		return false
+	}
+	return *c.DisableSelfServiceChangePassword
+}
+
 // GetDisableSignup returns the DisableSignup field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptions) GetDisableSignup() bool {
 	if c == nil || c.DisableSignup == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2058,6 +2058,16 @@ func TestConnectionOptions_GetCustomScripts(tt *testing.T) {
 	c.GetCustomScripts()
 }
 
+func TestConnectionOptions_GetDisableSelfServiceChangePassword(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptions{DisableSelfServiceChangePassword: &zeroValue}
+	c.GetDisableSelfServiceChangePassword()
+	c = &ConnectionOptions{}
+	c.GetDisableSelfServiceChangePassword()
+	c = nil
+	c.GetDisableSelfServiceChangePassword()
+}
+
 func TestConnectionOptions_GetDisableSignup(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptions{DisableSignup: &zeroValue}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds support for the `disable_self_service_change_password` property on DB connections

### 📚 References

terraform-provider-auth0/issues/486

### 🔬 Testing

Tested setting this on a connection in my tenant and it works as expected 

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
