### PR TITLE
[SDK-4235] Generate safe getters for map[string]interface types

### DIFF
--- a/management/gen-methods.go
+++ b/management/gen-methods.go
@@ -283,7 +283,7 @@ func (t *templateData) addMapType(x *ast.MapType, receiverType, fieldName string
 	case *ast.Ident:
 		valueType = value.String()
 	case *ast.InterfaceType:
-		valueType = "any"
+		valueType = "interface{}"
 	default:
 		logf("addMapType: type %q, field %q: unknown value type: %T %+v; skipping.", receiverType, fieldName, value, value)
 		return

--- a/management/gen-methods.go
+++ b/management/gen-methods.go
@@ -282,6 +282,8 @@ func (t *templateData) addMapType(x *ast.MapType, receiverType, fieldName string
 	switch value := x.Value.(type) {
 	case *ast.Ident:
 		valueType = value.String()
+	case *ast.InterfaceType:
+		valueType = "any"
 	default:
 		logf("addMapType: type %q, field %q: unknown value type: %T %+v; skipping.", receiverType, fieldName, value, value)
 		return

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5958,6 +5958,14 @@ func (l *Log) String() string {
 	return Stringify(l)
 }
 
+// GetFilters returns the Filters field if it's non-nil, zero value otherwise.
+func (l *LogStream) GetFilters() []map[string]string {
+	if l == nil || l.Filters == nil {
+		return []map[string]string{}
+	}
+	return *l.Filters
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (l *LogStream) GetID() string {
 	if l == nil || l.ID == nil {
@@ -6104,6 +6112,14 @@ func (l *LogStreamSinkHTTP) GetContentType() string {
 		return ""
 	}
 	return *l.ContentType
+}
+
+// GetCustomHeaders returns the CustomHeaders field if it's non-nil, zero value otherwise.
+func (l *LogStreamSinkHTTP) GetCustomHeaders() []map[string]string {
+	if l == nil || l.CustomHeaders == nil {
+		return []map[string]string{}
+	}
+	return *l.CustomHeaders
 }
 
 // GetEndpoint returns the Endpoint field if it's non-nil, zero value otherwise.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -278,9 +278,9 @@ func (a *ActionExecutionResult) GetEndedAt() time.Time {
 }
 
 // GetError returns the Error map if it's non-nil, an empty map otherwise.
-func (a *ActionExecutionResult) GetError() map[string]any {
+func (a *ActionExecutionResult) GetError() map[string]interface{} {
 	if a == nil || a.Error == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return a.Error
 }
@@ -964,9 +964,9 @@ func (b *BruteForceProtection) String() string {
 }
 
 // GetAddons returns the Addons map if it's non-nil, an empty map otherwise.
-func (c *Client) GetAddons() map[string]any {
+func (c *Client) GetAddons() map[string]interface{} {
 	if c == nil || c.Addons == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.Addons
 }
@@ -1036,9 +1036,9 @@ func (c *Client) GetClientID() string {
 }
 
 // GetClientMetadata returns the ClientMetadata field if it's non-nil, zero value otherwise.
-func (c *Client) GetClientMetadata() map[string]any {
+func (c *Client) GetClientMetadata() map[string]interface{} {
 	if c == nil || c.ClientMetadata == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return *c.ClientMetadata
 }
@@ -1719,9 +1719,9 @@ func (c *ConnectionOptions) GetImportMode() bool {
 }
 
 // GetMFA returns the MFA map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptions) GetMFA() map[string]any {
+func (c *ConnectionOptions) GetMFA() map[string]interface{} {
 	if c == nil || c.MFA == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.MFA
 }
@@ -1735,33 +1735,33 @@ func (c *ConnectionOptions) GetNonPersistentAttrs() []string {
 }
 
 // GetPasswordComplexityOptions returns the PasswordComplexityOptions map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptions) GetPasswordComplexityOptions() map[string]any {
+func (c *ConnectionOptions) GetPasswordComplexityOptions() map[string]interface{} {
 	if c == nil || c.PasswordComplexityOptions == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.PasswordComplexityOptions
 }
 
 // GetPasswordDictionary returns the PasswordDictionary map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptions) GetPasswordDictionary() map[string]any {
+func (c *ConnectionOptions) GetPasswordDictionary() map[string]interface{} {
 	if c == nil || c.PasswordDictionary == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.PasswordDictionary
 }
 
 // GetPasswordHistory returns the PasswordHistory map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptions) GetPasswordHistory() map[string]any {
+func (c *ConnectionOptions) GetPasswordHistory() map[string]interface{} {
 	if c == nil || c.PasswordHistory == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.PasswordHistory
 }
 
 // GetPasswordNoPersonalInfo returns the PasswordNoPersonalInfo map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptions) GetPasswordNoPersonalInfo() map[string]any {
+func (c *ConnectionOptions) GetPasswordNoPersonalInfo() map[string]interface{} {
 	if c == nil || c.PasswordNoPersonalInfo == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.PasswordNoPersonalInfo
 }
@@ -1799,17 +1799,17 @@ func (c *ConnectionOptions) GetStrategyVersion() int {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptions) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptions) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
 
 // GetValidation returns the Validation map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptions) GetValidation() map[string]any {
+func (c *ConnectionOptions) GetValidation() map[string]interface{} {
 	if c == nil || c.Validation == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.Validation
 }
@@ -1900,9 +1900,9 @@ func (c *ConnectionOptionsAD) GetTenantDomain() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsAD) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsAD) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -2001,9 +2001,9 @@ func (c *ConnectionOptionsADFS) GetTrustEmailVerified() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsADFS) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsADFS) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -2086,9 +2086,9 @@ func (c *ConnectionOptionsApple) GetTeamID() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsApple) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsApple) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -2267,9 +2267,9 @@ func (c *ConnectionOptionsAzureAD) GetTrustEmailVerified() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsAzureAD) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsAzureAD) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -2368,9 +2368,9 @@ func (c *ConnectionOptionsEmail) GetSetUserAttributes() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsEmail) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsEmail) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -2658,9 +2658,9 @@ func (c *ConnectionOptionsFacebook) GetSetUserAttributes() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsFacebook) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsFacebook) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -2967,9 +2967,9 @@ func (c *ConnectionOptionsGitHub) GetSetUserAttributes() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsGitHub) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsGitHub) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -3124,9 +3124,9 @@ func (c *ConnectionOptionsGoogleApps) GetTenantDomain() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsGoogleApps) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsGoogleApps) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -3393,9 +3393,9 @@ func (c *ConnectionOptionsGoogleOAuth2) GetTasks() bool {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsGoogleOAuth2) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsGoogleOAuth2) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -3494,9 +3494,9 @@ func (c *ConnectionOptionsLinkedin) GetStrategyVersion() int {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsLinkedin) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsLinkedin) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -3587,9 +3587,9 @@ func (c *ConnectionOptionsOAuth2) GetTokenURL() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsOAuth2) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsOAuth2) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -3712,9 +3712,9 @@ func (c *ConnectionOptionsOIDC) GetType() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsOIDC) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsOIDC) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -3829,9 +3829,9 @@ func (c *ConnectionOptionsOkta) GetTokenEndpoint() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsOkta) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsOkta) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -3975,9 +3975,9 @@ func (c *ConnectionOptionsPingFederate) GetTenantDomain() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsPingFederate) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsPingFederate) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -4036,9 +4036,9 @@ func (c *ConnectionOptionsSalesforce) GetSetUserAttributes() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsSalesforce) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsSalesforce) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -4105,9 +4105,9 @@ func (c *ConnectionOptionsSAML) GetExpires() string {
 }
 
 // GetFieldsMap returns the FieldsMap map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsSAML) GetFieldsMap() map[string]any {
