### PR TITLE
Fix UpdateCredential func

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -297,8 +297,24 @@ func (m *ClientManager) CreateCredential(clientID string, credential *Credential
 
 // UpdateCredential updates a client application's client credential expiry.
 func (m *ClientManager) UpdateCredential(clientID, credentialID string, credential *Credential, opts ...RequestOption) error {
-	credential = &Credential{ExpiresAt: credential.ExpiresAt} // The API only accepts the expires_at property.
-	return m.Request("PATCH", m.URI("clients", clientID, "credentials", credentialID), credential, opts...)
+	credentialClone := &Credential{ExpiresAt: credential.ExpiresAt} // The API only accepts the expires_at property.
+
+	err := m.Request("PATCH", m.URI("clients", clientID, "credentials", credentialID), credentialClone, opts...)
+	if err != nil {
+		return err
+	}
+
+	credential.ID = credentialClone.ID
+	credential.Name = credentialClone.Name
+	credential.CredentialType = credentialClone.CredentialType
+	credential.KeyID = credentialClone.KeyID
+	credential.Algorithm = credentialClone.Algorithm
+	credential.CreatedAt = credentialClone.CreatedAt
+	credential.UpdatedAt = credentialClone.UpdatedAt
+	credential.ExpiresAt = credentialClone.ExpiresAt
+	// PEM and ParseExpiryFromCert don't get returned.
+
+	return nil
 }
 
 // ListCredentials lists all client credentials associated with the client application.

--- a/management/client_test.go
+++ b/management/client_test.go
@@ -195,10 +195,16 @@ func TestClient_UpdateCredential(t *testing.T) {
 	expiresAt := time.Now().Add(time.Minute * 10)
 	expectedCredential.ExpiresAt = &expiresAt
 
-	err := api.Client.UpdateCredential(expectedClient.GetClientID(), expectedCredential.GetID(), expectedCredential)
+	pem := expectedCredential.GetPEM()
+	credentialID := expectedCredential.GetID()
+	expectedCredential.ID = nil
+
+	err := api.Client.UpdateCredential(expectedClient.GetClientID(), credentialID, expectedCredential)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedCredential.GetExpiresAt(), expiresAt)
+	assert.Equal(t, expectedCredential.GetID(), credentialID) // Check that we unmarshall the result into this struct.
+	assert.Equal(t, expectedCredential.GetPEM(), pem)
 }
 
 func TestClient_DeleteCredential(t *testing.T) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR fixes an unmarshal issue with the UpdateCredential func, where after patching it, the client credential doesn't get the response unmarshalled into the credential var passed by reference. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
