### PR TITLE
Handle instances where scope is returned as array in log entries

### DIFF
--- a/management/log_test.go
+++ b/management/log_test.go
@@ -1,10 +1,13 @@
 package management
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/auth0/go-auth0"
 )
 
 const successfulAPIOperation = "sapi"
@@ -48,4 +51,21 @@ func TestLogManager_CheckpointPagination(t *testing.T) {
 	log2 := logList[2]
 	assert.Equal(t, log1.GetID(), logs[0].GetID())
 	assert.Equal(t, log2.GetID(), logs[1].GetID())
+}
+
+func TestLogManagerScope_UnmarshalJSON(t *testing.T) {
+	for expectedAsString, expected := range map[string]*Log{
+		`{}`: {},
+		`{"scope": "openid profile email"}`: {
+			Scope: auth0.String("openid profile email"),
+		},
+		`{"scope": ["openid", "profile", "email"]}`: {
+			Scope: auth0.String("openid profile email"),
+		},
+	} {
+		var actual *Log
+		err := json.Unmarshal([]byte(expectedAsString), &actual)
+		assert.NoError(t, err)
+		assert.Equal(t, actual, expected)
+	}
 }

--- a/management/log_test.go
+++ b/management/log_test.go
@@ -62,6 +62,9 @@ func TestLogManagerScope_UnmarshalJSON(t *testing.T) {
 		`{"scope": ["openid", "profile", "email"]}`: {
 			Scope: auth0.String("openid profile email"),
 		},
+		`{"scope": []}`: {
+			Scope: auth0.String(""),
+		},
 	} {
 		var actual *Log
 		err := json.Unmarshal([]byte(expectedAsString), &actual)

--- a/management/log_test.go
+++ b/management/log_test.go
@@ -71,4 +71,10 @@ func TestLogManagerScope_UnmarshalJSON(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, actual, expected)
 	}
+
+	t.Run("Throws an unexpected type error", func(t *testing.T) {
+		var actual *Log
+		err := json.Unmarshal([]byte(`{"scope": 1}`), &actual)
+		assert.EqualError(t, err, "unexpected type for field scope: float64")
+	})
 }


### PR DESCRIPTION
### 🔧 Changes

This implements a custom `UnmarshalJSON` function for the `Log` type that will handle the differing types of `scope`. Although this is documented to be a `string` it appears in some instances (from checking, only `fsa` type events) to be an array of strings.

Unlike other instances where we have to implement this functionality, we do not need to implement a `MarshalJSON` function as we can only read the `Log` type, i.e. there is no create or update functionality exposed.

### 📚 References

#189

### 🔬 Testing

Covered by unit tests

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