+func (c *ConnectionOptionsSAML) GetFieldsMap() map[string]interface{} {
 	if c == nil || c.FieldsMap == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.FieldsMap
 }
@@ -4225,9 +4225,9 @@ func (c *ConnectionOptionsSAML) GetSignSAMLRequest() bool {
 }
 
 // GetSubject returns the Subject map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsSAML) GetSubject() map[string]any {
+func (c *ConnectionOptionsSAML) GetSubject() map[string]interface{} {
 	if c == nil || c.Subject == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.Subject
 }
@@ -4241,9 +4241,9 @@ func (c *ConnectionOptionsSAML) GetTenantDomain() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsSAML) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsSAML) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -4448,9 +4448,9 @@ func (c *ConnectionOptionsSMS) GetTwilioToken() string {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsSMS) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsSMS) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -4653,9 +4653,9 @@ func (c *ConnectionOptionsWindowsLive) GetTasksUpdate() bool {
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsWindowsLive) GetUpstreamParams() map[string]any {
+func (c *ConnectionOptionsWindowsLive) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return c.UpstreamParams
 }
@@ -4963,9 +4963,9 @@ func (e *Email) GetName() string {
 }
 
 // GetSettings returns the Settings map if it's non-nil, an empty map otherwise.
-func (e *Email) GetSettings() map[string]any {
+func (e *Email) GetSettings() map[string]interface{} {
 	if e == nil || e.Settings == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return e.Settings
 }
@@ -5710,9 +5710,9 @@ func (j *Job) String() string {
 }
 
 // GetUser returns the User map if it's non-nil, an empty map otherwise.
-func (j *JobError) GetUser() map[string]any {
+func (j *JobError) GetUser() map[string]interface{} {
 	if j == nil || j.User == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return j.User
 }
@@ -5826,9 +5826,9 @@ func (l *Log) GetDescription() string {
 }
 
 // GetDetails returns the Details map if it's non-nil, an empty map otherwise.
-func (l *Log) GetDetails() map[string]any {
+func (l *Log) GetDetails() map[string]interface{} {
 	if l == nil || l.Details == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return l.Details
 }
@@ -5866,9 +5866,9 @@ func (l *Log) GetIsMobile() bool {
 }
 
 // GetLocationInfo returns the LocationInfo map if it's non-nil, an empty map otherwise.
-func (l *Log) GetLocationInfo() map[string]any {
+func (l *Log) GetLocationInfo() map[string]interface{} {
 	if l == nil || l.LocationInfo == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return l.LocationInfo
 }
@@ -6681,9 +6681,9 @@ func (o *OrganizationConnectionList) String() string {
 }
 
 // GetAppMetadata returns the AppMetadata map if it's non-nil, an empty map otherwise.
-func (o *OrganizationInvitation) GetAppMetadata() map[string]any {
+func (o *OrganizationInvitation) GetAppMetadata() map[string]interface{} {
 	if o == nil || o.AppMetadata == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return o.AppMetadata
 }
@@ -6785,9 +6785,9 @@ func (o *OrganizationInvitation) GetTTLSec() int {
 }
 
 // GetUserMetadata returns the UserMetadata map if it's non-nil, an empty map otherwise.
-func (o *OrganizationInvitation) GetUserMetadata() map[string]any {
+func (o *OrganizationInvitation) GetUserMetadata() map[string]interface{} {
 	if o == nil || o.UserMetadata == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return o.UserMetadata
 }
@@ -8066,9 +8066,9 @@ func (t *Ticket) String() string {
 }
 
 // GetAppMetadata returns the AppMetadata field if it's non-nil, zero value otherwise.
-func (u *User) GetAppMetadata() map[string]any {
+func (u *User) GetAppMetadata() map[string]interface{} {
 	if u == nil || u.AppMetadata == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return *u.AppMetadata
 }
@@ -8274,9 +8274,9 @@ func (u *User) GetURL() string {
 }
 
 // GetUserMetadata returns the UserMetadata field if it's non-nil, zero value otherwise.
-func (u *User) GetUserMetadata() map[string]any {
+func (u *User) GetUserMetadata() map[string]interface{} {
 	if u == nil || u.UserMetadata == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return *u.UserMetadata
 }
@@ -8433,9 +8433,9 @@ func (u *UserIdentity) GetIsSocial() bool {
 }
 
 // GetProfileData returns the ProfileData field if it's non-nil, zero value otherwise.
-func (u *UserIdentity) GetProfileData() map[string]any {
+func (u *UserIdentity) GetProfileData() map[string]interface{} {
 	if u == nil || u.ProfileData == nil {
-		return map[string]any{}
+		return map[string]interface{}{}
 	}
 	return *u.ProfileData
 }

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -277,6 +277,14 @@ func (a *ActionExecutionResult) GetEndedAt() time.Time {
 	return *a.EndedAt
 }
 
+// GetError returns the Error map if it's non-nil, an empty map otherwise.
+func (a *ActionExecutionResult) GetError() map[string]any {
+	if a == nil || a.Error == nil {
+		return map[string]any{}
+	}
+	return a.Error
+}
+
 // GetStartedAt returns the StartedAt field if it's non-nil, zero value otherwise.
 func (a *ActionExecutionResult) GetStartedAt() time.Time {
 	if a == nil || a.StartedAt == nil {
@@ -955,6 +963,14 @@ func (b *BruteForceProtection) String() string {
 	return Stringify(b)
 }
 
+// GetAddons returns the Addons map if it's non-nil, an empty map otherwise.
+func (c *Client) GetAddons() map[string]any {
+	if c == nil || c.Addons == nil {
+		return map[string]any{}
+	}
+	return c.Addons
+}
+
 // GetAllowedClients returns the AllowedClients field if it's non-nil, zero value otherwise.
 func (c *Client) GetAllowedClients() []string {
 	if c == nil || c.AllowedClients == nil {
@@ -1017,6 +1033,14 @@ func (c *Client) GetClientID() string {
 		return ""
 	}
 	return *c.ClientID
+}
+
+// GetClientMetadata returns the ClientMetadata field if it's non-nil, zero value otherwise.
+func (c *Client) GetClientMetadata() map[string]any {
+	if c == nil || c.ClientMetadata == nil {
+		return map[string]any{}
+	}
+	return *c.ClientMetadata
 }
 
 // GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
@@ -1694,12 +1718,52 @@ func (c *ConnectionOptions) GetImportMode() bool {
 	return *c.ImportMode
 }
 
+// GetMFA returns the MFA map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptions) GetMFA() map[string]any {
+	if c == nil || c.MFA == nil {
+		return map[string]any{}
+	}
+	return c.MFA
+}
+
 // GetNonPersistentAttrs returns the NonPersistentAttrs field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptions) GetNonPersistentAttrs() []string {
 	if c == nil || c.NonPersistentAttrs == nil {
 		return nil
 	}
 	return *c.NonPersistentAttrs
+}
+
+// GetPasswordComplexityOptions returns the PasswordComplexityOptions map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptions) GetPasswordComplexityOptions() map[string]any {
+	if c == nil || c.PasswordComplexityOptions == nil {
+		return map[string]any{}
+	}
+	return c.PasswordComplexityOptions
+}
+
+// GetPasswordDictionary returns the PasswordDictionary map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptions) GetPasswordDictionary() map[string]any {
+	if c == nil || c.PasswordDictionary == nil {
+		return map[string]any{}
+	}
+	return c.PasswordDictionary
+}
+
+// GetPasswordHistory returns the PasswordHistory map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptions) GetPasswordHistory() map[string]any {
+	if c == nil || c.PasswordHistory == nil {
+		return map[string]any{}
+	}
+	return c.PasswordHistory
+}
+
+// GetPasswordNoPersonalInfo returns the PasswordNoPersonalInfo map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptions) GetPasswordNoPersonalInfo() map[string]any {
+	if c == nil || c.PasswordNoPersonalInfo == nil {
+		return map[string]any{}
+	}
+	return c.PasswordNoPersonalInfo
 }
 
 // GetPasswordPolicy returns the PasswordPolicy field if it's non-nil, zero value otherwise.
@@ -1732,6 +1796,22 @@ func (c *ConnectionOptions) GetStrategyVersion() int {
 		return 0
 	}
 	return *c.StrategyVersion
+}
+
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptions) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
+}
+
+// GetValidation returns the Validation map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptions) GetValidation() map[string]any {
+	if c == nil || c.Validation == nil {
+		return map[string]any{}
+	}
+	return c.Validation
 }
 
 // String returns a string representation of ConnectionOptions.
@@ -1817,6 +1897,14 @@ func (c *ConnectionOptionsAD) GetTenantDomain() string {
 		return ""
 	}
 	return *c.TenantDomain
+}
+
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsAD) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
 }
 
 // String returns a string representation of ConnectionOptionsAD.
