### PR TITLE
Clarify how to correctly paginate organization invitations

### DIFF
--- a/management/organization.go
+++ b/management/organization.go
@@ -270,6 +270,8 @@ func (m *OrganizationManager) UpdateConnection(id string, connectionID string, c
 }
 
 // Invitations retrieves invitations to organization.
+// Note that when paginating this response the `HasNext` helper cannot be used, so instead check the length of the returned list
+// manually and break when there are 0 entries. See https://github.com/auth0/go-auth0/issues/48 for more context.
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_invitations
 func (m *OrganizationManager) Invitations(id string, opts ...RequestOption) (i *OrganizationInvitationList, err error) {


### PR DESCRIPTION
### 🔧 Changes

Adds a note and link to #48 on the `Organization.Invitations` func to clarify how to paginate the response due to `totals` not being returned so `HasNext` does not work.

### 📚 References

#48

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
