### PR TITLE
Remove vulncheck version in govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,6 +17,5 @@ jobs:
         uses: Templum/govulncheck-action@main
         with:
           go-version: 1.19
-          vulncheck-version: latest
           package: ./...
           fail-on-vuln: true

--- a/management/hook.go
+++ b/management/hook.go
@@ -178,13 +178,13 @@ func (m *HookManager) RemoveSecrets(hookID string, keys []string, opts ...Reques
 
 // RemoveAllSecrets removes all secrets associated with a given hook.
 func (m *HookManager) RemoveAllSecrets(hookID string, opts ...RequestOption) (err error) {
-	s, err := m.Secrets(hookID)
+	s, err := m.Secrets(hookID, opts...)
 	if err != nil {
 		return err
 	}
 	keys := s.Keys()
 	if len(keys) > 0 {
-		err = m.RemoveSecrets(hookID, keys)
+		err = m.RemoveSecrets(hookID, keys, opts...)
 	}
 	return err
 }


### PR DESCRIPTION
### 🔧 Changes

There is a compatibility issue between Templum/govulncheck-action and the latest govulncheck json format. This has been "fixed" for now in Templum/govulncheck-action by setting the default to a known working version, but by supplying `latest` we're overriding this fix. So for now don't set a govulncheck version

Additionally, this PR also fixes a lint warning from the newer version of golanci-lint about an unused parameter.

### 📚 References

auth0/go-jwt-middleware/pull/196

### 🔬 Testing

This PR will fail too as we're using pull_request_target which runs the action based on the workflow defined in the base of this PR rather than from the PR, once merged it will pass