@@ -1912,6 +2000,14 @@ func (c *ConnectionOptionsADFS) GetTrustEmailVerified() string {
 	return *c.TrustEmailVerified
 }
 
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsADFS) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
+}
+
 // String returns a string representation of ConnectionOptionsADFS.
 func (c *ConnectionOptionsADFS) String() string {
 	return Stringify(c)
@@ -1987,6 +2083,14 @@ func (c *ConnectionOptionsApple) GetTeamID() string {
 		return ""
 	}
 	return *c.TeamID
+}
+
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsApple) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
 }
 
 // String returns a string representation of ConnectionOptionsApple.
@@ -2162,6 +2266,14 @@ func (c *ConnectionOptionsAzureAD) GetTrustEmailVerified() string {
 	return *c.TrustEmailVerified
 }
 
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsAzureAD) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
+}
+
 // GetUseCommonEndpoint returns the UseCommonEndpoint field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsAzureAD) GetUseCommonEndpoint() bool {
 	if c == nil || c.UseCommonEndpoint == nil {
@@ -2253,6 +2365,14 @@ func (c *ConnectionOptionsEmail) GetSetUserAttributes() string {
 		return ""
 	}
 	return *c.SetUserAttributes
+}
+
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsEmail) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
 }
 
 // String returns a string representation of ConnectionOptionsEmail.
@@ -2535,6 +2655,14 @@ func (c *ConnectionOptionsFacebook) GetSetUserAttributes() string {
 		return ""
 	}
 	return *c.SetUserAttributes
+}
+
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsFacebook) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
 }
 
 // GetUserAgeRange returns the UserAgeRange field if it's non-nil, zero value otherwise.
@@ -2838,6 +2966,14 @@ func (c *ConnectionOptionsGitHub) GetSetUserAttributes() string {
 	return *c.SetUserAttributes
 }
 
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsGitHub) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
+}
+
 // GetWriteOrg returns the WriteOrg field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsGitHub) GetWriteOrg() bool {
 	if c == nil || c.WriteOrg == nil {
@@ -2985,6 +3121,14 @@ func (c *ConnectionOptionsGoogleApps) GetTenantDomain() string {
 		return ""
 	}
 	return *c.TenantDomain
+}
+
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsGoogleApps) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
 }
 
 // String returns a string representation of ConnectionOptionsGoogleApps.
@@ -3248,6 +3392,14 @@ func (c *ConnectionOptionsGoogleOAuth2) GetTasks() bool {
 	return *c.Tasks
 }
 
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsGoogleOAuth2) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
+}
+
 // GetURLShortener returns the URLShortener field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsGoogleOAuth2) GetURLShortener() bool {
 	if c == nil || c.URLShortener == nil {
@@ -3341,6 +3493,14 @@ func (c *ConnectionOptionsLinkedin) GetStrategyVersion() int {
 	return *c.StrategyVersion
 }
 
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsLinkedin) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
+}
+
 // String returns a string representation of ConnectionOptionsLinkedin.
 func (c *ConnectionOptionsLinkedin) String() string {
 	return Stringify(c)
@@ -3424,6 +3584,14 @@ func (c *ConnectionOptionsOAuth2) GetTokenURL() string {
 		return ""
 	}
 	return *c.TokenURL
+}
+
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsOAuth2) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
 }
 
 // String returns a string representation of ConnectionOptionsOAuth2.
@@ -3543,6 +3711,14 @@ func (c *ConnectionOptionsOIDC) GetType() string {
 	return *c.Type
 }
 
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsOIDC) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
+}
+
 // GetUserInfoEndpoint returns the UserInfoEndpoint field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsOIDC) GetUserInfoEndpoint() string {
 	if c == nil || c.UserInfoEndpoint == nil {
@@ -3650,6 +3826,14 @@ func (c *ConnectionOptionsOkta) GetTokenEndpoint() string {
 		return ""
 	}
 	return *c.TokenEndpoint
+}
+
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsOkta) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
 }
 
 // GetUserInfoEndpoint returns the UserInfoEndpoint field if it's non-nil, zero value otherwise.
@@ -3790,6 +3974,14 @@ func (c *ConnectionOptionsPingFederate) GetTenantDomain() string {
 	return *c.TenantDomain
 }
 
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsPingFederate) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
+}
+
 // String returns a string representation of ConnectionOptionsPingFederate.
 func (c *ConnectionOptionsPingFederate) String() string {
 	return Stringify(c)
@@ -3841,6 +4033,14 @@ func (c *ConnectionOptionsSalesforce) GetSetUserAttributes() string {
 		return ""
 	}
 	return *c.SetUserAttributes
+}
+
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsSalesforce) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
 }
 
 // String returns a string representation of ConnectionOptionsSalesforce.
@@ -3902,6 +4102,14 @@ func (c *ConnectionOptionsSAML) GetExpires() string {
 		return ""
 	}
 	return *c.Expires
+}
+
+// GetFieldsMap returns the FieldsMap map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsSAML) GetFieldsMap() map[string]any {
+	if c == nil || c.FieldsMap == nil {
+		return map[string]any{}
+	}
+	return c.FieldsMap
 }
 
 // GetIdpInitiated returns the IdpInitiated field.
@@ -4016,12 +4224,28 @@ func (c *ConnectionOptionsSAML) GetSignSAMLRequest() bool {
 	return *c.SignSAMLRequest
 }
 
