### PR TITLE
Support setting Identity and OrganizationID on VerifyEmail calls

### DIFF
--- a/management/job.go
+++ b/management/job.go
@@ -27,6 +27,8 @@ type Job struct {
 	UserID *string `json:"user_id,omitempty"`
 	// The ID of the client, if not provided the global one will be used.
 	ClientID *string `json:"client_id,omitempty"`
+	// The identity of the user. This must be provided to verify primary social, enterprise and passwordless email identities. Also, is needed to verify secondary identities.
+	Identity *UserIdentity `json:"-"`
 	// The ID of the connection.
 	ConnectionID *string `json:"connection_id,omitempty"`
 	// The url to download the result of the job.
@@ -58,6 +60,29 @@ type Job struct {
 	SendCompletionEmail *bool `json:"send_completion_email,omitempty"`
 	// If a job is completed, the job status response will include a summary.
 	Summary *JobSummary `json:"summary,omitempty"`
+}
+
+// MarshalJSON is a custom serializer for the Job type.
+func (j *Job) MarshalJSON() ([]byte, error) {
+	type job Job
+	type identity struct {
+		UserID   *string `json:"user_id,omitempty"`
+		Provider *string `json:"provider,omitempty"`
+	}
+	type jobWrapper struct {
+		*job
+		Identity *identity `json:"identity,omitempty"`
+	}
+
+	w := &jobWrapper{job: (*job)(j)}
+	if j.Identity != nil {
+		w.Identity = &identity{
+			UserID:   j.Identity.UserID,
+			Provider: j.Identity.Provider,
+		}
+	}
+
+	return json.Marshal(w)
 }
 
 // JobSummary includes totals of successful,

--- a/management/job.go
+++ b/management/job.go
@@ -60,6 +60,9 @@ type Job struct {
 	SendCompletionEmail *bool `json:"send_completion_email,omitempty"`
 	// If a job is completed, the job status response will include a summary.
 	Summary *JobSummary `json:"summary,omitempty"`
+	// The ID of the Organization. If provided, organization parameters will be made available to the email template and organization branding will
+	// be applied to the prompt. In addition, the redirect link in the prompt will include organization_id and organization_name query string parameters.
+	OrganizationID *string `json:"organization_id,omitempty"`
 }
 
 // MarshalJSON is a custom serializer for the Job type.

--- a/management/job_test.go
+++ b/management/job_test.go
@@ -14,7 +14,10 @@ func TestJobManager_VerifyEmail(t *testing.T) {
 	configureHTTPTestRecordings(t)
 
 	user := givenAUser(t)
-	job := &Job{UserID: user.ID}
+	job := &Job{
+		UserID:   user.ID,
+		Identity: user.Identities[0],
+	}
 
 	err := api.Job.VerifyEmail(job)
 	assert.NoError(t, err)

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5238,6 +5238,14 @@ func (j *Job) GetID() string {
 	return *j.ID
 }
 
+// GetIdentity returns the Identity field.
+func (j *Job) GetIdentity() *UserIdentity {
+	if j == nil {
+		return nil
+	}
+	return j.Identity
+}
+
 // GetLimit returns the Limit field if it's non-nil, zero value otherwise.
 func (j *Job) GetLimit() int {
 	if j == nil || j.Limit == nil {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5262,6 +5262,14 @@ func (j *Job) GetLocation() string {
 	return *j.Location
 }
 
+// GetOrganizationID returns the OrganizationID field if it's non-nil, zero value otherwise.
+func (j *Job) GetOrganizationID() string {
+	if j == nil || j.OrganizationID == nil {
+		return ""
+	}
+	return *j.OrganizationID
+}
+
 // GetPercentageDone returns the PercentageDone field if it's non-nil, zero value otherwise.
 func (j *Job) GetPercentageDone() int {
 	if j == nil || j.PercentageDone == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -6634,6 +6634,13 @@ func TestJob_GetID(tt *testing.T) {
 	j.GetID()
 }
 
+func TestJob_GetIdentity(tt *testing.T) {
+	j := &Job{}
+	j.GetIdentity()
+	j = nil
+	j.GetIdentity()
+}
+
 func TestJob_GetLimit(tt *testing.T) {
 	var zeroValue int
 	j := &Job{Limit: &zeroValue}

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -6661,6 +6661,16 @@ func TestJob_GetLocation(tt *testing.T) {
 	j.GetLocation()
 }
 
+func TestJob_GetOrganizationID(tt *testing.T) {
+	var zeroValue string
+	j := &Job{OrganizationID: &zeroValue}
+	j.GetOrganizationID()
+	j = &Job{}
+	j.GetOrganizationID()
+	j = nil
+	j.GetOrganizationID()
+}
+
 func TestJob_GetPercentageDone(tt *testing.T) {
 	var zeroValue int
 	j := &Job{PercentageDone: &zeroValue}

--- a/test/data/recordings/TestJobManager_VerifyEmail.yaml
+++ b/test/data/recordings/TestJobManager_VerifyEmail.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection":"Username-Password-Authentication","email":"chuck750@example.com","given_name":"Chuck","family_name":"Sanchez","username":"test-user362","nickname":"Chucky","password":"Passwords hide their chuck","user_metadata":{"favourite_attack":"roundhouse_kick"},"verify_email":false,"app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]},"picture":"https://example-picture-url.jpg","blocked":false,"email_verified":true}
+            {"connection":"Username-Password-Authentication","email":"chuck359@example.com","given_name":"Chuck","family_name":"Sanchez","username":"test-user851","nickname":"Chucky","password":"Passwords hide their chuck","user_metadata":{"favourite_attack":"roundhouse_kick"},"verify_email":false,"app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]},"picture":"https://example-picture-url.jpg","blocked":false,"email_verified":true}
         form: {}
         headers:
             Content-Type:
@@ -30,26 +30,26 @@ interactions:
         trailer: {}
         content_length: 661
         uncompressed: false
-        body: '{"blocked":false,"created_at":"2023-01-25T17:48:13.425Z","email":"chuck750@example.com","email_verified":true,"family_name":"Sanchez","given_name":"Chuck","identities":[{"connection":"Username-Password-Authentication","user_id":"63d16b5d2b2c1a2ae38bad23","provider":"auth0","isSocial":false}],"name":"chuck750@example.com","nickname":"Chucky","picture":"https://example-picture-url.jpg","updated_at":"2023-01-25T17:48:13.425Z","user_id":"auth0|63d16b5d2b2c1a2ae38bad23","user_metadata":{"favourite_attack":"roundhouse_kick"},"username":"test-user362","app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]}}'
+        body: '{"blocked":false,"created_at":"2023-04-18T19:25:53.100Z","email":"chuck359@example.com","email_verified":true,"family_name":"Sanchez","given_name":"Chuck","identities":[{"connection":"Username-Password-Authentication","user_id":"643eeec175f861f25ed0a0b0","provider":"auth0","isSocial":false}],"name":"chuck359@example.com","nickname":"Chucky","picture":"https://example-picture-url.jpg","updated_at":"2023-04-18T19:25:53.100Z","user_id":"auth0|643eeec175f861f25ed0a0b0","user_metadata":{"favourite_attack":"roundhouse_kick"},"username":"test-user851","app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 883.699416ms
+        duration: 421.785208ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 45
+        content_length: 114
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"user_id":"auth0|63d16b5d2b2c1a2ae38bad23"}
+            {"user_id":"auth0|643eeec175f861f25ed0a0b0","identity":{"user_id":"643eeec175f861f25ed0a0b0","provider":"auth0"}}
         form: {}
         headers:
             Content-Type:
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: 116
         uncompressed: false
-        body: '{"type":"verification_email","status":"pending","created_at":"2023-01-25T17:48:14.201Z","id":"job_9zpIFCI3DAnZieXY"}'
+        body: '{"type":"verification_email","status":"pending","created_at":"2023-04-18T19:25:53.189Z","id":"job_LUdmtO6C0M42uqSz"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 147.932209ms
+        duration: 107.200791ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -92,7 +92,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/latest
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/jobs/job_9zpIFCI3DAnZieXY
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/jobs/job_LUdmtO6C0M42uqSz
         method: GET
       response:
         proto: HTTP/2.0
@@ -102,13 +102,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"type":"verification_email","status":"pending","created_at":"2023-01-25T17:48:14.201Z","id":"job_9zpIFCI3DAnZieXY"}'
+        body: '{"type":"verification_email","status":"failed","created_at":"2023-04-18T19:25:53.189Z","id":"job_LUdmtO6C0M42uqSz"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 80.518583ms
+        duration: 81.940542ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -127,7 +127,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/latest
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C63d16b5d2b2c1a2ae38bad23
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C643eeec175f861f25ed0a0b0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -143,4 +143,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 128.103083ms
+        duration: 194.868292ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

This PR adds an optional `Identity` field to the `management.Job` struct, for use in the `(*JobManager).VerifyEmail` method.

Per the [docs](https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email), this field "must be provided to verify primary social, enterprise and passwordless email identities. Also, is needed to verify secondary identities.".

This field only accepts a subset of the `UserIdentity` fields, so I have implemented `(*Job).MarshalJSON` to allow the reuse of the `UserIdentity` struct whilst omitting the extraneous fields.

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

I have added the `Identity` parameter to `TestJobManager_VerifyEmail` and re-recorded the HTTP interactions, so this is covered by the end-to-end tests.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests
- [x] I have added documentation for all new/changed functionality

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
