### PR TITLE
Allow passing extra environment data to the auth0client data

### DIFF
--- a/management/management_option.go
+++ b/management/management_option.go
@@ -93,6 +93,18 @@ func WithAuth0ClientInfo(auth0ClientInfo client.Auth0ClientInfo) Option {
 	}
 }
 
+// WithAuth0ClientEnvOption allows adding extra environment keys to the client information.
+func WithAuth0ClientEnvOption(key string, value string) Option {
+	return func(m *Management) {
+		if !m.auth0ClientInfo.IsEmpty() {
+			if m.auth0ClientInfo.Env == nil {
+				m.auth0ClientInfo.Env = map[string]string{}
+			}
+			m.auth0ClientInfo.Env[key] = value
+		}
+	}
+}
+
 // WithNoAuth0ClientInfo configures the management client to not send the "Auth0-Client" header
 // at all.
 func WithNoAuth0ClientInfo() Option {

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -361,4 +361,22 @@ func TestAuth0Client(t *testing.T) {
 		_, err = m.User.Read("123")
 		assert.NoError(t, err)
 	})
+
+	t.Run("Handles when client info has been disabled", func(t *testing.T) {
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			header := r.Header.Get("Auth0-Client")
+			assert.Equal(t, "", header)
+		})
+		s := httptest.NewServer(h)
+
+		m, err := New(
+			s.URL,
+			WithInsecure(),
+			WithNoAuth0ClientInfo(),
+			WithAuth0ClientEnvOption("foo", "bar"),
+		)
+		assert.NoError(t, err)
+		_, err = m.User.Read("123")
+		assert.NoError(t, err)
+	})
 }

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -325,4 +325,40 @@ func TestAuth0Client(t *testing.T) {
 		_, err = m.User.Read("123")
 		assert.NoError(t, err)
 	})
+
+	t.Run("Allows passing extra env info", func(t *testing.T) {
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			header := r.Header.Get("Auth0-Client")
+			assert.Equal(t, "eyJuYW1lIjoiZ28tYXV0aDAiLCJ2ZXJzaW9uIjoibGF0ZXN0IiwiZW52Ijp7ImZvbyI6ImJhciIsImdvIjoiZ28xLjIwLjIifX0=", header)
+		})
+		s := httptest.NewServer(h)
+
+		m, err := New(
+			s.URL,
+			WithInsecure(),
+			WithAuth0ClientEnvOption("foo", "bar"),
+		)
+		assert.NoError(t, err)
+		_, err = m.User.Read("123")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Allows passing extra env info with custom client", func(t *testing.T) {
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			header := r.Header.Get("Auth0-Client")
+			assert.Equal(t, "eyJuYW1lIjoidGVzdC1jbGllbnQiLCJ2ZXJzaW9uIjoiMS4wLjAiLCJlbnYiOnsiZm9vIjoiYmFyIn19", header)
+		})
+		s := httptest.NewServer(h)
+		customClient := client.Auth0ClientInfo{Name: "test-client", Version: "1.0.0"}
+
+		m, err := New(
+			s.URL,
+			WithInsecure(),
+			WithAuth0ClientInfo(customClient),
+			WithAuth0ClientEnvOption("foo", "bar"),
+		)
+		assert.NoError(t, err)
+		_, err = m.User.Read("123")
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
### 🔧 Changes

Adds a new `WithAuth0ClientEnvOption` func so that users of the SDK can enhance the env data with their own version to allow us to see their total usage, this is mostly for use in auth0-cli and terraform so that we can distinguish between their usage of the SDK and customer usage

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Covered by unit tests and also covered by manual testing and verifying the API log in manage

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