+// GetSubject returns the Subject map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsSAML) GetSubject() map[string]any {
+	if c == nil || c.Subject == nil {
+		return map[string]any{}
+	}
+	return c.Subject
+}
+
 // GetTenantDomain returns the TenantDomain field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSAML) GetTenantDomain() string {
 	if c == nil || c.TenantDomain == nil {
 		return ""
 	}
 	return *c.TenantDomain
+}
+
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsSAML) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
 }
 
 // GetUserIDAttribute returns the UserIDAttribute field if it's non-nil, zero value otherwise.
@@ -4223,6 +4447,14 @@ func (c *ConnectionOptionsSMS) GetTwilioToken() string {
 	return *c.TwilioToken
 }
 
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsSMS) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
+}
+
 // String returns a string representation of ConnectionOptionsSMS.
 func (c *ConnectionOptionsSMS) String() string {
 	return Stringify(c)
@@ -4418,6 +4650,14 @@ func (c *ConnectionOptionsWindowsLive) GetTasksUpdate() bool {
 		return false
 	}
 	return *c.TasksUpdate
+}
+
+// GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsWindowsLive) GetUpstreamParams() map[string]any {
+	if c == nil || c.UpstreamParams == nil {
+		return map[string]any{}
+	}
+	return c.UpstreamParams
 }
 
 // GetUser returns the User field if it's non-nil, zero value otherwise.
@@ -4720,6 +4960,14 @@ func (e *Email) GetName() string {
 		return ""
 	}
 	return *e.Name
+}
+
+// GetSettings returns the Settings map if it's non-nil, an empty map otherwise.
+func (e *Email) GetSettings() map[string]any {
+	if e == nil || e.Settings == nil {
+		return map[string]any{}
+	}
+	return e.Settings
 }
 
 // String returns a string representation of Email.
@@ -5461,6 +5709,14 @@ func (j *Job) String() string {
 	return Stringify(j)
 }
 
