### PR TITLE
Support configuring Back-Channel Logout URLs for a Client

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -110,6 +110,8 @@ type Client struct {
 
 	// If `true` then the client will require Pushed Authorization Requests
 	RequirePushedAuthorizationRequests *bool `json:"require_pushed_authorization_requests,omitempty"`
+
+	OIDCBackchannelLogout *OIDCBackchannelLogout `json:"oidc_backchannel_logout,omitempty"`
 }
 
 // ClientJWTConfiguration is used to configure JWT settings for our Client.
@@ -217,6 +219,11 @@ type ClientAuthenticationMethods struct {
 // PrivateKeyJWT defines the `private_key_jwt` client authentication method settings for the client.
 type PrivateKeyJWT struct {
 	Credentials *[]Credential `json:"credentials,omitempty"`
+}
+
+// OIDCBackchannelLogout defines the `oidc_backchannel_logout` settings for the client.
+type OIDCBackchannelLogout struct {
+	BackChannelLogoutURLs *[]string `json:"backchannel_logout_urls,omitempty"`
 }
 
 // ClientList is a list of Clients.

--- a/management/client.go
+++ b/management/client.go
@@ -111,6 +111,7 @@ type Client struct {
 	// If `true` then the client will require Pushed Authorization Requests
 	RequirePushedAuthorizationRequests *bool `json:"require_pushed_authorization_requests,omitempty"`
 
+	// URLs that are valid to call back from Auth0 for OIDC backchannel logout.
 	OIDCBackchannelLogout *OIDCBackchannelLogout `json:"oidc_backchannel_logout,omitempty"`
 }
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1163,6 +1163,14 @@ func (c *Client) GetNativeSocialLogin() *ClientNativeSocialLogin {
 	return c.NativeSocialLogin
 }
 
+// GetOIDCBackchannelLogout returns the OIDCBackchannelLogout field.
+func (c *Client) GetOIDCBackchannelLogout() *OIDCBackchannelLogout {
+	if c == nil {
+		return nil
+	}
+	return c.OIDCBackchannelLogout
+}
+
 // GetOIDCConformant returns the OIDCConformant field if it's non-nil, zero value otherwise.
 func (c *Client) GetOIDCConformant() bool {
 	if c == nil || c.OIDCConformant == nil {
@@ -6264,6 +6272,19 @@ func (m *MultiFactorWebAuthnSettings) GetUserVerification() string {
 // String returns a string representation of MultiFactorWebAuthnSettings.
 func (m *MultiFactorWebAuthnSettings) String() string {
 	return Stringify(m)
+}
+
+// GetBackChannelLogoutURLs returns the BackChannelLogoutURLs field if it's non-nil, zero value otherwise.
+func (o *OIDCBackchannelLogout) GetBackChannelLogoutURLs() []string {
+	if o == nil || o.BackChannelLogoutURLs == nil {
+		return nil
+	}
+	return *o.BackChannelLogoutURLs
+}
+
+// String returns a string representation of OIDCBackchannelLogout.
+func (o *OIDCBackchannelLogout) String() string {
+	return Stringify(o)
 }
 
 // GetBranding returns the Branding field.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -1478,6 +1478,13 @@ func TestClient_GetNativeSocialLogin(tt *testing.T) {
 	c.GetNativeSocialLogin()
 }
 
+func TestClient_GetOIDCBackchannelLogout(tt *testing.T) {
+	c := &Client{}
+	c.GetOIDCBackchannelLogout()
+	c = nil
+	c.GetOIDCBackchannelLogout()
+}
+
 func TestClient_GetOIDCConformant(tt *testing.T) {
 	var zeroValue bool
 	c := &Client{OIDCConformant: &zeroValue}
@@ -7965,6 +7972,24 @@ func TestMultiFactorWebAuthnSettings_GetUserVerification(tt *testing.T) {
 func TestMultiFactorWebAuthnSettings_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &MultiFactorWebAuthnSettings{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestOIDCBackchannelLogout_GetBackChannelLogoutURLs(tt *testing.T) {
+	var zeroValue []string
+	o := &OIDCBackchannelLogout{BackChannelLogoutURLs: &zeroValue}
+	o.GetBackChannelLogoutURLs()
+	o = &OIDCBackchannelLogout{}
+	o.GetBackChannelLogoutURLs()
+	o = nil
+	o.GetBackChannelLogoutURLs()
+}
+
+func TestOIDCBackchannelLogout_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &OIDCBackchannelLogout{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}


### PR DESCRIPTION
### 🔧 Changes

Add support for configuring the Back-Channel Logout URLs on a Client

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Tested configuring manually as this feature is currently feature flagged.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
