### PR TITLE
[SDK-4223] Improve typing of Client Addons

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,6 +1,5 @@
 # Go-Auth0 v1 Migration Guide
 
-With the v1 release of Go-Auth0, we've
 
 **Please review this guide thoroughly to understand the changes required to migrate your usage of go-auth0 to v1**
 
@@ -11,3 +10,40 @@ With the v1 release of Go-Auth0, we've
 The `Addons` property of a `Client` was previously simply typed as `map[string]interface{}`, now it is explicitly typed to allow better support of addons.
 
 However, with this there are now only two explicitly supported Addon types, `SAML2` and `WS-FED` which are the 2 addons supported in the Management UI. If you require a specific Addon, please open a [feature request](https://github.com/auth0/go-auth0/issues/new?assignees=&labels=feature&projects=&template=feature_request.yml)
+
+<table>
+<tr>
+<th>Before (v0.17.1)</th>
+<th>After (v1.0.0)</th>
+</tr>
+<tr>
+<td>
+
+```go
+client := &management.Client{ 
+    Name: auth0.String("My Client"),
+    Addons: map[string]interface{}{
+        "samlp": map[string]interface{}{
+            "audience": "my-audience",
+        },
+        "wsfed": map[string]interface{}{},
+    },
+}
+```
+</td>
+<td>
+
+```go
+client := &management.Client{
+    Name: auth0.String("My Client"),
+    Addons: &management.ClientAddons{
+        SAML2: &management.SAML2ClientAddon{
+            Audience: auth0.String("my-audience"),
+        },
+        WSFED: &management.WSFEDClientAddon{},
+    },
+}
+```
+</td>
+</tr>
+</table>

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,13 @@
+# Go-Auth0 v1 Migration Guide
+
+With the v1 release of Go-Auth0, we've
+
+**Please review this guide thoroughly to understand the changes required to migrate your usage of go-auth0 to v1**
+
+## Public API Changes
+
+### Improve Typing Of Client Addons
+
+The `Addons` property of a `Client` was previously simply typed as `map[string]interface{}`, now it is explicitly typed to allow better support of addons.
+
+However, with this there are now only two explicitly supported Addon types, `SAML2` and `WS-FED` which are the 2 addons supported in the Management UI. If you require a specific Addon, please open a [feature request](https://github.com/auth0/go-auth0/issues/new?assignees=&labels=feature&projects=&template=feature_request.yml)

--- a/management/client.go
+++ b/management/client.go
@@ -76,11 +76,11 @@ type Client struct {
 	CrossOriginLocation *string `json:"cross_origin_loc,omitempty"`
 
 	// True if the custom login page is to be used, false otherwise. Defaults to true.
-	CustomLoginPageOn      *bool                  `json:"custom_login_page_on,omitempty"`
-	CustomLoginPage        *string                `json:"custom_login_page,omitempty"`
-	CustomLoginPagePreview *string                `json:"custom_login_page_preview,omitempty"`
-	FormTemplate           *string                `json:"form_template,omitempty"`
-	Addons                 map[string]interface{} `json:"addons,omitempty"`
+	CustomLoginPageOn      *bool   `json:"custom_login_page_on,omitempty"`
+	CustomLoginPage        *string `json:"custom_login_page,omitempty"`
+	CustomLoginPagePreview *string `json:"custom_login_page_preview,omitempty"`
+	FormTemplate           *string `json:"form_template,omitempty"`
+	Addons                 *Addons `json:"addons,omitempty"`
 
 	// Defines the requested authentication method for the token endpoint.
 	// Possible values are:
@@ -227,6 +227,84 @@ type PrivateKeyJWT struct {
 // OIDCBackchannelLogout defines the `oidc_backchannel_logout` settings for the client.
 type OIDCBackchannelLogout struct {
 	BackChannelLogoutURLs *[]string `json:"backchannel_logout_urls,omitempty"`
+}
+
+// Addons defines the `addons` settings for a Client.
+type Addons struct {
+	// SAML2 Addon configuration. Set this property to indicate that the Addon should be enabled, all settings are optional.
+	// The first entry in `Callbacks` should be the URL to post the SAML Token to
+	SAML2 *SAML2Addon `json:"samlp,omitempty"`
+	// WS-Fed Addon. Set this property to indicate the Addon should be enabled and then store the
+	// configuration in `Callbacks` and `ClientAliases` properties on the Client.
+	// The first entry in `Callbacks` should be the URL to post the SAML Token to.
+	// ClientAliases should include the Realm which is the identifier sent by the application.
+	WSFED *WSFEDAddon `json:"wsfed,omitempty"`
+}
+
+// SAML2Addon defines the `SAML2` settings for a Client.
+type SAML2Addon struct {
+	// The mappings between the Auth0 user profile and the output attributes on the SAML Assertion.
+	// Each "name" represents the property name on the Auth0 user profile.
+	// Each "value" is the name (including namespace) for the resulting SAML attribute in the assertion.
+	Mappings *map[string]string `json:"mappings,omitempty"`
+	// The audience of the SAML Assertion.
+	Audience *string `json:"audience,omitempty"`
+	// The recipient of the SAML Assertion.
+	Recipient *string `json:"recipient,omitempty"`
+	// Whether or not a UPN claim should be created.
+	CreateUPNClaim *bool `json:"create_upn_claim,omitempty"`
+	// If `PassthroughClaimsWithNoMapping` is true and this is false, for each claim that is not mapped to the common profile Auth0 will add a prefix
+	// 	http://schema.auth0.com	. If true it will passthrough the claim as-is.
+	MapUnknownClaimsAsIs *bool `json:"map_unknown_claims_as_is,omitempty"`
+	// If true, for each claim that is not mapped to the common profile, Auth0 will passthrough those in the output assertion.
+	// If false, those claims won't be mapped.
+	PassthroughClaimsWithNoMapping *bool `json:"passthrough_claims_with_no_mapping,omitempty"`
+	// If true, it will will add more information in the token like the provider used (google, adfs, ad, etc.) and the access_token if available.
+	MapIdentities *bool `json:"map_identities,omitempty"`
+	// Signature algorithm to sign the SAML Assertion or response.
+	SignatureAlgorithm *string `json:"signature_algorithm,omitempty"`
+	// Digest algorithm to calculate digest of the SAML Assertion or response.
+	DigestAlgorithm *string `json:"digest_algorithm,omitempty"`
+	Issuer          *string `json:"issuer,omitempty"`
+	// Destination of the SAML Response. If not specified, it will be AssertionConsumerUrlof SAMLRequest or Callback URL if there was no SAMLRequest.
+	Destination *string `json:"destination,omitempty"`
+	// Expiration of the token.
+	LifetimeInSeconds *int `json:"lifetime_in_seconds,omitempty"`
+	// Whether or not the SAML Response should be signed. By default the SAML Assertion will be signed, but not the SAML Response.
+	// If true, SAML Response will be signed instead of SAML Assertion.
+	SignResponse         *bool   `json:"sign_response,omitempty"`
+	NameIdentifierFormat *string `json:"name_identifier_format,omitempty"`
+	// Auth0 will try each of the attributes of this array in order. If one of them has a value, it will use that for the Subject/NameID
+	NameIdentifierProbes *[]string `json:"name_identifier_probes,omitempty"`
+	AuthnContextClassRef *string   `json:"authn_context_class_ref,omitempty"`
+	// When set to true, the xs:type of the element is inferred. Types are xs:string, xs:boolean, xs:double, and xs:anyType.
+	// When set to false all xs:type are xs:anyType
+	TypedAttributes *bool `json:"typed_attributes,omitempty"`
+	// When set to true, the NameFormat is inferred based on the attribute name.
+	// NameFormat values are urn:oasis:names:tc:SAML:2.0:attrname-format:uri, urn:oasis:names:tc:SAML:2.0:attrname-format:basic,
+	// and urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified.
+	// If set to false, the attribute NameFormat is not set in the assertion.
+	IncludeAttributeNameFormat *bool `json:"include_attribute_name_format,omitempty"`
+	// Indicates the protocol binding used for SAML logout responses.
+	// By default Auth0 uses HTTP-POST, but you can switch to HTTP-Redirect by setting to `urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect`.
+	Binding *string `json:"binding,omitempty"`
+	// Optionally indicates the public key certificate used to validate SAML requests. If set, SAML requests will be required to be signed.
+	SigningCert *string `json:"signing_cert,omitempty"`
+	//  An object that controls SAML logout behavior.
+	Logout *SAML2AddonLogout `json:"logout,omitempty"`
+}
+
+// SAML2AddonLogout defines the `logout` settings for the SAML2Addon.
+type SAML2AddonLogout struct {
+	// The service provider (client application)'s Single Logout Service URL, where Auth0 will send logout requests and responses
+	Callback *string `json:"callback,omitempty"`
+	// Controls whether Auth0 should notify service providers of session termination
+	SLOEnabled *bool `json:"slo_enabled,omitempty"`
+}
+
+// WSFEDAddon is an empty struct used to indicate that the WS-FED Addon should be enabled.
+// Configuration for this Addon is stored in the `Callbacks` and `ClientAliases` properties on the Client.
+type WSFEDAddon struct {
 }
 
 // ClientList is a list of Clients.

--- a/management/client.go
+++ b/management/client.go
@@ -76,11 +76,11 @@ type Client struct {
 	CrossOriginLocation *string `json:"cross_origin_loc,omitempty"`
 
 	// True if the custom login page is to be used, false otherwise. Defaults to true.
-	CustomLoginPageOn      *bool   `json:"custom_login_page_on,omitempty"`
-	CustomLoginPage        *string `json:"custom_login_page,omitempty"`
-	CustomLoginPagePreview *string `json:"custom_login_page_preview,omitempty"`
-	FormTemplate           *string `json:"form_template,omitempty"`
-	Addons                 *Addons `json:"addons,omitempty"`
+	CustomLoginPageOn      *bool         `json:"custom_login_page_on,omitempty"`
+	CustomLoginPage        *string       `json:"custom_login_page,omitempty"`
+	CustomLoginPagePreview *string       `json:"custom_login_page_preview,omitempty"`
+	FormTemplate           *string       `json:"form_template,omitempty"`
+	Addons                 *ClientAddons `json:"addons,omitempty"`
 
 	// Defines the requested authentication method for the token endpoint.
 	// Possible values are:
@@ -229,20 +229,20 @@ type OIDCBackchannelLogout struct {
 	BackChannelLogoutURLs *[]string `json:"backchannel_logout_urls,omitempty"`
 }
 
-// Addons defines the `addons` settings for a Client.
-type Addons struct {
+// ClientAddons defines the `addons` settings for a Client.
+type ClientAddons struct {
 	// SAML2 Addon configuration. Set this property to indicate that the Addon should be enabled, all settings are optional.
-	// The first entry in `Callbacks` should be the URL to post the SAML Token to
-	SAML2 *SAML2Addon `json:"samlp,omitempty"`
+	// The first entry in `Callbacks` should be the URL to post the SAML Token to.
+	SAML2 *SAML2ClientAddon `json:"samlp,omitempty"`
 	// WS-Fed Addon. Set this property to indicate the Addon should be enabled and then store the
 	// configuration in `Callbacks` and `ClientAliases` properties on the Client.
 	// The first entry in `Callbacks` should be the URL to post the SAML Token to.
 	// ClientAliases should include the Realm which is the identifier sent by the application.
-	WSFED *WSFEDAddon `json:"wsfed,omitempty"`
+	WSFED *WSFEDClientAddon `json:"wsfed,omitempty"`
 }
 
-// SAML2Addon defines the `SAML2` settings for a Client.
-type SAML2Addon struct {
+// SAML2ClientAddon defines the `SAML2` settings for a Client.
+type SAML2ClientAddon struct {
 	// The mappings between the Auth0 user profile and the output attributes on the SAML Assertion.
 	// Each "name" represents the property name on the Auth0 user profile.
 	// Each "value" is the name (including namespace) for the resulting SAML attribute in the assertion.
@@ -291,20 +291,20 @@ type SAML2Addon struct {
 	// Optionally indicates the public key certificate used to validate SAML requests. If set, SAML requests will be required to be signed.
 	SigningCert *string `json:"signing_cert,omitempty"`
 	//  An object that controls SAML logout behavior.
-	Logout *SAML2AddonLogout `json:"logout,omitempty"`
+	Logout *SAML2ClientAddonLogout `json:"logout,omitempty"`
 }
 
-// SAML2AddonLogout defines the `logout` settings for the SAML2Addon.
-type SAML2AddonLogout struct {
+// SAML2ClientAddonLogout defines the `logout` settings for the SAML2Addon.
+type SAML2ClientAddonLogout struct {
 	// The service provider (client application)'s Single Logout Service URL, where Auth0 will send logout requests and responses
 	Callback *string `json:"callback,omitempty"`
 	// Controls whether Auth0 should notify service providers of session termination
 	SLOEnabled *bool `json:"slo_enabled,omitempty"`
 }
 
-// WSFEDAddon is an empty struct used to indicate that the WS-FED Addon should be enabled.
+// WSFEDClientAddon is an empty struct used to indicate that the WS-FED Addon should be enabled.
 // Configuration for this Addon is stored in the `Callbacks` and `ClientAliases` properties on the Client.
-type WSFEDAddon struct {
+type WSFEDClientAddon struct {
 }
 
 // ClientList is a list of Clients.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -487,27 +487,6 @@ func (a *ActionVersionList) String() string {
 	return Stringify(a)
 }
 
-// GetSAML2 returns the SAML2 field.
-func (a *Addons) GetSAML2() *SAML2Addon {
-	if a == nil {
-		return nil
-	}
-	return a.SAML2
-}
-
-// GetWSFED returns the WSFED field.
-func (a *Addons) GetWSFED() *WSFEDAddon {
-	if a == nil {
-		return nil
-	}
-	return a.WSFED
-}
-
-// String returns a string representation of Addons.
-func (a *Addons) String() string {
-	return Stringify(a)
-}
-
 // GetAuthenticationMethods returns the AuthenticationMethods field if it's non-nil, zero value otherwise.
 func (a *AuthenticationMethod) GetAuthenticationMethods() []AuthenticationMethodReference {
 	if a == nil || a.AuthenticationMethods == nil {
@@ -985,7 +964,7 @@ func (b *BruteForceProtection) String() string {
 }
 
 // GetAddons returns the Addons field.
-func (c *Client) GetAddons() *Addons {
+func (c *Client) GetAddons() *ClientAddons {
 	if c == nil {
 		return nil
 	}
@@ -1290,6 +1269,27 @@ func (c *Client) GetWebOrigins() []string {
 
 // String returns a string representation of Client.
 func (c *Client) String() string {
+	return Stringify(c)
+}
+
+// GetSAML2 returns the SAML2 field.
+func (c *ClientAddons) GetSAML2() *SAML2ClientAddon {
+	if c == nil {
+		return nil
+	}
+	return c.SAML2
+}
+
+// GetWSFED returns the WSFED field.
+func (c *ClientAddons) GetWSFED() *WSFEDClientAddon {
+	if c == nil {
+		return nil
+	}
+	return c.WSFED
+}
+
+// String returns a string representation of ClientAddons.
+func (c *ClientAddons) String() string {
 	return Stringify(c)
 }
 
@@ -7326,7 +7326,7 @@ func (r *RuleList) String() string {
 }
 
 // GetAudience returns the Audience field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetAudience() string {
+func (s *SAML2ClientAddon) GetAudience() string {
 	if s == nil || s.Audience == nil {
 		return ""
 	}
@@ -7334,7 +7334,7 @@ func (s *SAML2Addon) GetAudience() string {
 }
 
 // GetAuthnContextClassRef returns the AuthnContextClassRef field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetAuthnContextClassRef() string {
+func (s *SAML2ClientAddon) GetAuthnContextClassRef() string {
 	if s == nil || s.AuthnContextClassRef == nil {
 		return ""
 	}
@@ -7342,7 +7342,7 @@ func (s *SAML2Addon) GetAuthnContextClassRef() string {
 }
 
 // GetBinding returns the Binding field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetBinding() string {
+func (s *SAML2ClientAddon) GetBinding() string {
 	if s == nil || s.Binding == nil {
 		return ""
 	}
@@ -7350,7 +7350,7 @@ func (s *SAML2Addon) GetBinding() string {
 }
 
 // GetCreateUPNClaim returns the CreateUPNClaim field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetCreateUPNClaim() bool {
+func (s *SAML2ClientAddon) GetCreateUPNClaim() bool {
 	if s == nil || s.CreateUPNClaim == nil {
 		return false
 	}
@@ -7358,7 +7358,7 @@ func (s *SAML2Addon) GetCreateUPNClaim() bool {
 }
 
 // GetDestination returns the Destination field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetDestination() string {
+func (s *SAML2ClientAddon) GetDestination() string {
 	if s == nil || s.Destination == nil {
 		return ""
 	}
@@ -7366,7 +7366,7 @@ func (s *SAML2Addon) GetDestination() string {
 }
 
 // GetDigestAlgorithm returns the DigestAlgorithm field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetDigestAlgorithm() string {
+func (s *SAML2ClientAddon) GetDigestAlgorithm() string {
 	if s == nil || s.DigestAlgorithm == nil {
 		return ""
 	}
@@ -7374,7 +7374,7 @@ func (s *SAML2Addon) GetDigestAlgorithm() string {
 }
 
 // GetIncludeAttributeNameFormat returns the IncludeAttributeNameFormat field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetIncludeAttributeNameFormat() bool {
+func (s *SAML2ClientAddon) GetIncludeAttributeNameFormat() bool {
 	if s == nil || s.IncludeAttributeNameFormat == nil {
 		return false
 	}
@@ -7382,7 +7382,7 @@ func (s *SAML2Addon) GetIncludeAttributeNameFormat() bool {
 }
 
 // GetIssuer returns the Issuer field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetIssuer() string {
+func (s *SAML2ClientAddon) GetIssuer() string {
 	if s == nil || s.Issuer == nil {
 		return ""
 	}
@@ -7390,7 +7390,7 @@ func (s *SAML2Addon) GetIssuer() string {
 }
 
 // GetLifetimeInSeconds returns the LifetimeInSeconds field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetLifetimeInSeconds() int {
+func (s *SAML2ClientAddon) GetLifetimeInSeconds() int {
 	if s == nil || s.LifetimeInSeconds == nil {
 		return 0
 	}
@@ -7398,7 +7398,7 @@ func (s *SAML2Addon) GetLifetimeInSeconds() int {
 }
 
 // GetLogout returns the Logout field.
-func (s *SAML2Addon) GetLogout() *SAML2AddonLogout {
+func (s *SAML2ClientAddon) GetLogout() *SAML2ClientAddonLogout {
 	if s == nil {
 		return nil
 	}
@@ -7406,7 +7406,7 @@ func (s *SAML2Addon) GetLogout() *SAML2AddonLogout {
 }
 
 // GetMapIdentities returns the MapIdentities field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetMapIdentities() bool {
+func (s *SAML2ClientAddon) GetMapIdentities() bool {
 	if s == nil || s.MapIdentities == nil {
 		return false
 	}
@@ -7414,7 +7414,7 @@ func (s *SAML2Addon) GetMapIdentities() bool {
 }
 
 // GetMappings returns the Mappings field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetMappings() map[string]string {
+func (s *SAML2ClientAddon) GetMappings() map[string]string {
 	if s == nil || s.Mappings == nil {
 		return map[string]string{}
 	}
@@ -7422,7 +7422,7 @@ func (s *SAML2Addon) GetMappings() map[string]string {
 }
 
 // GetMapUnknownClaimsAsIs returns the MapUnknownClaimsAsIs field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetMapUnknownClaimsAsIs() bool {
+func (s *SAML2ClientAddon) GetMapUnknownClaimsAsIs() bool {
 	if s == nil || s.MapUnknownClaimsAsIs == nil {
 		return false
 	}
@@ -7430,7 +7430,7 @@ func (s *SAML2Addon) GetMapUnknownClaimsAsIs() bool {
 }
 
 // GetNameIdentifierFormat returns the NameIdentifierFormat field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetNameIdentifierFormat() string {
+func (s *SAML2ClientAddon) GetNameIdentifierFormat() string {
 	if s == nil || s.NameIdentifierFormat == nil {
 		return ""
 	}
@@ -7438,7 +7438,7 @@ func (s *SAML2Addon) GetNameIdentifierFormat() string {
 }
 
 // GetNameIdentifierProbes returns the NameIdentifierProbes field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetNameIdentifierProbes() []string {
+func (s *SAML2ClientAddon) GetNameIdentifierProbes() []string {
 	if s == nil || s.NameIdentifierProbes == nil {
 		return nil
 	}
@@ -7446,7 +7446,7 @@ func (s *SAML2Addon) GetNameIdentifierProbes() []string {
 }
 
 // GetPassthroughClaimsWithNoMapping returns the PassthroughClaimsWithNoMapping field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetPassthroughClaimsWithNoMapping() bool {
+func (s *SAML2ClientAddon) GetPassthroughClaimsWithNoMapping() bool {
 	if s == nil || s.PassthroughClaimsWithNoMapping == nil {
 		return false
 	}
@@ -7454,7 +7454,7 @@ func (s *SAML2Addon) GetPassthroughClaimsWithNoMapping() bool {
 }
 
 // GetRecipient returns the Recipient field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetRecipient() string {
+func (s *SAML2ClientAddon) GetRecipient() string {
 	if s == nil || s.Recipient == nil {
 		return ""
 	}
@@ -7462,7 +7462,7 @@ func (s *SAML2Addon) GetRecipient() string {
 }
 
 // GetSignatureAlgorithm returns the SignatureAlgorithm field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetSignatureAlgorithm() string {
+func (s *SAML2ClientAddon) GetSignatureAlgorithm() string {
 	if s == nil || s.SignatureAlgorithm == nil {
 		return ""
 	}
@@ -7470,7 +7470,7 @@ func (s *SAML2Addon) GetSignatureAlgorithm() string {
 }
 
 // GetSigningCert returns the SigningCert field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetSigningCert() string {
+func (s *SAML2ClientAddon) GetSigningCert() string {
 	if s == nil || s.SigningCert == nil {
 		return ""
 	}
@@ -7478,7 +7478,7 @@ func (s *SAML2Addon) GetSigningCert() string {
 }
 
 // GetSignResponse returns the SignResponse field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetSignResponse() bool {
+func (s *SAML2ClientAddon) GetSignResponse() bool {
 	if s == nil || s.SignResponse == nil {
 		return false
 	}
@@ -7486,20 +7486,20 @@ func (s *SAML2Addon) GetSignResponse() bool {
 }
 
 // GetTypedAttributes returns the TypedAttributes field if it's non-nil, zero value otherwise.
-func (s *SAML2Addon) GetTypedAttributes() bool {
+func (s *SAML2ClientAddon) GetTypedAttributes() bool {
 	if s == nil || s.TypedAttributes == nil {
 		return false
 	}
 	return *s.TypedAttributes
 }
 
-// String returns a string representation of SAML2Addon.
-func (s *SAML2Addon) String() string {
+// String returns a string representation of SAML2ClientAddon.
+func (s *SAML2ClientAddon) String() string {
 	return Stringify(s)
 }
 
 // GetCallback returns the Callback field if it's non-nil, zero value otherwise.
-func (s *SAML2AddonLogout) GetCallback() string {
+func (s *SAML2ClientAddonLogout) GetCallback() string {
 	if s == nil || s.Callback == nil {
 		return ""
 	}
@@ -7507,15 +7507,15 @@ func (s *SAML2AddonLogout) GetCallback() string {
 }
 
 // GetSLOEnabled returns the SLOEnabled field if it's non-nil, zero value otherwise.
-func (s *SAML2AddonLogout) GetSLOEnabled() bool {
+func (s *SAML2ClientAddonLogout) GetSLOEnabled() bool {
 	if s == nil || s.SLOEnabled == nil {
 		return false
 	}
 	return *s.SLOEnabled
 }
 
-// String returns a string representation of SAML2AddonLogout.
-func (s *SAML2AddonLogout) String() string {
+// String returns a string representation of SAML2ClientAddonLogout.
+func (s *SAML2ClientAddonLogout) String() string {
 	return Stringify(s)
 }
 
@@ -8755,7 +8755,7 @@ func (u *UserRecoveryCode) String() string {
 	return Stringify(u)
 }
 
-// String returns a string representation of WSFEDAddon.
-func (w *WSFEDAddon) String() string {
+// String returns a string representation of WSFEDClientAddon.
+func (w *WSFEDClientAddon) String() string {
 	return Stringify(w)
 }

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -487,6 +487,27 @@ func (a *ActionVersionList) String() string {
 	return Stringify(a)
 }
 
+// GetSAML2 returns the SAML2 field.
+func (a *Addons) GetSAML2() *SAML2Addon {
+	if a == nil {
+		return nil
+	}
+	return a.SAML2
+}
+
+// GetWSFED returns the WSFED field.
+func (a *Addons) GetWSFED() *WSFEDAddon {
+	if a == nil {
+		return nil
+	}
+	return a.WSFED
+}
+
+// String returns a string representation of Addons.
+func (a *Addons) String() string {
+	return Stringify(a)
+}
+
 // GetAuthenticationMethods returns the AuthenticationMethods field if it's non-nil, zero value otherwise.
 func (a *AuthenticationMethod) GetAuthenticationMethods() []AuthenticationMethodReference {
 	if a == nil || a.AuthenticationMethods == nil {
@@ -963,10 +984,10 @@ func (b *BruteForceProtection) String() string {
 	return Stringify(b)
 }
 
-// GetAddons returns the Addons map if it's non-nil, an empty map otherwise.
-func (c *Client) GetAddons() map[string]interface{} {
-	if c == nil || c.Addons == nil {
-		return map[string]interface{}{}
+// GetAddons returns the Addons field.
+func (c *Client) GetAddons() *Addons {
+	if c == nil {
+		return nil
 	}
 	return c.Addons
 }
@@ -7304,6 +7325,200 @@ func (r *RuleList) String() string {
 	return Stringify(r)
 }
 
+// GetAudience returns the Audience field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetAudience() string {
+	if s == nil || s.Audience == nil {
+		return ""
+	}
+	return *s.Audience
+}
+
+// GetAuthnContextClassRef returns the AuthnContextClassRef field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetAuthnContextClassRef() string {
+	if s == nil || s.AuthnContextClassRef == nil {
+		return ""
+	}
+	return *s.AuthnContextClassRef
+}
+
+// GetBinding returns the Binding field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetBinding() string {
+	if s == nil || s.Binding == nil {
+		return ""
+	}
+	return *s.Binding
+}
+
+// GetCreateUPNClaim returns the CreateUPNClaim field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetCreateUPNClaim() bool {
+	if s == nil || s.CreateUPNClaim == nil {
+		return false
+	}
+	return *s.CreateUPNClaim
+}
+
+// GetDestination returns the Destination field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetDestination() string {
+	if s == nil || s.Destination == nil {
+		return ""
+	}
+	return *s.Destination
+}
+
+// GetDigestAlgorithm returns the DigestAlgorithm field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetDigestAlgorithm() string {
+	if s == nil || s.DigestAlgorithm == nil {
+		return ""
+	}
+	return *s.DigestAlgorithm
+}
+
+// GetIncludeAttributeNameFormat returns the IncludeAttributeNameFormat field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetIncludeAttributeNameFormat() bool {
+	if s == nil || s.IncludeAttributeNameFormat == nil {
+		return false
+	}
+	return *s.IncludeAttributeNameFormat
+}
+
+// GetIssuer returns the Issuer field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetIssuer() string {
+	if s == nil || s.Issuer == nil {
+		return ""
+	}
+	return *s.Issuer
+}
+
+// GetLifetimeInSeconds returns the LifetimeInSeconds field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetLifetimeInSeconds() int {
+	if s == nil || s.LifetimeInSeconds == nil {
+		return 0
+	}
+	return *s.LifetimeInSeconds
+}
+
+// GetLogout returns the Logout field.
+func (s *SAML2Addon) GetLogout() *SAML2AddonLogout {
+	if s == nil {
+		return nil
+	}
+	return s.Logout
+}
+
+// GetMapIdentities returns the MapIdentities field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetMapIdentities() bool {
+	if s == nil || s.MapIdentities == nil {
+		return false
+	}
+	return *s.MapIdentities
+}
+
+// GetMappings returns the Mappings field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetMappings() map[string]string {
+	if s == nil || s.Mappings == nil {
+		return map[string]string{}
+	}
+	return *s.Mappings
+}
+
+// GetMapUnknownClaimsAsIs returns the MapUnknownClaimsAsIs field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetMapUnknownClaimsAsIs() bool {
+	if s == nil || s.MapUnknownClaimsAsIs == nil {
+		return false
+	}
+	return *s.MapUnknownClaimsAsIs
+}
+
+// GetNameIdentifierFormat returns the NameIdentifierFormat field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetNameIdentifierFormat() string {
+	if s == nil || s.NameIdentifierFormat == nil {
+		return ""
+	}
+	return *s.NameIdentifierFormat
+}
+
+// GetNameIdentifierProbes returns the NameIdentifierProbes field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetNameIdentifierProbes() []string {
+	if s == nil || s.NameIdentifierProbes == nil {
+		return nil
+	}
+	return *s.NameIdentifierProbes
+}
+
+// GetPassthroughClaimsWithNoMapping returns the PassthroughClaimsWithNoMapping field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetPassthroughClaimsWithNoMapping() bool {
+	if s == nil || s.PassthroughClaimsWithNoMapping == nil {
+		return false
+	}
+	return *s.PassthroughClaimsWithNoMapping
+}
+
+// GetRecipient returns the Recipient field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetRecipient() string {
+	if s == nil || s.Recipient == nil {
+		return ""
+	}
+	return *s.Recipient
+}
+
+// GetSignatureAlgorithm returns the SignatureAlgorithm field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetSignatureAlgorithm() string {
+	if s == nil || s.SignatureAlgorithm == nil {
+		return ""
+	}
+	return *s.SignatureAlgorithm
+}
+
+// GetSigningCert returns the SigningCert field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetSigningCert() string {
+	if s == nil || s.SigningCert == nil {
+		return ""
+	}
+	return *s.SigningCert
+}
+
+// GetSignResponse returns the SignResponse field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetSignResponse() bool {
+	if s == nil || s.SignResponse == nil {
+		return false
+	}
+	return *s.SignResponse
+}
+
+// GetTypedAttributes returns the TypedAttributes field if it's non-nil, zero value otherwise.
+func (s *SAML2Addon) GetTypedAttributes() bool {
+	if s == nil || s.TypedAttributes == nil {
+		return false
+	}
+	return *s.TypedAttributes
+}
+
+// String returns a string representation of SAML2Addon.
+func (s *SAML2Addon) String() string {
+	return Stringify(s)
+}
+
+// GetCallback returns the Callback field if it's non-nil, zero value otherwise.
+func (s *SAML2AddonLogout) GetCallback() string {
+	if s == nil || s.Callback == nil {
+		return ""
+	}
+	return *s.Callback
+}
+
+// GetSLOEnabled returns the SLOEnabled field if it's non-nil, zero value otherwise.
+func (s *SAML2AddonLogout) GetSLOEnabled() bool {
+	if s == nil || s.SLOEnabled == nil {
+		return false
+	}
+	return *s.SLOEnabled
+}
+
+// String returns a string representation of SAML2AddonLogout.
+func (s *SAML2AddonLogout) String() string {
+	return Stringify(s)
+}
+
 // GetCert returns the Cert field if it's non-nil, zero value otherwise.
 func (s *SigningKey) GetCert() string {
 	if s == nil || s.Cert == nil {
@@ -8538,4 +8753,9 @@ func (u *UserRecoveryCode) GetRecoveryCode() string {
 // String returns a string representation of UserRecoveryCode.
 func (u *UserRecoveryCode) String() string {
 	return Stringify(u)
+}
+
+// String returns a string representation of WSFEDAddon.
+func (w *WSFEDAddon) String() string {
+	return Stringify(w)
 }

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -625,28 +625,6 @@ func TestActionVersionList_String(t *testing.T) {
 	}
 }
 
-func TestAddons_GetSAML2(tt *testing.T) {
-	a := &Addons{}
-	a.GetSAML2()
-	a = nil
-	a.GetSAML2()
-}
-
-func TestAddons_GetWSFED(tt *testing.T) {
-	a := &Addons{}
-	a.GetWSFED()
-	a = nil
-	a.GetWSFED()
-}
-
-func TestAddons_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &Addons{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
 func TestAuthenticationMethod_GetAuthenticationMethods(tt *testing.T) {
 	var zeroValue []AuthenticationMethodReference
 	a := &AuthenticationMethod{AuthenticationMethods: &zeroValue}
@@ -1624,6 +1602,28 @@ func TestClient_GetWebOrigins(tt *testing.T) {
 func TestClient_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &Client{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestClientAddons_GetSAML2(tt *testing.T) {
+	c := &ClientAddons{}
+	c.GetSAML2()
+	c = nil
+	c.GetSAML2()
+}
+
+func TestClientAddons_GetWSFED(tt *testing.T) {
+	c := &ClientAddons{}
+	c.GetWSFED()
+	c = nil
+	c.GetWSFED()
+}
+
+func TestClientAddons_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ClientAddons{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
@@ -9324,244 +9324,244 @@ func TestRuleList_String(t *testing.T) {
 	}
 }
 
-func TestSAML2Addon_GetAudience(tt *testing.T) {
+func TestSAML2ClientAddon_GetAudience(tt *testing.T) {
 	var zeroValue string
-	s := &SAML2Addon{Audience: &zeroValue}
+	s := &SAML2ClientAddon{Audience: &zeroValue}
 	s.GetAudience()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetAudience()
 	s = nil
 	s.GetAudience()
 }
 
-func TestSAML2Addon_GetAuthnContextClassRef(tt *testing.T) {
+func TestSAML2ClientAddon_GetAuthnContextClassRef(tt *testing.T) {
 	var zeroValue string
-	s := &SAML2Addon{AuthnContextClassRef: &zeroValue}
+	s := &SAML2ClientAddon{AuthnContextClassRef: &zeroValue}
 	s.GetAuthnContextClassRef()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetAuthnContextClassRef()
 	s = nil
 	s.GetAuthnContextClassRef()
 }
 
-func TestSAML2Addon_GetBinding(tt *testing.T) {
+func TestSAML2ClientAddon_GetBinding(tt *testing.T) {
 	var zeroValue string
-	s := &SAML2Addon{Binding: &zeroValue}
+	s := &SAML2ClientAddon{Binding: &zeroValue}
 	s.GetBinding()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetBinding()
 	s = nil
 	s.GetBinding()
 }
 
-func TestSAML2Addon_GetCreateUPNClaim(tt *testing.T) {
+func TestSAML2ClientAddon_GetCreateUPNClaim(tt *testing.T) {
 	var zeroValue bool
-	s := &SAML2Addon{CreateUPNClaim: &zeroValue}
+	s := &SAML2ClientAddon{CreateUPNClaim: &zeroValue}
 	s.GetCreateUPNClaim()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetCreateUPNClaim()
 	s = nil
 	s.GetCreateUPNClaim()
 }
 
-func TestSAML2Addon_GetDestination(tt *testing.T) {
+func TestSAML2ClientAddon_GetDestination(tt *testing.T) {
 	var zeroValue string
-	s := &SAML2Addon{Destination: &zeroValue}
+	s := &SAML2ClientAddon{Destination: &zeroValue}
 	s.GetDestination()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetDestination()
 	s = nil
 	s.GetDestination()
 }
 
-func TestSAML2Addon_GetDigestAlgorithm(tt *testing.T) {
+func TestSAML2ClientAddon_GetDigestAlgorithm(tt *testing.T) {
 	var zeroValue string
-	s := &SAML2Addon{DigestAlgorithm: &zeroValue}
+	s := &SAML2ClientAddon{DigestAlgorithm: &zeroValue}
 	s.GetDigestAlgorithm()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetDigestAlgorithm()
 	s = nil
 	s.GetDigestAlgorithm()
 }
 
-func TestSAML2Addon_GetIncludeAttributeNameFormat(tt *testing.T) {
+func TestSAML2ClientAddon_GetIncludeAttributeNameFormat(tt *testing.T) {
 	var zeroValue bool
-	s := &SAML2Addon{IncludeAttributeNameFormat: &zeroValue}
+	s := &SAML2ClientAddon{IncludeAttributeNameFormat: &zeroValue}
 	s.GetIncludeAttributeNameFormat()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetIncludeAttributeNameFormat()
 	s = nil
 	s.GetIncludeAttributeNameFormat()
 }
 
-func TestSAML2Addon_GetIssuer(tt *testing.T) {
+func TestSAML2ClientAddon_GetIssuer(tt *testing.T) {
 	var zeroValue string
-	s := &SAML2Addon{Issuer: &zeroValue}
+	s := &SAML2ClientAddon{Issuer: &zeroValue}
 	s.GetIssuer()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetIssuer()
 	s = nil
 	s.GetIssuer()
 }
 
-func TestSAML2Addon_GetLifetimeInSeconds(tt *testing.T) {
+func TestSAML2ClientAddon_GetLifetimeInSeconds(tt *testing.T) {
 	var zeroValue int
-	s := &SAML2Addon{LifetimeInSeconds: &zeroValue}
+	s := &SAML2ClientAddon{LifetimeInSeconds: &zeroValue}
 	s.GetLifetimeInSeconds()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetLifetimeInSeconds()
 	s = nil
 	s.GetLifetimeInSeconds()
 }
 
-func TestSAML2Addon_GetLogout(tt *testing.T) {
-	s := &SAML2Addon{}
+func TestSAML2ClientAddon_GetLogout(tt *testing.T) {
+	s := &SAML2ClientAddon{}
 	s.GetLogout()
 	s = nil
 	s.GetLogout()
 }
 
-func TestSAML2Addon_GetMapIdentities(tt *testing.T) {
+func TestSAML2ClientAddon_GetMapIdentities(tt *testing.T) {
 	var zeroValue bool
-	s := &SAML2Addon{MapIdentities: &zeroValue}
+	s := &SAML2ClientAddon{MapIdentities: &zeroValue}
 	s.GetMapIdentities()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetMapIdentities()
 	s = nil
 	s.GetMapIdentities()
 }
 
-func TestSAML2Addon_GetMappings(tt *testing.T) {
+func TestSAML2ClientAddon_GetMappings(tt *testing.T) {
 	var zeroValue map[string]string
-	s := &SAML2Addon{Mappings: &zeroValue}
+	s := &SAML2ClientAddon{Mappings: &zeroValue}
 	s.GetMappings()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetMappings()
 	s = nil
 	s.GetMappings()
 }
 
-func TestSAML2Addon_GetMapUnknownClaimsAsIs(tt *testing.T) {
+func TestSAML2ClientAddon_GetMapUnknownClaimsAsIs(tt *testing.T) {
 	var zeroValue bool
-	s := &SAML2Addon{MapUnknownClaimsAsIs: &zeroValue}
+	s := &SAML2ClientAddon{MapUnknownClaimsAsIs: &zeroValue}
 	s.GetMapUnknownClaimsAsIs()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetMapUnknownClaimsAsIs()
 	s = nil
 	s.GetMapUnknownClaimsAsIs()
 }
 
-func TestSAML2Addon_GetNameIdentifierFormat(tt *testing.T) {
+func TestSAML2ClientAddon_GetNameIdentifierFormat(tt *testing.T) {
 	var zeroValue string
-	s := &SAML2Addon{NameIdentifierFormat: &zeroValue}
+	s := &SAML2ClientAddon{NameIdentifierFormat: &zeroValue}
 	s.GetNameIdentifierFormat()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetNameIdentifierFormat()
 	s = nil
 	s.GetNameIdentifierFormat()
 }
 
-func TestSAML2Addon_GetNameIdentifierProbes(tt *testing.T) {
+func TestSAML2ClientAddon_GetNameIdentifierProbes(tt *testing.T) {
 	var zeroValue []string
-	s := &SAML2Addon{NameIdentifierProbes: &zeroValue}
+	s := &SAML2ClientAddon{NameIdentifierProbes: &zeroValue}
 	s.GetNameIdentifierProbes()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetNameIdentifierProbes()
 	s = nil
 	s.GetNameIdentifierProbes()
 }
 
-func TestSAML2Addon_GetPassthroughClaimsWithNoMapping(tt *testing.T) {
+func TestSAML2ClientAddon_GetPassthroughClaimsWithNoMapping(tt *testing.T) {
 	var zeroValue bool
-	s := &SAML2Addon{PassthroughClaimsWithNoMapping: &zeroValue}
+	s := &SAML2ClientAddon{PassthroughClaimsWithNoMapping: &zeroValue}
 	s.GetPassthroughClaimsWithNoMapping()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetPassthroughClaimsWithNoMapping()
 	s = nil
 	s.GetPassthroughClaimsWithNoMapping()
 }
 
-func TestSAML2Addon_GetRecipient(tt *testing.T) {
+func TestSAML2ClientAddon_GetRecipient(tt *testing.T) {
 	var zeroValue string
-	s := &SAML2Addon{Recipient: &zeroValue}
+	s := &SAML2ClientAddon{Recipient: &zeroValue}
 	s.GetRecipient()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetRecipient()
 	s = nil
 	s.GetRecipient()
 }
 
-func TestSAML2Addon_GetSignatureAlgorithm(tt *testing.T) {
+func TestSAML2ClientAddon_GetSignatureAlgorithm(tt *testing.T) {
 	var zeroValue string
-	s := &SAML2Addon{SignatureAlgorithm: &zeroValue}
+	s := &SAML2ClientAddon{SignatureAlgorithm: &zeroValue}
 	s.GetSignatureAlgorithm()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetSignatureAlgorithm()
 	s = nil
 	s.GetSignatureAlgorithm()
 }
 
-func TestSAML2Addon_GetSigningCert(tt *testing.T) {
+func TestSAML2ClientAddon_GetSigningCert(tt *testing.T) {
 	var zeroValue string
-	s := &SAML2Addon{SigningCert: &zeroValue}
+	s := &SAML2ClientAddon{SigningCert: &zeroValue}
 	s.GetSigningCert()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetSigningCert()
 	s = nil
 	s.GetSigningCert()
 }
 
-func TestSAML2Addon_GetSignResponse(tt *testing.T) {
+func TestSAML2ClientAddon_GetSignResponse(tt *testing.T) {
 	var zeroValue bool
-	s := &SAML2Addon{SignResponse: &zeroValue}
+	s := &SAML2ClientAddon{SignResponse: &zeroValue}
 	s.GetSignResponse()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetSignResponse()
 	s = nil
 	s.GetSignResponse()
 }
 
-func TestSAML2Addon_GetTypedAttributes(tt *testing.T) {
+func TestSAML2ClientAddon_GetTypedAttributes(tt *testing.T) {
 	var zeroValue bool
-	s := &SAML2Addon{TypedAttributes: &zeroValue}
+	s := &SAML2ClientAddon{TypedAttributes: &zeroValue}
 	s.GetTypedAttributes()
-	s = &SAML2Addon{}
+	s = &SAML2ClientAddon{}
 	s.GetTypedAttributes()
 	s = nil
 	s.GetTypedAttributes()
 }
 
-func TestSAML2Addon_String(t *testing.T) {
+func TestSAML2ClientAddon_String(t *testing.T) {
 	var rawJSON json.RawMessage
-	v := &SAML2Addon{}
+	v := &SAML2ClientAddon{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
 }
 
-func TestSAML2AddonLogout_GetCallback(tt *testing.T) {
+func TestSAML2ClientAddonLogout_GetCallback(tt *testing.T) {
 	var zeroValue string
-	s := &SAML2AddonLogout{Callback: &zeroValue}
+	s := &SAML2ClientAddonLogout{Callback: &zeroValue}
 	s.GetCallback()
-	s = &SAML2AddonLogout{}
+	s = &SAML2ClientAddonLogout{}
 	s.GetCallback()
 	s = nil
 	s.GetCallback()
 }
 
-func TestSAML2AddonLogout_GetSLOEnabled(tt *testing.T) {
+func TestSAML2ClientAddonLogout_GetSLOEnabled(tt *testing.T) {
 	var zeroValue bool
-	s := &SAML2AddonLogout{SLOEnabled: &zeroValue}
+	s := &SAML2ClientAddonLogout{SLOEnabled: &zeroValue}
 	s.GetSLOEnabled()
-	s = &SAML2AddonLogout{}
+	s = &SAML2ClientAddonLogout{}
 	s.GetSLOEnabled()
 	s = nil
 	s.GetSLOEnabled()
 }
 
-func TestSAML2AddonLogout_String(t *testing.T) {
+func TestSAML2ClientAddonLogout_String(t *testing.T) {
 	var rawJSON json.RawMessage
-	v := &SAML2AddonLogout{}
+	v := &SAML2ClientAddonLogout{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
@@ -11111,9 +11111,9 @@ func TestUserRecoveryCode_String(t *testing.T) {
 	}
 }
 
-func TestWSFEDAddon_String(t *testing.T) {
+func TestWSFEDClientAddon_String(t *testing.T) {
 	var rawJSON json.RawMessage
-	v := &WSFEDAddon{}
+	v := &WSFEDClientAddon{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -625,6 +625,28 @@ func TestActionVersionList_String(t *testing.T) {
 	}
 }
 
+func TestAddons_GetSAML2(tt *testing.T) {
+	a := &Addons{}
+	a.GetSAML2()
+	a = nil
+	a.GetSAML2()
+}
+
+func TestAddons_GetWSFED(tt *testing.T) {
+	a := &Addons{}
+	a.GetWSFED()
+	a = nil
+	a.GetWSFED()
+}
+
+func TestAddons_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &Addons{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestAuthenticationMethod_GetAuthenticationMethods(tt *testing.T) {
 	var zeroValue []AuthenticationMethodReference
 	a := &AuthenticationMethod{AuthenticationMethods: &zeroValue}
@@ -1241,10 +1263,7 @@ func TestBruteForceProtection_String(t *testing.T) {
 }
 
 func TestClient_GetAddons(tt *testing.T) {
-	zeroValue := map[string]interface{}{}
-	c := &Client{Addons: zeroValue}
-	c.GetAddons()
-	c = &Client{}
+	c := &Client{}
 	c.GetAddons()
 	c = nil
 	c.GetAddons()
@@ -9305,6 +9324,249 @@ func TestRuleList_String(t *testing.T) {
 	}
 }
 
+func TestSAML2Addon_GetAudience(tt *testing.T) {
+	var zeroValue string
+	s := &SAML2Addon{Audience: &zeroValue}
+	s.GetAudience()
+	s = &SAML2Addon{}
+	s.GetAudience()
+	s = nil
+	s.GetAudience()
+}
+
+func TestSAML2Addon_GetAuthnContextClassRef(tt *testing.T) {
+	var zeroValue string
+	s := &SAML2Addon{AuthnContextClassRef: &zeroValue}
+	s.GetAuthnContextClassRef()
+	s = &SAML2Addon{}
+	s.GetAuthnContextClassRef()
+	s = nil
+	s.GetAuthnContextClassRef()
+}
+
+func TestSAML2Addon_GetBinding(tt *testing.T) {
+	var zeroValue string
+	s := &SAML2Addon{Binding: &zeroValue}
+	s.GetBinding()
+	s = &SAML2Addon{}
+	s.GetBinding()
+	s = nil
+	s.GetBinding()
+}
+
+func TestSAML2Addon_GetCreateUPNClaim(tt *testing.T) {
+	var zeroValue bool
+	s := &SAML2Addon{CreateUPNClaim: &zeroValue}
+	s.GetCreateUPNClaim()
+	s = &SAML2Addon{}
+	s.GetCreateUPNClaim()
+	s = nil
+	s.GetCreateUPNClaim()
+}
+
+func TestSAML2Addon_GetDestination(tt *testing.T) {
+	var zeroValue string
+	s := &SAML2Addon{Destination: &zeroValue}
+	s.GetDestination()
+	s = &SAML2Addon{}
+	s.GetDestination()
+	s = nil
+	s.GetDestination()
+}
+
+func TestSAML2Addon_GetDigestAlgorithm(tt *testing.T) {
+	var zeroValue string
+	s := &SAML2Addon{DigestAlgorithm: &zeroValue}
+	s.GetDigestAlgorithm()
+	s = &SAML2Addon{}
+	s.GetDigestAlgorithm()
+	s = nil
+	s.GetDigestAlgorithm()
+}
+
+func TestSAML2Addon_GetIncludeAttributeNameFormat(tt *testing.T) {
+	var zeroValue bool
+	s := &SAML2Addon{IncludeAttributeNameFormat: &zeroValue}
+	s.GetIncludeAttributeNameFormat()
+	s = &SAML2Addon{}
+	s.GetIncludeAttributeNameFormat()
+	s = nil
+	s.GetIncludeAttributeNameFormat()
+}
+
+func TestSAML2Addon_GetIssuer(tt *testing.T) {
+	var zeroValue string
+	s := &SAML2Addon{Issuer: &zeroValue}
+	s.GetIssuer()
+	s = &SAML2Addon{}
+	s.GetIssuer()
+	s = nil
+	s.GetIssuer()
+}
+
+func TestSAML2Addon_GetLifetimeInSeconds(tt *testing.T) {
+	var zeroValue int
+	s := &SAML2Addon{LifetimeInSeconds: &zeroValue}
+	s.GetLifetimeInSeconds()
+	s = &SAML2Addon{}
+	s.GetLifetimeInSeconds()
+	s = nil
+	s.GetLifetimeInSeconds()
+}
+
+func TestSAML2Addon_GetLogout(tt *testing.T) {
+	s := &SAML2Addon{}
+	s.GetLogout()
+	s = nil
+	s.GetLogout()
+}
+
+func TestSAML2Addon_GetMapIdentities(tt *testing.T) {
+	var zeroValue bool
+	s := &SAML2Addon{MapIdentities: &zeroValue}
+	s.GetMapIdentities()
+	s = &SAML2Addon{}
+	s.GetMapIdentities()
+	s = nil
+	s.GetMapIdentities()
+}
+
+func TestSAML2Addon_GetMappings(tt *testing.T) {
+	var zeroValue map[string]string
+	s := &SAML2Addon{Mappings: &zeroValue}
+	s.GetMappings()
+	s = &SAML2Addon{}
+	s.GetMappings()
+	s = nil
+	s.GetMappings()
+}
+
+func TestSAML2Addon_GetMapUnknownClaimsAsIs(tt *testing.T) {
+	var zeroValue bool
+	s := &SAML2Addon{MapUnknownClaimsAsIs: &zeroValue}
+	s.GetMapUnknownClaimsAsIs()
+	s = &SAML2Addon{}
+	s.GetMapUnknownClaimsAsIs()
+	s = nil
+	s.GetMapUnknownClaimsAsIs()
+}
+
+func TestSAML2Addon_GetNameIdentifierFormat(tt *testing.T) {
+	var zeroValue string
+	s := &SAML2Addon{NameIdentifierFormat: &zeroValue}
+	s.GetNameIdentifierFormat()
+	s = &SAML2Addon{}
+	s.GetNameIdentifierFormat()
+	s = nil
+	s.GetNameIdentifierFormat()
+}
+
+func TestSAML2Addon_GetNameIdentifierProbes(tt *testing.T) {
+	var zeroValue []string
+	s := &SAML2Addon{NameIdentifierProbes: &zeroValue}
+	s.GetNameIdentifierProbes()
+	s = &SAML2Addon{}
+	s.GetNameIdentifierProbes()
+	s = nil
+	s.GetNameIdentifierProbes()
+}
+
+func TestSAML2Addon_GetPassthroughClaimsWithNoMapping(tt *testing.T) {
+	var zeroValue bool
+	s := &SAML2Addon{PassthroughClaimsWithNoMapping: &zeroValue}
+	s.GetPassthroughClaimsWithNoMapping()
+	s = &SAML2Addon{}
+	s.GetPassthroughClaimsWithNoMapping()
+	s = nil
+	s.GetPassthroughClaimsWithNoMapping()
+}
+
+func TestSAML2Addon_GetRecipient(tt *testing.T) {
+	var zeroValue string
+	s := &SAML2Addon{Recipient: &zeroValue}
+	s.GetRecipient()
+	s = &SAML2Addon{}
+	s.GetRecipient()
+	s = nil
+	s.GetRecipient()
+}
+
+func TestSAML2Addon_GetSignatureAlgorithm(tt *testing.T) {
+	var zeroValue string
+	s := &SAML2Addon{SignatureAlgorithm: &zeroValue}
+	s.GetSignatureAlgorithm()
+	s = &SAML2Addon{}
+	s.GetSignatureAlgorithm()
+	s = nil
+	s.GetSignatureAlgorithm()
+}
+
+func TestSAML2Addon_GetSigningCert(tt *testing.T) {
+	var zeroValue string
+	s := &SAML2Addon{SigningCert: &zeroValue}
+	s.GetSigningCert()
+	s = &SAML2Addon{}
+	s.GetSigningCert()
+	s = nil
+	s.GetSigningCert()
+}
+
+func TestSAML2Addon_GetSignResponse(tt *testing.T) {
+	var zeroValue bool
+	s := &SAML2Addon{SignResponse: &zeroValue}
+	s.GetSignResponse()
+	s = &SAML2Addon{}
+	s.GetSignResponse()
+	s = nil
+	s.GetSignResponse()
+}
+
+func TestSAML2Addon_GetTypedAttributes(tt *testing.T) {
+	var zeroValue bool
+	s := &SAML2Addon{TypedAttributes: &zeroValue}
+	s.GetTypedAttributes()
+	s = &SAML2Addon{}
+	s.GetTypedAttributes()
+	s = nil
+	s.GetTypedAttributes()
+}
+
+func TestSAML2Addon_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &SAML2Addon{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestSAML2AddonLogout_GetCallback(tt *testing.T) {
+	var zeroValue string
+	s := &SAML2AddonLogout{Callback: &zeroValue}
+	s.GetCallback()
+	s = &SAML2AddonLogout{}
+	s.GetCallback()
+	s = nil
+	s.GetCallback()
+}
+
+func TestSAML2AddonLogout_GetSLOEnabled(tt *testing.T) {
+	var zeroValue bool
+	s := &SAML2AddonLogout{SLOEnabled: &zeroValue}
+	s.GetSLOEnabled()
+	s = &SAML2AddonLogout{}
+	s.GetSLOEnabled()
+	s = nil
+	s.GetSLOEnabled()
+}
+
+func TestSAML2AddonLogout_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &SAML2AddonLogout{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestSigningKey_GetCert(tt *testing.T) {
 	var zeroValue string
 	s := &SigningKey{Cert: &zeroValue}
@@ -10844,6 +11106,14 @@ func TestUserRecoveryCode_GetRecoveryCode(tt *testing.T) {
 func TestUserRecoveryCode_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &UserRecoveryCode{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestWSFEDAddon_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &WSFEDAddon{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/test/data/recordings/TestClient_CreateWithClientAddons.yaml
+++ b/test/data/recordings/TestClient_CreateWithClientAddons.yaml
@@ -1,0 +1,74 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 165
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client Addons (May 19 14:22:59.192)","description":"This is just a test client with addons.","addons":{"samlp":{"audience":"my-audience"},"wsfed":{}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client Addons (May 19 14:22:59.192)","description":"This is just a test client with addons.","client_id":"OdsYM6QlPE7iJFv8cS727xJcGNu2CIgF","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"addons":{"samlp":{"audience":"my-audience"},"wsfed":{}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 514.512333ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/OdsYM6QlPE7iJFv8cS727xJcGNu2CIgF
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 151.484208ms


### PR DESCRIPTION
### 🔧 Changes

This improves the typing of the `Addons` property of a `Client` by moving the type from a simple `map[string]interface{}` to a struct that can include the dedicated settings.

There is not configuration for WS-FED that is stored in the `wsfed` object, it is instead set in the `Callbacks` and `ClientAliases`. Rather than include logic around this in the SDK (such as taking the properties and setting these), I chose to instead document this and leave this up to the user.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

### ⚠️  Breaking Change

With this, we now only directly support 2 Addons, `SAML2` and `WS-FED`, which are the default supported Addons in new tenants. We will expand the supported Addons upon request.