+// GetUser returns the User map if it's non-nil, an empty map otherwise.
+func (j *JobError) GetUser() map[string]any {
+	if j == nil || j.User == nil {
+		return map[string]any{}
+	}
+	return j.User
+}
+
 // String returns a string representation of JobError.
 func (j *JobError) String() string {
 	return Stringify(j)
@@ -5569,6 +5825,14 @@ func (l *Log) GetDescription() string {
 	return *l.Description
 }
 
+// GetDetails returns the Details map if it's non-nil, an empty map otherwise.
+func (l *Log) GetDetails() map[string]any {
+	if l == nil || l.Details == nil {
+		return map[string]any{}
+	}
+	return l.Details
+}
+
 // GetHostname returns the Hostname field if it's non-nil, zero value otherwise.
 func (l *Log) GetHostname() string {
 	if l == nil || l.Hostname == nil {
@@ -5599,6 +5863,14 @@ func (l *Log) GetIsMobile() bool {
 		return false
 	}
 	return *l.IsMobile
+}
+
+// GetLocationInfo returns the LocationInfo map if it's non-nil, an empty map otherwise.
+func (l *Log) GetLocationInfo() map[string]any {
+	if l == nil || l.LocationInfo == nil {
+		return map[string]any{}
+	}
+	return l.LocationInfo
 }
 
 // GetLogID returns the LogID field if it's non-nil, zero value otherwise.
@@ -6408,6 +6680,14 @@ func (o *OrganizationConnectionList) String() string {
 	return Stringify(o)
 }
 
+// GetAppMetadata returns the AppMetadata map if it's non-nil, an empty map otherwise.
+func (o *OrganizationInvitation) GetAppMetadata() map[string]any {
+	if o == nil || o.AppMetadata == nil {
+		return map[string]any{}
+	}
+	return o.AppMetadata
+}
+
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
 func (o *OrganizationInvitation) GetClientID() string {
 	if o == nil || o.ClientID == nil {
@@ -6502,6 +6782,14 @@ func (o *OrganizationInvitation) GetTTLSec() int {
 		return 0
 	}
 	return *o.TTLSec
+}
+
+// GetUserMetadata returns the UserMetadata map if it's non-nil, an empty map otherwise.
+func (o *OrganizationInvitation) GetUserMetadata() map[string]any {
+	if o == nil || o.UserMetadata == nil {
+		return map[string]any{}
+	}
+	return o.UserMetadata
 }
 
 // String returns a string representation of OrganizationInvitation.
@@ -7777,6 +8065,14 @@ func (t *Ticket) String() string {
 	return Stringify(t)
 }
 
+// GetAppMetadata returns the AppMetadata field if it's non-nil, zero value otherwise.
+func (u *User) GetAppMetadata() map[string]any {
+	if u == nil || u.AppMetadata == nil {
+		return map[string]any{}
+	}
+	return *u.AppMetadata
+}
+
 // GetBlocked returns the Blocked field if it's non-nil, zero value otherwise.
 func (u *User) GetBlocked() bool {
 	if u == nil || u.Blocked == nil {
@@ -7977,6 +8273,14 @@ func (u *User) GetURL() string {
 	return *u.URL
 }
 
+// GetUserMetadata returns the UserMetadata field if it's non-nil, zero value otherwise.
+func (u *User) GetUserMetadata() map[string]any {
+	if u == nil || u.UserMetadata == nil {
+		return map[string]any{}
+	}
+	return *u.UserMetadata
+}
+
 // GetUsername returns the Username field if it's non-nil, zero value otherwise.
 func (u *User) GetUsername() string {
 	if u == nil || u.Username == nil {
@@ -8126,6 +8430,14 @@ func (u *UserIdentity) GetIsSocial() bool {
 		return false
 	}
 	return *u.IsSocial
+}
+
+// GetProfileData returns the ProfileData field if it's non-nil, zero value otherwise.
+func (u *UserIdentity) GetProfileData() map[string]any {
+	if u == nil || u.ProfileData == nil {
+		return map[string]any{}
+	}
+	return *u.ProfileData
 }
 
 // GetProvider returns the Provider field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -348,6 +348,16 @@ func TestActionExecutionResult_GetEndedAt(tt *testing.T) {
 	a.GetEndedAt()
 }
 
+func TestActionExecutionResult_GetError(tt *testing.T) {
+	zeroValue := map[string]any{}
+	a := &ActionExecutionResult{Error: zeroValue}
+	a.GetError()
+	a = &ActionExecutionResult{}
+	a.GetError()
+	a = nil
+	a.GetError()
+}
+
 func TestActionExecutionResult_GetStartedAt(tt *testing.T) {
 	var zeroValue time.Time
 	a := &ActionExecutionResult{StartedAt: &zeroValue}
@@ -1230,6 +1240,16 @@ func TestBruteForceProtection_String(t *testing.T) {
 	}
 }
 
+func TestClient_GetAddons(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &Client{Addons: zeroValue}
+	c.GetAddons()
+	c = &Client{}
+	c.GetAddons()
+	c = nil
+	c.GetAddons()
+}
+
 func TestClient_GetAllowedClients(tt *testing.T) {
 	var zeroValue []string
 	c := &Client{AllowedClients: &zeroValue}
@@ -1305,6 +1325,16 @@ func TestClient_GetClientID(tt *testing.T) {
 	c.GetClientID()
 	c = nil
 	c.GetClientID()
+}
+
+func TestClient_GetClientMetadata(tt *testing.T) {
+	var zeroValue map[string]any
+	c := &Client{ClientMetadata: &zeroValue}
+	c.GetClientMetadata()
+	c = &Client{}
+	c.GetClientMetadata()
+	c = nil
+	c.GetClientMetadata()
 }
 
 func TestClient_GetClientSecret(tt *testing.T) {
@@ -2147,6 +2177,16 @@ func TestConnectionOptions_GetImportMode(tt *testing.T) {
 	c.GetImportMode()
 }
 
+func TestConnectionOptions_GetMFA(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptions{MFA: zeroValue}
+	c.GetMFA()
+	c = &ConnectionOptions{}
+	c.GetMFA()
+	c = nil
+	c.GetMFA()
+}
+
 func TestConnectionOptions_GetNonPersistentAttrs(tt *testing.T) {
 	var zeroValue []string
 	c := &ConnectionOptions{NonPersistentAttrs: &zeroValue}
@@ -2155,6 +2195,46 @@ func TestConnectionOptions_GetNonPersistentAttrs(tt *testing.T) {
 	c.GetNonPersistentAttrs()
 	c = nil
 	c.GetNonPersistentAttrs()
+}
+
+func TestConnectionOptions_GetPasswordComplexityOptions(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptions{PasswordComplexityOptions: zeroValue}
+	c.GetPasswordComplexityOptions()
+	c = &ConnectionOptions{}
+	c.GetPasswordComplexityOptions()
+	c = nil
+	c.GetPasswordComplexityOptions()
+}
+
+func TestConnectionOptions_GetPasswordDictionary(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptions{PasswordDictionary: zeroValue}
+	c.GetPasswordDictionary()
+	c = &ConnectionOptions{}
+	c.GetPasswordDictionary()
+	c = nil
+	c.GetPasswordDictionary()
+}
+
+func TestConnectionOptions_GetPasswordHistory(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptions{PasswordHistory: zeroValue}
+	c.GetPasswordHistory()
+	c = &ConnectionOptions{}
+	c.GetPasswordHistory()
+	c = nil
+	c.GetPasswordHistory()
+}
+
+func TestConnectionOptions_GetPasswordNoPersonalInfo(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptions{PasswordNoPersonalInfo: zeroValue}
+	c.GetPasswordNoPersonalInfo()
+	c = &ConnectionOptions{}
+	c.GetPasswordNoPersonalInfo()
+	c = nil
+	c.GetPasswordNoPersonalInfo()
 }
 
 func TestConnectionOptions_GetPasswordPolicy(tt *testing.T) {
@@ -2195,6 +2275,26 @@ func TestConnectionOptions_GetStrategyVersion(tt *testing.T) {
 	c.GetStrategyVersion()
 	c = nil
 	c.GetStrategyVersion()
+}
+
+func TestConnectionOptions_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptions{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptions{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
+}
+
+func TestConnectionOptions_GetValidation(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptions{Validation: zeroValue}
+	c.GetValidation()
+	c = &ConnectionOptions{}
+	c.GetValidation()
+	c = nil
+	c.GetValidation()
 }
 
 func TestConnectionOptions_String(t *testing.T) {
@@ -2303,6 +2403,16 @@ func TestConnectionOptionsAD_GetTenantDomain(tt *testing.T) {
 	c.GetTenantDomain()
 	c = nil
 	c.GetTenantDomain()
+}
+
+func TestConnectionOptionsAD_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsAD{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsAD{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
 }
 
 func TestConnectionOptionsAD_String(t *testing.T) {
@@ -2423,6 +2533,16 @@ func TestConnectionOptionsADFS_GetTrustEmailVerified(tt *testing.T) {
 	c.GetTrustEmailVerified()
 }
 
+func TestConnectionOptionsADFS_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsADFS{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsADFS{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
+}
+
 func TestConnectionOptionsADFS_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ConnectionOptionsADFS{}
@@ -2519,6 +2639,16 @@ func TestConnectionOptionsApple_GetTeamID(tt *testing.T) {
 	c.GetTeamID()
 	c = nil
 	c.GetTeamID()
+}
+
+func TestConnectionOptionsApple_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsApple{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsApple{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
 }
 
 func TestConnectionOptionsApple_String(t *testing.T) {
@@ -2739,6 +2869,16 @@ func TestConnectionOptionsAzureAD_GetTrustEmailVerified(tt *testing.T) {
 	c.GetTrustEmailVerified()
 }
 
+func TestConnectionOptionsAzureAD_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsAzureAD{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsAzureAD{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
+}
+
 func TestConnectionOptionsAzureAD_GetUseCommonEndpoint(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptionsAzureAD{UseCommonEndpoint: &zeroValue}
@@ -2849,6 +2989,16 @@ func TestConnectionOptionsEmail_GetSetUserAttributes(tt *testing.T) {
 	c.GetSetUserAttributes()
 	c = nil
 	c.GetSetUserAttributes()
+}
+
+func TestConnectionOptionsEmail_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsEmail{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsEmail{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
 }
 
 func TestConnectionOptionsEmail_String(t *testing.T) {
@@ -3205,6 +3355,16 @@ func TestConnectionOptionsFacebook_GetSetUserAttributes(tt *testing.T) {
 	c.GetSetUserAttributes()
 	c = nil
 	c.GetSetUserAttributes()
+}
+
+func TestConnectionOptionsFacebook_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsFacebook{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsFacebook{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
 }
 
 func TestConnectionOptionsFacebook_GetUserAgeRange(tt *testing.T) {
@@ -3585,6 +3745,16 @@ func TestConnectionOptionsGitHub_GetSetUserAttributes(tt *testing.T) {
 	c.GetSetUserAttributes()
 }
 
+func TestConnectionOptionsGitHub_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsGitHub{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsGitHub{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
+}
+
 func TestConnectionOptionsGitHub_GetWriteOrg(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptionsGitHub{WriteOrg: &zeroValue}
@@ -3771,6 +3941,16 @@ func TestConnectionOptionsGoogleApps_GetTenantDomain(tt *testing.T) {
 	c.GetTenantDomain()
 	c = nil
 	c.GetTenantDomain()
+}
+
+func TestConnectionOptionsGoogleApps_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsGoogleApps{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsGoogleApps{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
 }
 
 func TestConnectionOptionsGoogleApps_String(t *testing.T) {
@@ -4101,6 +4281,16 @@ func TestConnectionOptionsGoogleOAuth2_GetTasks(tt *testing.T) {
 	c.GetTasks()
 }
 
+func TestConnectionOptionsGoogleOAuth2_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsGoogleOAuth2{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsGoogleOAuth2{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
+}
+
 func TestConnectionOptionsGoogleOAuth2_GetURLShortener(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptionsGoogleOAuth2{URLShortener: &zeroValue}
@@ -4219,6 +4409,16 @@ func TestConnectionOptionsLinkedin_GetStrategyVersion(tt *testing.T) {
 	c.GetStrategyVersion()
 }
 
+func TestConnectionOptionsLinkedin_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsLinkedin{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsLinkedin{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
+}
+
 func TestConnectionOptionsLinkedin_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ConnectionOptionsLinkedin{}
@@ -4325,6 +4525,16 @@ func TestConnectionOptionsOAuth2_GetTokenURL(tt *testing.T) {
 	c.GetTokenURL()
 	c = nil
 	c.GetTokenURL()
+}
+
+func TestConnectionOptionsOAuth2_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsOAuth2{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsOAuth2{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
 }
 
 func TestConnectionOptionsOAuth2_String(t *testing.T) {
@@ -4475,6 +4685,16 @@ func TestConnectionOptionsOIDC_GetType(tt *testing.T) {
 	c.GetType()
 }
 
+func TestConnectionOptionsOIDC_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsOIDC{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsOIDC{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
+}
+
 func TestConnectionOptionsOIDC_GetUserInfoEndpoint(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsOIDC{UserInfoEndpoint: &zeroValue}
@@ -4611,6 +4831,16 @@ func TestConnectionOptionsOkta_GetTokenEndpoint(tt *testing.T) {
 	c.GetTokenEndpoint()
 	c = nil
 	c.GetTokenEndpoint()
+}
+
+func TestConnectionOptionsOkta_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsOkta{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsOkta{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
 }
 
 func TestConnectionOptionsOkta_GetUserInfoEndpoint(tt *testing.T) {
@@ -4786,6 +5016,16 @@ func TestConnectionOptionsPingFederate_GetTenantDomain(tt *testing.T) {
 	c.GetTenantDomain()
 }
 
+func TestConnectionOptionsPingFederate_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsPingFederate{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
+}
+
 func TestConnectionOptionsPingFederate_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ConnectionOptionsPingFederate{}
@@ -4852,6 +5092,16 @@ func TestConnectionOptionsSalesforce_GetSetUserAttributes(tt *testing.T) {
 	c.GetSetUserAttributes()
 	c = nil
 	c.GetSetUserAttributes()
+}
+
+func TestConnectionOptionsSalesforce_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsSalesforce{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsSalesforce{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
 }
 
 func TestConnectionOptionsSalesforce_String(t *testing.T) {
@@ -4930,6 +5180,16 @@ func TestConnectionOptionsSAML_GetExpires(tt *testing.T) {
 	c.GetExpires()
 	c = nil
 	c.GetExpires()
+}
+
+func TestConnectionOptionsSAML_GetFieldsMap(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsSAML{FieldsMap: zeroValue}
+	c.GetFieldsMap()
+	c = &ConnectionOptionsSAML{}
+	c.GetFieldsMap()
+	c = nil
+	c.GetFieldsMap()
 }
 
 func TestConnectionOptionsSAML_GetIdpInitiated(tt *testing.T) {
@@ -5066,6 +5326,16 @@ func TestConnectionOptionsSAML_GetSignSAMLRequest(tt *testing.T) {
 	c.GetSignSAMLRequest()
 }
 
+func TestConnectionOptionsSAML_GetSubject(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsSAML{Subject: zeroValue}
+	c.GetSubject()
+	c = &ConnectionOptionsSAML{}
+	c.GetSubject()
+	c = nil
+	c.GetSubject()
+}
+
 func TestConnectionOptionsSAML_GetTenantDomain(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsSAML{TenantDomain: &zeroValue}
@@ -5074,6 +5344,16 @@ func TestConnectionOptionsSAML_GetTenantDomain(tt *testing.T) {
 	c.GetTenantDomain()
 	c = nil
 	c.GetTenantDomain()
+}
+
+func TestConnectionOptionsSAML_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsSAML{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsSAML{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
 }
 
 func TestConnectionOptionsSAML_GetUserIDAttribute(tt *testing.T) {
@@ -5324,6 +5604,16 @@ func TestConnectionOptionsSMS_GetTwilioToken(tt *testing.T) {
 	c.GetTwilioToken()
 }
 
+func TestConnectionOptionsSMS_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsSMS{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsSMS{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
+}
+
 func TestConnectionOptionsSMS_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ConnectionOptionsSMS{}
@@ -5570,6 +5860,16 @@ func TestConnectionOptionsWindowsLive_GetTasksUpdate(tt *testing.T) {
 	c.GetTasksUpdate()
 	c = nil
 	c.GetTasksUpdate()
+}
+
+func TestConnectionOptionsWindowsLive_GetUpstreamParams(tt *testing.T) {
+	zeroValue := map[string]any{}
+	c := &ConnectionOptionsWindowsLive{UpstreamParams: zeroValue}
+	c.GetUpstreamParams()
+	c = &ConnectionOptionsWindowsLive{}
+	c.GetUpstreamParams()
+	c = nil
+	c.GetUpstreamParams()
 }
 
 func TestConnectionOptionsWindowsLive_GetUser(tt *testing.T) {
@@ -5952,6 +6252,16 @@ func TestEmail_GetName(tt *testing.T) {
 	e.GetName()
 	e = nil
 	e.GetName()
+}
+
+func TestEmail_GetSettings(tt *testing.T) {
+	zeroValue := map[string]any{}
+	e := &Email{Settings: zeroValue}
+	e.GetSettings()
+	e = &Email{}
+	e.GetSettings()
+	e = nil
+	e.GetSettings()
 }
 
 func TestEmail_String(t *testing.T) {
@@ -6903,6 +7213,16 @@ func TestJob_String(t *testing.T) {
 	}
 }
 
+func TestJobError_GetUser(tt *testing.T) {
+	zeroValue := map[string]any{}
+	j := &JobError{User: zeroValue}
+	j.GetUser()
+	j = &JobError{}
+	j.GetUser()
+	j = nil
+	j.GetUser()
+}
+
 func TestJobError_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &JobError{}
@@ -7045,6 +7365,16 @@ func TestLog_GetDescription(tt *testing.T) {
 	l.GetDescription()
 }
 
+func TestLog_GetDetails(tt *testing.T) {
+	zeroValue := map[string]any{}
+	l := &Log{Details: zeroValue}
+	l.GetDetails()
+	l = &Log{}
+	l.GetDetails()
+	l = nil
+	l.GetDetails()
+}
+
 func TestLog_GetHostname(tt *testing.T) {
 	var zeroValue string
 	l := &Log{Hostname: &zeroValue}
@@ -7083,6 +7413,16 @@ func TestLog_GetIsMobile(tt *testing.T) {
 	l.GetIsMobile()
 	l = nil
 	l.GetIsMobile()
+}
+
+func TestLog_GetLocationInfo(tt *testing.T) {
+	zeroValue := map[string]any{}
+	l := &Log{LocationInfo: zeroValue}
+	l.GetLocationInfo()
+	l = &Log{}
+	l.GetLocationInfo()
+	l = nil
+	l.GetLocationInfo()
 }
 
 func TestLog_GetLogID(tt *testing.T) {
@@ -8149,6 +8489,16 @@ func TestOrganizationConnectionList_String(t *testing.T) {
 	}
 }
 
+func TestOrganizationInvitation_GetAppMetadata(tt *testing.T) {
+	zeroValue := map[string]any{}
+	o := &OrganizationInvitation{AppMetadata: zeroValue}
+	o.GetAppMetadata()
+	o = &OrganizationInvitation{}
+	o.GetAppMetadata()
+	o = nil
+	o.GetAppMetadata()
+}
+
 func TestOrganizationInvitation_GetClientID(tt *testing.T) {
 	var zeroValue string
 	o := &OrganizationInvitation{ClientID: &zeroValue}
@@ -8261,6 +8611,16 @@ func TestOrganizationInvitation_GetTTLSec(tt *testing.T) {
 	o.GetTTLSec()
 	o = nil
 	o.GetTTLSec()
+}
+
+func TestOrganizationInvitation_GetUserMetadata(tt *testing.T) {
+	zeroValue := map[string]any{}
+	o := &OrganizationInvitation{UserMetadata: zeroValue}
+	o.GetUserMetadata()
+	o = &OrganizationInvitation{}
+	o.GetUserMetadata()
+	o = nil
+	o.GetUserMetadata()
 }
 
 func TestOrganizationInvitation_String(t *testing.T) {
@@ -9883,6 +10243,16 @@ func TestTicket_String(t *testing.T) {
 	}
 }
 
+func TestUser_GetAppMetadata(tt *testing.T) {
+	var zeroValue map[string]any
+	u := &User{AppMetadata: &zeroValue}
+	u.GetAppMetadata()
+	u = &User{}
+	u.GetAppMetadata()
+	u = nil
+	u.GetAppMetadata()
+}
+
 func TestUser_GetBlocked(tt *testing.T) {
 	var zeroValue bool
 	u := &User{Blocked: &zeroValue}
@@ -10133,6 +10503,16 @@ func TestUser_GetURL(tt *testing.T) {
 	u.GetURL()
 }
 
+func TestUser_GetUserMetadata(tt *testing.T) {
+	var zeroValue map[string]any
+	u := &User{UserMetadata: &zeroValue}
+	u.GetUserMetadata()
+	u = &User{}
+	u.GetUserMetadata()
+	u = nil
+	u.GetUserMetadata()
+}
+
 func TestUser_GetUsername(tt *testing.T) {
 	var zeroValue string
 	u := &User{Username: &zeroValue}
@@ -10325,6 +10705,16 @@ func TestUserIdentity_GetIsSocial(tt *testing.T) {
 	u.GetIsSocial()
 	u = nil
 	u.GetIsSocial()
+}
+
+func TestUserIdentity_GetProfileData(tt *testing.T) {
+	var zeroValue map[string]any
+	u := &UserIdentity{ProfileData: &zeroValue}
+	u.GetProfileData()
+	u = &UserIdentity{}
+	u.GetProfileData()
+	u = nil
+	u.GetProfileData()
 }
 
 func TestUserIdentity_GetProvider(tt *testing.T) {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -7533,6 +7533,16 @@ func TestLog_String(t *testing.T) {
 	}
 }
 
+func TestLogStream_GetFilters(tt *testing.T) {
+	var zeroValue []map[string]string
+	l := &LogStream{Filters: &zeroValue}
+	l.GetFilters()
+	l = &LogStream{}
+	l.GetFilters()
+	l = nil
+	l.GetFilters()
+}
+
 func TestLogStream_GetID(tt *testing.T) {
 	var zeroValue string
 	l := &LogStream{ID: &zeroValue}
@@ -7723,6 +7733,16 @@ func TestLogStreamSinkHTTP_GetContentType(tt *testing.T) {
 	l.GetContentType()
 	l = nil
 	l.GetContentType()
+}
+
+func TestLogStreamSinkHTTP_GetCustomHeaders(tt *testing.T) {
+	var zeroValue []map[string]string
+	l := &LogStreamSinkHTTP{CustomHeaders: &zeroValue}
+	l.GetCustomHeaders()
+	l = &LogStreamSinkHTTP{}
+	l.GetCustomHeaders()
+	l = nil
+	l.GetCustomHeaders()
 }
 
 func TestLogStreamSinkHTTP_GetEndpoint(tt *testing.T) {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -349,7 +349,7 @@ func TestActionExecutionResult_GetEndedAt(tt *testing.T) {
 }
 
 func TestActionExecutionResult_GetError(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	a := &ActionExecutionResult{Error: zeroValue}
 	a.GetError()
 	a = &ActionExecutionResult{}
@@ -1241,7 +1241,7 @@ func TestBruteForceProtection_String(t *testing.T) {
 }
 
 func TestClient_GetAddons(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &Client{Addons: zeroValue}
 	c.GetAddons()
 	c = &Client{}
@@ -1328,7 +1328,7 @@ func TestClient_GetClientID(tt *testing.T) {
 }
 
 func TestClient_GetClientMetadata(tt *testing.T) {
-	var zeroValue map[string]any
+	var zeroValue map[string]interface{}
 	c := &Client{ClientMetadata: &zeroValue}
 	c.GetClientMetadata()
 	c = &Client{}
@@ -2178,7 +2178,7 @@ func TestConnectionOptions_GetImportMode(tt *testing.T) {
 }
 
 func TestConnectionOptions_GetMFA(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptions{MFA: zeroValue}
 	c.GetMFA()
 	c = &ConnectionOptions{}
@@ -2198,7 +2198,7 @@ func TestConnectionOptions_GetNonPersistentAttrs(tt *testing.T) {
 }
 
 func TestConnectionOptions_GetPasswordComplexityOptions(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptions{PasswordComplexityOptions: zeroValue}
 	c.GetPasswordComplexityOptions()
 	c = &ConnectionOptions{}
@@ -2208,7 +2208,7 @@ func TestConnectionOptions_GetPasswordComplexityOptions(tt *testing.T) {
 }
 
 func TestConnectionOptions_GetPasswordDictionary(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptions{PasswordDictionary: zeroValue}
 	c.GetPasswordDictionary()
 	c = &ConnectionOptions{}
@@ -2218,7 +2218,7 @@ func TestConnectionOptions_GetPasswordDictionary(tt *testing.T) {
 }
 
 func TestConnectionOptions_GetPasswordHistory(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptions{PasswordHistory: zeroValue}
 	c.GetPasswordHistory()
 	c = &ConnectionOptions{}
@@ -2228,7 +2228,7 @@ func TestConnectionOptions_GetPasswordHistory(tt *testing.T) {
 }
 
 func TestConnectionOptions_GetPasswordNoPersonalInfo(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptions{PasswordNoPersonalInfo: zeroValue}
 	c.GetPasswordNoPersonalInfo()
 	c = &ConnectionOptions{}
@@ -2278,7 +2278,7 @@ func TestConnectionOptions_GetStrategyVersion(tt *testing.T) {
 }
 
 func TestConnectionOptions_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptions{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptions{}
@@ -2288,7 +2288,7 @@ func TestConnectionOptions_GetUpstreamParams(tt *testing.T) {
 }
 
 func TestConnectionOptions_GetValidation(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptions{Validation: zeroValue}
 	c.GetValidation()
 	c = &ConnectionOptions{}
@@ -2406,7 +2406,7 @@ func TestConnectionOptionsAD_GetTenantDomain(tt *testing.T) {
 }
 
 func TestConnectionOptionsAD_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsAD{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsAD{}
@@ -2534,7 +2534,7 @@ func TestConnectionOptionsADFS_GetTrustEmailVerified(tt *testing.T) {
 }
 
 func TestConnectionOptionsADFS_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsADFS{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsADFS{}
@@ -2642,7 +2642,7 @@ func TestConnectionOptionsApple_GetTeamID(tt *testing.T) {
 }
 
 func TestConnectionOptionsApple_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsApple{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsApple{}
@@ -2870,7 +2870,7 @@ func TestConnectionOptionsAzureAD_GetTrustEmailVerified(tt *testing.T) {
 }
 
 func TestConnectionOptionsAzureAD_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsAzureAD{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsAzureAD{}
@@ -2992,7 +2992,7 @@ func TestConnectionOptionsEmail_GetSetUserAttributes(tt *testing.T) {
 }
 
 func TestConnectionOptionsEmail_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsEmail{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsEmail{}
@@ -3358,7 +3358,7 @@ func TestConnectionOptionsFacebook_GetSetUserAttributes(tt *testing.T) {
 }
 
 func TestConnectionOptionsFacebook_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsFacebook{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsFacebook{}
@@ -3746,7 +3746,7 @@ func TestConnectionOptionsGitHub_GetSetUserAttributes(tt *testing.T) {
 }
 
 func TestConnectionOptionsGitHub_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsGitHub{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsGitHub{}
@@ -3944,7 +3944,7 @@ func TestConnectionOptionsGoogleApps_GetTenantDomain(tt *testing.T) {
 }
 
 func TestConnectionOptionsGoogleApps_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsGoogleApps{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsGoogleApps{}
@@ -4282,7 +4282,7 @@ func TestConnectionOptionsGoogleOAuth2_GetTasks(tt *testing.T) {
 }
 
 func TestConnectionOptionsGoogleOAuth2_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsGoogleOAuth2{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsGoogleOAuth2{}
@@ -4410,7 +4410,7 @@ func TestConnectionOptionsLinkedin_GetStrategyVersion(tt *testing.T) {
 }
 
 func TestConnectionOptionsLinkedin_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsLinkedin{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsLinkedin{}
@@ -4528,7 +4528,7 @@ func TestConnectionOptionsOAuth2_GetTokenURL(tt *testing.T) {
 }
 
 func TestConnectionOptionsOAuth2_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsOAuth2{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsOAuth2{}
@@ -4686,7 +4686,7 @@ func TestConnectionOptionsOIDC_GetType(tt *testing.T) {
 }
 
 func TestConnectionOptionsOIDC_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsOIDC{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsOIDC{}
@@ -4834,7 +4834,7 @@ func TestConnectionOptionsOkta_GetTokenEndpoint(tt *testing.T) {
 }
 
 func TestConnectionOptionsOkta_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsOkta{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsOkta{}
@@ -5017,7 +5017,7 @@ func TestConnectionOptionsPingFederate_GetTenantDomain(tt *testing.T) {
 }
 
 func TestConnectionOptionsPingFederate_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsPingFederate{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsPingFederate{}
@@ -5095,7 +5095,7 @@ func TestConnectionOptionsSalesforce_GetSetUserAttributes(tt *testing.T) {
 }
 
 func TestConnectionOptionsSalesforce_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsSalesforce{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsSalesforce{}
@@ -5183,7 +5183,7 @@ func TestConnectionOptionsSAML_GetExpires(tt *testing.T) {
 }
 
 func TestConnectionOptionsSAML_GetFieldsMap(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsSAML{FieldsMap: zeroValue}
 	c.GetFieldsMap()
 	c = &ConnectionOptionsSAML{}
@@ -5327,7 +5327,7 @@ func TestConnectionOptionsSAML_GetSignSAMLRequest(tt *testing.T) {
 }
 
 func TestConnectionOptionsSAML_GetSubject(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsSAML{Subject: zeroValue}
 	c.GetSubject()
 	c = &ConnectionOptionsSAML{}
@@ -5347,7 +5347,7 @@ func TestConnectionOptionsSAML_GetTenantDomain(tt *testing.T) {
 }
 
 func TestConnectionOptionsSAML_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsSAML{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsSAML{}
@@ -5605,7 +5605,7 @@ func TestConnectionOptionsSMS_GetTwilioToken(tt *testing.T) {
 }
 
 func TestConnectionOptionsSMS_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsSMS{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsSMS{}
@@ -5863,7 +5863,7 @@ func TestConnectionOptionsWindowsLive_GetTasksUpdate(tt *testing.T) {
 }
 
 func TestConnectionOptionsWindowsLive_GetUpstreamParams(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsWindowsLive{UpstreamParams: zeroValue}
 	c.GetUpstreamParams()
 	c = &ConnectionOptionsWindowsLive{}
@@ -6255,7 +6255,7 @@ func TestEmail_GetName(tt *testing.T) {
 }
 
 func TestEmail_GetSettings(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	e := &Email{Settings: zeroValue}
 	e.GetSettings()
 	e = &Email{}
@@ -7214,7 +7214,7 @@ func TestJob_String(t *testing.T) {
 }
 
 func TestJobError_GetUser(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	j := &JobError{User: zeroValue}
 	j.GetUser()
 	j = &JobError{}
@@ -7366,7 +7366,7 @@ func TestLog_GetDescription(tt *testing.T) {
 }
 
 func TestLog_GetDetails(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	l := &Log{Details: zeroValue}
 	l.GetDetails()
 	l = &Log{}
@@ -7416,7 +7416,7 @@ func TestLog_GetIsMobile(tt *testing.T) {
 }
 
 func TestLog_GetLocationInfo(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	l := &Log{LocationInfo: zeroValue}
 	l.GetLocationInfo()
 	l = &Log{}
@@ -8490,7 +8490,7 @@ func TestOrganizationConnectionList_String(t *testing.T) {
 }
 
 func TestOrganizationInvitation_GetAppMetadata(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	o := &OrganizationInvitation{AppMetadata: zeroValue}
 	o.GetAppMetadata()
 	o = &OrganizationInvitation{}
@@ -8614,7 +8614,7 @@ func TestOrganizationInvitation_GetTTLSec(tt *testing.T) {
 }
 
 func TestOrganizationInvitation_GetUserMetadata(tt *testing.T) {
-	zeroValue := map[string]any{}
+	zeroValue := map[string]interface{}{}
 	o := &OrganizationInvitation{UserMetadata: zeroValue}
 	o.GetUserMetadata()
 	o = &OrganizationInvitation{}
@@ -10244,7 +10244,7 @@ func TestTicket_String(t *testing.T) {
 }
 
 func TestUser_GetAppMetadata(tt *testing.T) {
-	var zeroValue map[string]any
+	var zeroValue map[string]interface{}
 	u := &User{AppMetadata: &zeroValue}
 	u.GetAppMetadata()
 	u = &User{}
@@ -10504,7 +10504,7 @@ func TestUser_GetURL(tt *testing.T) {
 }
 
 func TestUser_GetUserMetadata(tt *testing.T) {
-	var zeroValue map[string]any
+	var zeroValue map[string]interface{}
 	u := &User{UserMetadata: &zeroValue}
 	u.GetUserMetadata()
 	u = &User{}
@@ -10708,7 +10708,7 @@ func TestUserIdentity_GetIsSocial(tt *testing.T) {
 }
 
 func TestUserIdentity_GetProfileData(tt *testing.T) {
-	var zeroValue map[string]any
+	var zeroValue map[string]interface{}
 	u := &UserIdentity{ProfileData: &zeroValue}
 	u.GetProfileData()
 	u = &UserIdentity{}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds support for generating safe getters for `map[string]interface` types, this means that the SDK can generate a safe getter for all types used

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
