### PR TITLE
[SDK-4253] Refactor management struct to avoid chaining issue

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -99,3 +99,32 @@ err := auth0API.Client.Create(
 </td>
 </tr>
 </table>
+
+### Removal Of Manager Chaining
+
+Previously, the individual Manager instances in the Management Client could be chained when calling them, this was unintended and has now been removed.
+
+This should improve code completion features such as IntelliSense to only provide the relevant methods rather than all the individual Managers.
+
+<table>
+<tr>
+<th>Before (v0.17.1)</th>
+<th>After (v1.0.0)</th>
+</tr>
+<tr>
+<td>
+
+```go
+// Managers could be chained before calling the desired method.
+api.Action.Client.Action.Client.Create()
+```
+</td>
+<td>
+
+```go
+// Chaining is no longer supported.
+api.Client.Create()
+```
+</td>
+</tr>
+</table>

--- a/management/actions.go
+++ b/management/actions.go
@@ -217,13 +217,7 @@ type ActionLogSession struct {
 }
 
 // ActionManager manages Auth0 Action resources.
-type ActionManager struct {
-	*Management
-}
-
-func newActionManager(m *Management) *ActionManager {
-	return &ActionManager{m}
-}
+type ActionManager manager
 
 func applyActionsListDefaults(options []RequestOption) RequestOption {
 	return newRequestOption(func(r *http.Request) {
@@ -238,7 +232,7 @@ func applyActionsListDefaults(options []RequestOption) RequestOption {
 //
 // https://auth0.com/docs/api/management/v2/#!/Actions/get_triggers
 func (m *ActionManager) Triggers(ctx context.Context, opts ...RequestOption) (l *ActionTriggerList, err error) {
-	err = m.Request(ctx, "GET", m.URI("actions", "triggers"), &l, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("actions", "triggers"), &l, opts...)
 	return
 }
 
@@ -246,14 +240,14 @@ func (m *ActionManager) Triggers(ctx context.Context, opts ...RequestOption) (l 
 //
 // See: https://auth0.com/docs/api/management/v2#!/Actions/post_action
 func (m *ActionManager) Create(ctx context.Context, a *Action, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("actions", "actions"), a, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("actions", "actions"), a, opts...)
 }
 
 // Retrieve action details.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Actions/get_action
 func (m *ActionManager) Read(ctx context.Context, id string, opts ...RequestOption) (a *Action, err error) {
-	err = m.Request(ctx, "GET", m.URI("actions", "actions", id), &a, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("actions", "actions", id), &a, opts...)
 	return
 }
 
@@ -261,21 +255,21 @@ func (m *ActionManager) Read(ctx context.Context, id string, opts ...RequestOpti
 //
 // See: https://auth0.com/docs/api/management/v2#!/Actions/patch_action
 func (m *ActionManager) Update(ctx context.Context, id string, a *Action, opts ...RequestOption) error {
-	return m.Request(ctx, "PATCH", m.URI("actions", "actions", id), &a, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("actions", "actions", id), &a, opts...)
 }
 
 // Delete an action
 //
 // See: https://auth0.com/docs/api/management/v2#!/Actions/delete_action
 func (m *ActionManager) Delete(ctx context.Context, id string, opts ...RequestOption) error {
-	return m.Request(ctx, "DELETE", m.URI("actions", "actions", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("actions", "actions", id), nil, opts...)
 }
 
 // List all actions.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Actions/get_actions
 func (m *ActionManager) List(ctx context.Context, opts ...RequestOption) (l *ActionList, err error) {
-	err = m.Request(ctx, "GET", m.URI("actions", "actions"), &l, applyActionsListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("actions", "actions"), &l, applyActionsListDefaults(opts))
 	return
 }
 
@@ -283,7 +277,7 @@ func (m *ActionManager) List(ctx context.Context, opts ...RequestOption) (l *Act
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Actions/get_action_version
 func (m *ActionManager) Version(ctx context.Context, id string, versionID string, opts ...RequestOption) (v *ActionVersion, err error) {
-	err = m.Request(ctx, "GET", m.URI("actions", "actions", id, "versions", versionID), &v, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("actions", "actions", id, "versions", versionID), &v, opts...)
 	return
 }
 
@@ -291,7 +285,7 @@ func (m *ActionManager) Version(ctx context.Context, id string, versionID string
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Actions/get_action_versions
 func (m *ActionManager) Versions(ctx context.Context, id string, opts ...RequestOption) (c *ActionVersionList, err error) {
-	err = m.Request(ctx, "GET", m.URI("actions", "actions", id, "versions"), &c, applyActionsListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("actions", "actions", id, "versions"), &c, applyActionsListDefaults(opts))
 	return
 }
 
@@ -302,14 +296,14 @@ func (m *ActionManager) UpdateBindings(ctx context.Context, triggerID string, b 
 	bl := &actionBindingsPerTrigger{
 		Bindings: b,
 	}
-	return m.Request(ctx, "PATCH", m.URI("actions", "triggers", triggerID, "bindings"), &bl, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("actions", "triggers", triggerID, "bindings"), &bl, opts...)
 }
 
 // Bindings lists the bindings of a trigger.
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Actions/get_bindings
 func (m *ActionManager) Bindings(ctx context.Context, triggerID string, opts ...RequestOption) (bl *ActionBindingList, err error) {
-	err = m.Request(ctx, "GET", m.URI("actions", "triggers", triggerID, "bindings"), &bl, applyActionsListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("actions", "triggers", triggerID, "bindings"), &bl, applyActionsListDefaults(opts))
 	return
 }
 
@@ -317,7 +311,7 @@ func (m *ActionManager) Bindings(ctx context.Context, triggerID string, opts ...
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Actions/post_deploy_action
 func (m *ActionManager) Deploy(ctx context.Context, id string, opts ...RequestOption) (v *ActionVersion, err error) {
-	err = m.Request(ctx, "POST", m.URI("actions", "actions", id, "deploy"), &v, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("actions", "actions", id, "deploy"), &v, opts...)
 	return
 }
 
@@ -325,7 +319,7 @@ func (m *ActionManager) Deploy(ctx context.Context, id string, opts ...RequestOp
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Actions/post_deploy_draft_version
 func (m *ActionManager) DeployVersion(ctx context.Context, id string, versionID string, opts ...RequestOption) (v *ActionVersion, err error) {
-	err = m.Request(ctx, "POST", m.URI("actions", "actions", id, "versions", versionID, "deploy"), &v, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("actions", "actions", id, "versions", versionID, "deploy"), &v, opts...)
 	return
 }
 
@@ -336,7 +330,7 @@ func (m *ActionManager) Test(ctx context.Context, id string, payload *ActionTest
 	r := &actionTestRequest{
 		Payload: payload,
 	}
-	err = m.Request(ctx, "POST", m.URI("actions", "actions", id, "test"), &r, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("actions", "actions", id, "test"), &r, opts...)
 	return
 }
 
@@ -344,7 +338,7 @@ func (m *ActionManager) Test(ctx context.Context, id string, payload *ActionTest
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Actions/get_execution
 func (m *ActionManager) Execution(ctx context.Context, executionID string, opts ...RequestOption) (v *ActionExecution, err error) {
-	err = m.Request(ctx, "GET", m.URI("actions", "executions", executionID), &v, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("actions", "executions", executionID), &v, opts...)
 	return
 }
 
@@ -352,6 +346,6 @@ func (m *ActionManager) Execution(ctx context.Context, executionID string, opts 
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Actions/post_actions_log_sessions
 func (m *ActionManager) LogSession(ctx context.Context, l *ActionLogSession, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "POST", m.URI("actions", "log-sessions"), &l, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("actions", "log-sessions"), &l, opts...)
 	return
 }

--- a/management/anomaly.go
+++ b/management/anomaly.go
@@ -6,25 +6,19 @@ import (
 )
 
 // AnomalyManager manages Auth0 Anomaly resources.
-type AnomalyManager struct {
-	*Management
-}
-
-func newAnomalyManager(m *Management) *AnomalyManager {
-	return &AnomalyManager{m}
-}
+type AnomalyManager manager
 
 // CheckIP checks if a given IP address is blocked via the multiple
 // user accounts trigger due to multiple failed logins.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Anomaly/get_ips_by_id
 func (m *AnomalyManager) CheckIP(ctx context.Context, ip string, opts ...RequestOption) (isBlocked bool, err error) {
-	request, err := m.NewRequest(ctx, "GET", m.URI("anomaly", "blocks", "ips", ip), nil, opts...)
+	request, err := m.management.NewRequest(ctx, "GET", m.management.URI("anomaly", "blocks", "ips", ip), nil, opts...)
 	if err != nil {
 		return false, err
 	}
 
-	response, err := m.Do(request)
+	response, err := m.management.Do(request)
 	if err != nil {
 		return false, err
 	}
@@ -48,5 +42,5 @@ func (m *AnomalyManager) CheckIP(ctx context.Context, ip string, opts ...Request
 //
 // See: https://auth0.com/docs/api/management/v2#!/Anomaly/delete_ips_by_id
 func (m *AnomalyManager) UnblockIP(ctx context.Context, ip string, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "DELETE", m.URI("anomaly", "blocks", "ips", ip), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("anomaly", "blocks", "ips", ip), nil, opts...)
 }

--- a/management/attack_protection.go
+++ b/management/attack_protection.go
@@ -8,13 +8,7 @@ import (
 // AttackProtectionManager manages Auth0 Attack Protection settings.
 //
 // See: https://auth0.com/docs/secure/attack-protection
-type AttackProtectionManager struct {
-	*Management
-}
-
-func newAttackProtectionManager(m *Management) *AttackProtectionManager {
-	return &AttackProtectionManager{m}
-}
+type AttackProtectionManager manager
 
 // BreachedPasswordDetection protects applications from
 // bad actors logging in with stolen credentials.
@@ -51,10 +45,10 @@ func (m *AttackProtectionManager) GetBreachedPasswordDetection(
 	opts ...RequestOption,
 ) (*BreachedPasswordDetection, error) {
 	var breachedPasswordDetection BreachedPasswordDetection
-	err := m.Request(
+	err := m.management.Request(
 		ctx,
 		http.MethodGet,
-		m.URI("attack-protection", "breached-password-detection"),
+		m.management.URI("attack-protection", "breached-password-detection"),
 		&breachedPasswordDetection,
 		opts...,
 	)
@@ -72,10 +66,10 @@ func (m *AttackProtectionManager) UpdateBreachedPasswordDetection(
 	breachedPasswordDetection *BreachedPasswordDetection,
 	opts ...RequestOption,
 ) error {
-	return m.Request(
+	return m.management.Request(
 		ctx,
 		http.MethodPatch,
-		m.URI("attack-protection", "breached-password-detection"),
+		m.management.URI("attack-protection", "breached-password-detection"),
 		breachedPasswordDetection,
 		opts...,
 	)
@@ -103,10 +97,10 @@ func (m *AttackProtectionManager) GetBruteForceProtection(
 	opts ...RequestOption,
 ) (*BruteForceProtection, error) {
 	var bruteForceProtection BruteForceProtection
-	err := m.Request(
+	err := m.management.Request(
 		ctx,
 		http.MethodGet,
-		m.URI("attack-protection", "brute-force-protection"),
+		m.management.URI("attack-protection", "brute-force-protection"),
 		&bruteForceProtection,
 		opts...,
 	)
@@ -124,10 +118,10 @@ func (m *AttackProtectionManager) UpdateBruteForceProtection(
 	bruteForceProtection *BruteForceProtection,
 	opts ...RequestOption,
 ) error {
-	return m.Request(
+	return m.management.Request(
 		ctx,
 		http.MethodPatch,
-		m.URI("attack-protection", "brute-force-protection"),
+		m.management.URI("attack-protection", "brute-force-protection"),
 		bruteForceProtection,
 		opts...,
 	)
@@ -173,10 +167,10 @@ func (m *AttackProtectionManager) GetSuspiciousIPThrottling(
 	opts ...RequestOption,
 ) (*SuspiciousIPThrottling, error) {
 	var suspiciousIPThrottling SuspiciousIPThrottling
-	err := m.Request(
+	err := m.management.Request(
 		ctx,
 		http.MethodGet,
-		m.URI("attack-protection", "suspicious-ip-throttling"),
+		m.management.URI("attack-protection", "suspicious-ip-throttling"),
 		&suspiciousIPThrottling,
 		opts...,
 	)
@@ -194,10 +188,10 @@ func (m *AttackProtectionManager) UpdateSuspiciousIPThrottling(
 	suspiciousIPThrottling *SuspiciousIPThrottling,
 	opts ...RequestOption,
 ) error {
-	return m.Request(
+	return m.management.Request(
 		ctx,
 		http.MethodPatch,
-		m.URI("attack-protection", "suspicious-ip-throttling"),
+		m.management.URI("attack-protection", "suspicious-ip-throttling"),
 		suspiciousIPThrottling,
 		opts...,
 	)

--- a/management/blacklist.go
+++ b/management/blacklist.go
@@ -18,13 +18,7 @@ type BlacklistToken struct {
 }
 
 // BlacklistManager manages Auth0 BlacklistToken resources.
-type BlacklistManager struct {
-	*Management
-}
-
-func newBlacklistManager(m *Management) *BlacklistManager {
-	return &BlacklistManager{m}
-}
+type BlacklistManager manager
 
 // List all tokens that are blacklisted.
 //
@@ -38,7 +32,7 @@ func newBlacklistManager(m *Management) *BlacklistManager {
 //
 // See: https://auth0.com/docs/api/management/v2#!/Blacklists/get_tokens
 func (m *BlacklistManager) List(ctx context.Context, opts ...RequestOption) (bl []*BlacklistToken, err error) {
-	err = m.Request(ctx, "GET", m.URI("blacklists", "tokens"), &bl, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("blacklists", "tokens"), &bl, applyListDefaults(opts))
 	return
 }
 
@@ -46,5 +40,5 @@ func (m *BlacklistManager) List(ctx context.Context, opts ...RequestOption) (bl 
 //
 // See: https://auth0.com/docs/api/management/v2#!/Blacklists/post_tokens
 func (m *BlacklistManager) Create(ctx context.Context, t *BlacklistToken, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("blacklists", "tokens"), t, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("blacklists", "tokens"), t, opts...)
 }

--- a/management/branding.go
+++ b/management/branding.go
@@ -134,19 +134,13 @@ type BrandingUniversalLogin struct {
 }
 
 // BrandingManager manages Auth0 Branding resources.
-type BrandingManager struct {
-	*Management
-}
-
-func newBrandingManager(m *Management) *BrandingManager {
-	return &BrandingManager{m}
-}
+type BrandingManager manager
 
 // Read retrieves various settings related to branding.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/get_branding
 func (m *BrandingManager) Read(ctx context.Context, opts ...RequestOption) (b *Branding, err error) {
-	err = m.Request(ctx, "GET", m.URI("branding"), &b, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("branding"), &b, opts...)
 	return
 }
 
@@ -154,14 +148,14 @@ func (m *BrandingManager) Read(ctx context.Context, opts ...RequestOption) (b *B
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/patch_branding
 func (m *BrandingManager) Update(ctx context.Context, t *Branding, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("branding"), t, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("branding"), t, opts...)
 }
 
 // UniversalLogin retrieves the template for the New Universal Login Experience.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/get_universal_login
 func (m *BrandingManager) UniversalLogin(ctx context.Context, opts ...RequestOption) (ul *BrandingUniversalLogin, err error) {
-	err = m.Request(ctx, "GET", m.URI("branding", "templates", "universal-login"), &ul, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("branding", "templates", "universal-login"), &ul, opts...)
 	return
 }
 
@@ -169,12 +163,12 @@ func (m *BrandingManager) UniversalLogin(ctx context.Context, opts ...RequestOpt
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/put_universal_login
 func (m *BrandingManager) SetUniversalLogin(ctx context.Context, ul *BrandingUniversalLogin, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PUT", m.URI("branding", "templates", "universal-login"), ul.Body, opts...)
+	return m.management.Request(ctx, "PUT", m.management.URI("branding", "templates", "universal-login"), ul.Body, opts...)
 }
 
 // DeleteUniversalLogin deletes the template for the New Universal Login Experience.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/delete_universal_login
 func (m *BrandingManager) DeleteUniversalLogin(ctx context.Context, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "DELETE", m.URI("branding", "templates", "universal-login"), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("branding", "templates", "universal-login"), nil, opts...)
 }

--- a/management/branding_theme.go
+++ b/management/branding_theme.go
@@ -90,19 +90,13 @@ type BrandingThemeWidget struct {
 }
 
 // BrandingThemeManager manages Auth0 BrandingTheme resources.
-type BrandingThemeManager struct {
-	*Management
-}
-
-func newBrandingThemeManager(m *Management) *BrandingThemeManager {
-	return &BrandingThemeManager{m}
-}
+type BrandingThemeManager manager
 
 // Default retrieves the default BrandingTheme.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/get_default_branding_theme
 func (m *BrandingThemeManager) Default(ctx context.Context, opts ...RequestOption) (theme *BrandingTheme, err error) {
-	err = m.Request(ctx, http.MethodGet, m.URI("branding", "themes", "default"), &theme, opts...)
+	err = m.management.Request(ctx, http.MethodGet, m.management.URI("branding", "themes", "default"), &theme, opts...)
 	return
 }
 
@@ -110,14 +104,14 @@ func (m *BrandingThemeManager) Default(ctx context.Context, opts ...RequestOptio
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/post_branding_theme
 func (m *BrandingThemeManager) Create(ctx context.Context, theme *BrandingTheme, opts ...RequestOption) (err error) {
-	return m.Request(ctx, http.MethodPost, m.URI("branding", "themes"), theme, opts...)
+	return m.management.Request(ctx, http.MethodPost, m.management.URI("branding", "themes"), theme, opts...)
 }
 
 // Read retrieves a BrandingTheme.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/get_branding_theme
 func (m *BrandingThemeManager) Read(ctx context.Context, id string, opts ...RequestOption) (theme *BrandingTheme, err error) {
-	err = m.Request(ctx, http.MethodGet, m.URI("branding", "themes", id), &theme, opts...)
+	err = m.management.Request(ctx, http.MethodGet, m.management.URI("branding", "themes", id), &theme, opts...)
 	return
 }
 
@@ -125,12 +119,12 @@ func (m *BrandingThemeManager) Read(ctx context.Context, id string, opts ...Requ
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/patch_branding_theme
 func (m *BrandingThemeManager) Update(ctx context.Context, id string, theme *BrandingTheme, opts ...RequestOption) (err error) {
-	return m.Request(ctx, http.MethodPatch, m.URI("branding", "themes", id), theme, opts...)
+	return m.management.Request(ctx, http.MethodPatch, m.management.URI("branding", "themes", id), theme, opts...)
 }
 
 // Delete a BrandingTheme.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/delete_branding_theme
 func (m *BrandingThemeManager) Delete(ctx context.Context, id string, opts ...RequestOption) (err error) {
-	return m.Request(ctx, http.MethodDelete, m.URI("branding", "themes", id), nil, opts...)
+	return m.management.Request(ctx, http.MethodDelete, m.management.URI("branding", "themes", id), nil, opts...)
 }

--- a/management/client.go
+++ b/management/client.go
@@ -315,26 +315,20 @@ type ClientList struct {
 }
 
 // ClientManager manages Auth0 Client resources.
-type ClientManager struct {
-	*Management
-}
-
-func newClientManager(m *Management) *ClientManager {
-	return &ClientManager{m}
-}
+type ClientManager manager
 
 // Create a new client application.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Clients/post_clients
 func (m *ClientManager) Create(ctx context.Context, c *Client, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "POST", m.URI("clients"), c, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("clients"), c, opts...)
 }
 
 // Read a client by its ID.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Clients/get_clients_by_id
 func (m *ClientManager) Read(ctx context.Context, id string, opts ...RequestOption) (c *Client, err error) {
-	err = m.Request(ctx, "GET", m.URI("clients", id), &c, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("clients", id), &c, opts...)
 	return
 }
 
@@ -342,7 +336,7 @@ func (m *ClientManager) Read(ctx context.Context, id string, opts ...RequestOpti
 //
 // See: https://auth0.com/docs/api/management/v2#!/Clients/get_clients
 func (m *ClientManager) List(ctx context.Context, opts ...RequestOption) (c *ClientList, err error) {
-	err = m.Request(ctx, "GET", m.URI("clients"), &c, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("clients"), &c, applyListDefaults(opts))
 	return
 }
 
@@ -350,14 +344,14 @@ func (m *ClientManager) List(ctx context.Context, opts ...RequestOption) (c *Cli
 //
 // See: https://auth0.com/docs/api/management/v2#!/Clients/patch_clients_by_id
 func (m *ClientManager) Update(ctx context.Context, id string, c *Client, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("clients", id), c, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("clients", id), c, opts...)
 }
 
 // RotateSecret rotates a client secret.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Clients/post_rotate_secret
 func (m *ClientManager) RotateSecret(ctx context.Context, id string, opts ...RequestOption) (c *Client, err error) {
-	err = m.Request(ctx, "POST", m.URI("clients", id, "rotate-secret"), &c, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("clients", id, "rotate-secret"), &c, opts...)
 	return
 }
 
@@ -366,29 +360,29 @@ func (m *ClientManager) RotateSecret(ctx context.Context, id string, opts ...Req
 //
 // See: https://auth0.com/docs/api/management/v2#!/Clients/delete_clients_by_id
 func (m *ClientManager) Delete(ctx context.Context, id string, opts ...RequestOption) error {
-	return m.Request(ctx, "DELETE", m.URI("clients", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("clients", id), nil, opts...)
 }
 
 // CreateCredential creates a client application's client credential.
 func (m *ClientManager) CreateCredential(ctx context.Context, clientID string, credential *Credential, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("clients", clientID, "credentials"), credential, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("clients", clientID, "credentials"), credential, opts...)
 }
 
 // ListCredentials lists all client credentials associated with the client application.
 func (m *ClientManager) ListCredentials(ctx context.Context, clientID string, opts ...RequestOption) (c []*Credential, err error) {
-	err = m.Request(ctx, "GET", m.URI("clients", clientID, "credentials"), &c, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("clients", clientID, "credentials"), &c, applyListDefaults(opts))
 	return
 }
 
 // GetCredential gets a client credentials object.
 func (m *ClientManager) GetCredential(ctx context.Context, clientID string, credentialID string, opts ...RequestOption) (c *Credential, err error) {
-	err = m.Request(ctx, "GET", m.URI("clients", clientID, "credentials", credentialID), &c, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("clients", clientID, "credentials", credentialID), &c, opts...)
 	return
 }
 
 // DeleteCredential deletes a client credentials object.
 func (m *ClientManager) DeleteCredential(ctx context.Context, clientID string, credentialID string, opts ...RequestOption) error {
-	return m.Request(ctx, "DELETE", m.URI("clients", clientID, "credentials", credentialID), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("clients", clientID, "credentials", credentialID), nil, opts...)
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.

--- a/management/client_grant.go
+++ b/management/client_grant.go
@@ -25,19 +25,13 @@ type ClientGrantList struct {
 }
 
 // ClientGrantManager manages Auth0 ClientGrant resources.
-type ClientGrantManager struct {
-	*Management
-}
-
-func newClientGrantManager(m *Management) *ClientGrantManager {
-	return &ClientGrantManager{m}
-}
+type ClientGrantManager manager
 
 // Create a client grant.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Client_Grants/post_client_grants
 func (m *ClientGrantManager) Create(ctx context.Context, g *ClientGrant, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "POST", m.URI("client-grants"), g, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("client-grants"), g, opts...)
 }
 
 // Read a client grant by its ID.
@@ -73,14 +67,14 @@ func (m *ClientGrantManager) Read(ctx context.Context, id string, opts ...Reques
 //
 // See: https://auth0.com/docs/api/management/v2#!/Client_Grants/patch_client_grants_by_id
 func (m *ClientGrantManager) Update(ctx context.Context, id string, g *ClientGrant, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("client-grants", id), g, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("client-grants", id), g, opts...)
 }
 
 // Delete a client grant.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Client_Grants/delete_client_grants_by_id
 func (m *ClientGrantManager) Delete(ctx context.Context, id string, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "DELETE", m.URI("client-grants", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("client-grants", id), nil, opts...)
 }
 
 // List all client grants.
@@ -90,6 +84,6 @@ func (m *ClientGrantManager) Delete(ctx context.Context, id string, opts ...Requ
 //
 // See: https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants
 func (m *ClientGrantManager) List(ctx context.Context, opts ...RequestOption) (gs *ClientGrantList, err error) {
-	err = m.Request(ctx, "GET", m.URI("client-grants"), &gs, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("client-grants"), &gs, applyListDefaults(opts))
 	return
 }

--- a/management/connection.go
+++ b/management/connection.go
@@ -1062,9 +1062,7 @@ func (c *ConnectionOptionsGoogleApps) SetScopes(enable bool, scopes ...string) {
 }
 
 // ConnectionManager manages Auth0 Connection resources.
-type ConnectionManager struct {
-	*Management
-}
+type ConnectionManager manager
 
 // ConnectionList is a list of Connections.
 type ConnectionList struct {
@@ -1072,22 +1070,18 @@ type ConnectionList struct {
 	Connections []*Connection `json:"connections"`
 }
 
-func newConnectionManager(m *Management) *ConnectionManager {
-	return &ConnectionManager{m}
-}
-
 // Create a new connection.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Connections/post_connections
 func (m *ConnectionManager) Create(ctx context.Context, c *Connection, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("connections"), c, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("connections"), c, opts...)
 }
 
 // Read retrieves a connection by its id.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Connections/get_connections_by_id
 func (m *ConnectionManager) Read(ctx context.Context, id string, opts ...RequestOption) (c *Connection, err error) {
-	err = m.Request(ctx, "GET", m.URI("connections", id), &c, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("connections", id), &c, opts...)
 	return
 }
 
@@ -1095,7 +1089,7 @@ func (m *ConnectionManager) Read(ctx context.Context, id string, opts ...Request
 //
 // See: https://auth0.com/docs/api/management/v2#!/Connections/get_connections
 func (m *ConnectionManager) List(ctx context.Context, opts ...RequestOption) (c *ConnectionList, err error) {
-	err = m.Request(ctx, "GET", m.URI("connections"), &c, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("connections"), &c, applyListDefaults(opts))
 	return
 }
 
@@ -1106,14 +1100,14 @@ func (m *ConnectionManager) List(ctx context.Context, opts ...RequestOption) (c 
 //
 // See: https://auth0.com/docs/api/management/v2#!/Connections/patch_connections_by_id
 func (m *ConnectionManager) Update(ctx context.Context, id string, c *Connection, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("connections", id), c, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("connections", id), c, opts...)
 }
 
 // Delete a connection and all its users.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Connections/delete_connections_by_id
 func (m *ConnectionManager) Delete(ctx context.Context, id string, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "DELETE", m.URI("connections", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("connections", id), nil, opts...)
 }
 
 // ReadByName retrieves a connection by its name. This is a helper method when a

--- a/management/custom_domain.go
+++ b/management/custom_domain.go
@@ -52,13 +52,7 @@ type CustomDomainVerification struct {
 }
 
 // CustomDomainManager manages Auth0 CustomDomain resources.
-type CustomDomainManager struct {
-	*Management
-}
-
-func newCustomDomainManager(m *Management) *CustomDomainManager {
-	return &CustomDomainManager{m}
-}
+type CustomDomainManager manager
 
 // Create a new custom domain.
 //
@@ -67,21 +61,21 @@ func newCustomDomainManager(m *Management) *CustomDomainManager {
 //
 // See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/post_custom_domains
 func (m *CustomDomainManager) Create(ctx context.Context, c *CustomDomain, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "POST", m.URI("custom-domains"), c, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("custom-domains"), c, opts...)
 }
 
 // Update a custom domain.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/patch_custom_domains_by_id
 func (m *CustomDomainManager) Update(ctx context.Context, id string, c *CustomDomain, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("custom-domains", id), c, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("custom-domains", id), c, opts...)
 }
 
 // Read a custom domain configuration and status.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/get_custom_domains_by_id
 func (m *CustomDomainManager) Read(ctx context.Context, id string, opts ...RequestOption) (c *CustomDomain, err error) {
-	err = m.Request(ctx, "GET", m.URI("custom-domains", id), &c, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("custom-domains", id), &c, opts...)
 	return
 }
 
@@ -89,7 +83,7 @@ func (m *CustomDomainManager) Read(ctx context.Context, id string, opts ...Reque
 //
 // See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/post_verify
 func (m *CustomDomainManager) Verify(ctx context.Context, id string, opts ...RequestOption) (c *CustomDomain, err error) {
-	err = m.Request(ctx, "POST", m.URI("custom-domains", id, "verify"), &c, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("custom-domains", id, "verify"), &c, opts...)
 	return
 }
 
@@ -97,13 +91,13 @@ func (m *CustomDomainManager) Verify(ctx context.Context, id string, opts ...Req
 //
 // See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/delete_custom_domains_by_id
 func (m *CustomDomainManager) Delete(ctx context.Context, id string, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "DELETE", m.URI("custom-domains", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("custom-domains", id), nil, opts...)
 }
 
 // List all custom domains.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/get_custom_domains
 func (m *CustomDomainManager) List(ctx context.Context, opts ...RequestOption) (c []*CustomDomain, err error) {
-	err = m.Request(ctx, "GET", m.URI("custom-domains"), &c, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("custom-domains"), &c, opts...)
 	return
 }

--- a/management/email.go
+++ b/management/email.go
@@ -48,13 +48,7 @@ type EmailCredentials struct {
 
 // EmailManager manages Auth0 Email resources.
 // Deprecated: Use EmailProviderManager instead.
-type EmailManager struct {
-	*Management
-}
-
-func newEmailManager(m *Management) *EmailManager {
-	return &EmailManager{m}
-}
+type EmailManager manager
 
 // Create an email provider.
 //
@@ -83,7 +77,7 @@ func newEmailManager(m *Management) *EmailManager {
 //
 // See: https://auth0.com/docs/api/management/v2#!/Emails/post_provider
 func (m *EmailManager) Create(ctx context.Context, e *Email, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("emails", "provider"), e, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("emails", "provider"), e, opts...)
 }
 
 // Read email provider details.
@@ -91,7 +85,7 @@ func (m *EmailManager) Create(ctx context.Context, e *Email, opts ...RequestOpti
 // See: https://auth0.com/docs/api/management/v2#!/Emails/get_provider
 func (m *EmailManager) Read(ctx context.Context, opts ...RequestOption) (e *Email, err error) {
 	opts = append(opts, IncludeFields("name", "enabled", "default_from_address", "credentials", "settings"))
-	err = m.Request(ctx, "GET", m.URI("emails", "provider"), &e, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("emails", "provider"), &e, opts...)
 	return
 }
 
@@ -99,12 +93,12 @@ func (m *EmailManager) Read(ctx context.Context, opts ...RequestOption) (e *Emai
 //
 // See: https://auth0.com/docs/api/management/v2#!/Emails/patch_provider
 func (m *EmailManager) Update(ctx context.Context, e *Email, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("emails", "provider"), e, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("emails", "provider"), e, opts...)
 }
 
 // Delete the email provider.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Emails/delete_provider
 func (m *EmailManager) Delete(ctx context.Context, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "DELETE", m.URI("emails", "provider"), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("emails", "provider"), nil, opts...)
 }

--- a/management/email_provider.go
+++ b/management/email_provider.go
@@ -221,13 +221,7 @@ func (ep *EmailProvider) UnmarshalJSON(b []byte) error {
 }
 
 // EmailProviderManager manages the Auth0 EmailProvider.
-type EmailProviderManager struct {
-	*Management
-}
-
-func newEmailProviderManager(m *Management) *EmailProviderManager {
-	return &EmailProviderManager{m}
-}
+type EmailProviderManager manager
 
 // Create an email provider.
 //
@@ -256,7 +250,7 @@ func newEmailProviderManager(m *Management) *EmailProviderManager {
 //
 // See: https://auth0.com/docs/api/management/v2#!/Emails/post_provider
 func (m *EmailProviderManager) Create(ctx context.Context, ep *EmailProvider, opts ...RequestOption) error {
-	return m.Request(ctx, http.MethodPost, m.URI("emails", "provider"), ep, opts...)
+	return m.management.Request(ctx, http.MethodPost, m.management.URI("emails", "provider"), ep, opts...)
 }
 
 // Read email provider details.
@@ -264,7 +258,7 @@ func (m *EmailProviderManager) Create(ctx context.Context, ep *EmailProvider, op
 // See: https://auth0.com/docs/api/management/v2#!/Emails/get_provider
 func (m *EmailProviderManager) Read(ctx context.Context, opts ...RequestOption) (ep *EmailProvider, err error) {
 	opts = append(opts, IncludeFields("name", "enabled", "default_from_address", "credentials", "settings"))
-	err = m.Request(ctx, http.MethodGet, m.URI("emails", "provider"), &ep, opts...)
+	err = m.management.Request(ctx, http.MethodGet, m.management.URI("emails", "provider"), &ep, opts...)
 	return
 }
 
@@ -272,12 +266,12 @@ func (m *EmailProviderManager) Read(ctx context.Context, opts ...RequestOption) 
 //
 // See: https://auth0.com/docs/api/management/v2#!/Emails/patch_provider
 func (m *EmailProviderManager) Update(ctx context.Context, ep *EmailProvider, opts ...RequestOption) (err error) {
-	return m.Request(ctx, http.MethodPatch, m.URI("emails", "provider"), ep, opts...)
+	return m.management.Request(ctx, http.MethodPatch, m.management.URI("emails", "provider"), ep, opts...)
 }
 
 // Delete the email provider.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Emails/delete_provider
 func (m *EmailProviderManager) Delete(ctx context.Context, opts ...RequestOption) (err error) {
-	return m.Request(ctx, http.MethodDelete, m.URI("emails", "provider"), nil, opts...)
+	return m.management.Request(ctx, http.MethodDelete, m.management.URI("emails", "provider"), nil, opts...)
 }

--- a/management/email_template.go
+++ b/management/email_template.go
@@ -40,19 +40,13 @@ type EmailTemplate struct {
 }
 
 // EmailTemplateManager manages Auth0 EmailTemplate resources.
-type EmailTemplateManager struct {
-	*Management
-}
-
-func newEmailTemplateManager(m *Management) *EmailTemplateManager {
-	return &EmailTemplateManager{m}
-}
+type EmailTemplateManager manager
 
 // Create an email template.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Email_Templates/post_email_templates
 func (m *EmailTemplateManager) Create(ctx context.Context, e *EmailTemplate, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("email-templates"), e, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("email-templates"), e, opts...)
 }
 
 // Read an email template by pre-defined name.
@@ -66,7 +60,7 @@ func (m *EmailTemplateManager) Create(ctx context.Context, e *EmailTemplate, opt
 //
 // See: https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName
 func (m *EmailTemplateManager) Read(ctx context.Context, template string, opts ...RequestOption) (e *EmailTemplate, err error) {
-	err = m.Request(ctx, "GET", m.URI("email-templates", template), &e, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("email-templates", template), &e, opts...)
 	return
 }
 
@@ -74,12 +68,12 @@ func (m *EmailTemplateManager) Read(ctx context.Context, template string, opts .
 //
 // See: https://auth0.com/docs/api/management/v2#!/Email_Templates/patch_email_templates_by_templateName
 func (m *EmailTemplateManager) Update(ctx context.Context, template string, e *EmailTemplate, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("email-templates", template), e, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("email-templates", template), e, opts...)
 }
 
 // Replace an email template.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Email_Templates/put_email_templates_by_templateName
 func (m *EmailTemplateManager) Replace(ctx context.Context, template string, e *EmailTemplate, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PUT", m.URI("email-templates", template), e, opts...)
+	return m.management.Request(ctx, "PUT", m.management.URI("email-templates", template), e, opts...)
 }

--- a/management/grant.go
+++ b/management/grant.go
@@ -28,19 +28,13 @@ type GrantList struct {
 }
 
 // GrantManager manages Auth0 Grant resources.
-type GrantManager struct {
-	*Management
-}
-
-func newGrantManager(m *Management) *GrantManager {
-	return &GrantManager{m}
-}
+type GrantManager manager
 
 // List the grants associated with your account.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Grants/get_grants
 func (m *GrantManager) List(ctx context.Context, opts ...RequestOption) (g *GrantList, err error) {
-	err = m.Request(ctx, "GET", m.URI("grants"), &g, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("grants"), &g, applyListDefaults(opts))
 	return
 }
 
@@ -48,5 +42,5 @@ func (m *GrantManager) List(ctx context.Context, opts ...RequestOption) (g *Gran
 //
 // https://auth0.com/docs/api/management/v2#!/Grants/delete_grants_by_id
 func (m *GrantManager) Delete(ctx context.Context, id string, opts ...RequestOption) error {
-	return m.Request(ctx, "DELETE", m.URI("grants", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("grants", id), nil, opts...)
 }

--- a/management/hook.go
+++ b/management/hook.go
@@ -75,13 +75,7 @@ func (s HookSecrets) intersection(other HookSecrets) HookSecrets {
 }
 
 // HookManager manages Auth0 Hook resources.
-type HookManager struct {
-	*Management
-}
-
-func newHookManager(m *Management) *HookManager {
-	return &HookManager{m}
-}
+type HookManager manager
 
 // Create a new hook.
 //
@@ -89,14 +83,14 @@ func newHookManager(m *Management) *HookManager {
 //
 // See: https://auth0.com/docs/api/management/v2#!/Hooks/post_hooks
 func (m *HookManager) Create(ctx context.Context, h *Hook, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("hooks"), h, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("hooks"), h, opts...)
 }
 
 // Read hook details. Accepts a list of fields to include or exclude in the result.
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Hooks/get_hooks_by_id
 func (m *HookManager) Read(ctx context.Context, id string, opts ...RequestOption) (h *Hook, err error) {
-	err = m.Request(ctx, "GET", m.URI("hooks", id), &h, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("hooks", id), &h, opts...)
 	return
 }
 
@@ -104,21 +98,21 @@ func (m *HookManager) Read(ctx context.Context, id string, opts ...RequestOption
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Hooks/patch_hooks_by_id
 func (m *HookManager) Update(ctx context.Context, id string, h *Hook, opts ...RequestOption) error {
-	return m.Request(ctx, "PATCH", m.URI("hooks", id), h, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("hooks", id), h, opts...)
 }
 
 // Delete a hook.
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Hooks/delete_hooks_by_id
 func (m *HookManager) Delete(ctx context.Context, id string, opts ...RequestOption) error {
-	return m.Request(ctx, "DELETE", m.URI("hooks", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("hooks", id), nil, opts...)
 }
 
 // List all hooks.
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Hooks/get_hooks
 func (m *HookManager) List(ctx context.Context, opts ...RequestOption) (l *HookList, err error) {
-	err = m.Request(ctx, "GET", m.URI("hooks"), &l, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("hooks"), &l, applyListDefaults(opts))
 	return
 }
 
@@ -127,14 +121,14 @@ func (m *HookManager) List(ctx context.Context, opts ...RequestOption) (l *HookL
 //
 // See: https://auth0.com/docs/api/management/v2#!/Hooks/post_secrets
 func (m *HookManager) CreateSecrets(ctx context.Context, hookID string, s HookSecrets, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "POST", m.URI("hooks", hookID, "secrets"), &s, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("hooks", hookID, "secrets"), &s, opts...)
 }
 
 // UpdateSecrets updates one or more existing secrets for an existing hook.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Hooks/patch_secrets
 func (m *HookManager) UpdateSecrets(ctx context.Context, hookID string, s HookSecrets, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("hooks", hookID, "secrets"), &s, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("hooks", hookID, "secrets"), &s, opts...)
 }
 
 // ReplaceSecrets replaces existing secrets with the provided ones.
@@ -166,7 +160,7 @@ func (m *HookManager) ReplaceSecrets(ctx context.Context, hookID string, s HookS
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Hooks/get_secrets
 func (m *HookManager) Secrets(ctx context.Context, hookID string, opts ...RequestOption) (s HookSecrets, err error) {
-	err = m.Request(ctx, "GET", m.URI("hooks", hookID, "secrets"), &s, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("hooks", hookID, "secrets"), &s, opts...)
 	return
 }
 
@@ -175,7 +169,7 @@ func (m *HookManager) Secrets(ctx context.Context, hookID string, opts ...Reques
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Hooks/delete_secrets
 func (m *HookManager) RemoveSecrets(ctx context.Context, hookID string, keys []string, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "DELETE", m.URI("hooks", hookID, "secrets"), keys, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("hooks", hookID, "secrets"), keys, opts...)
 }
 
 // RemoveAllSecrets removes all secrets associated with a given hook.

--- a/management/job.go
+++ b/management/job.go
@@ -114,19 +114,13 @@ type JobUserErrors struct {
 }
 
 // JobManager manages Auth0 Job resources.
-type JobManager struct {
-	*Management
-}
-
-func newJobManager(m *Management) *JobManager {
-	return &JobManager{m}
-}
+type JobManager manager
 
 // Read retrieves a job. Useful to check its status.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id
 func (m *JobManager) Read(ctx context.Context, id string, opts ...RequestOption) (j *Job, err error) {
-	err = m.Request(ctx, "GET", m.URI("jobs", id), &j, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("jobs", id), &j, opts...)
 	return
 }
 
@@ -134,21 +128,21 @@ func (m *JobManager) Read(ctx context.Context, id string, opts ...RequestOption)
 //
 // See: https://auth0.com/docs/api/management/v2#!/Jobs/get_errors
 func (m *JobManager) ReadErrors(ctx context.Context, id string, opts ...RequestOption) (jobErrors []JobError, err error) {
-	err = m.Request(ctx, "GET", m.URI("jobs", id, "errors"), &jobErrors, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("jobs", id, "errors"), &jobErrors, opts...)
 	return
 }
 
 // VerifyEmail sends an email to the specified user that asks them to
 // click a link to verify their email address.
 func (m *JobManager) VerifyEmail(ctx context.Context, j *Job, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("jobs", "verification-email"), j, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("jobs", "verification-email"), j, opts...)
 }
 
 // ExportUsers exports all users to a file via a long-running job.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Jobs/post_users_exports
 func (m *JobManager) ExportUsers(ctx context.Context, j *Job, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("jobs", "users-exports"), j, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("jobs", "users-exports"), j, opts...)
 }
 
 // ImportUsers imports users from a formatted file into a connection via a long-running job.
@@ -194,7 +188,7 @@ func (m *JobManager) ImportUsers(ctx context.Context, j *Job, opts ...RequestOpt
 		return err
 	}
 
-	request, err := http.NewRequestWithContext(ctx, "POST", m.URI("jobs", "users-imports"), &payload)
+	request, err := http.NewRequestWithContext(ctx, "POST", m.management.URI("jobs", "users-imports"), &payload)
 	if err != nil {
 		return err
 	}
@@ -204,7 +198,7 @@ func (m *JobManager) ImportUsers(ctx context.Context, j *Job, opts ...RequestOpt
 		option.apply(request)
 	}
 
-	response, err := m.Do(request)
+	response, err := m.management.Do(request)
 	if err != nil {
 		return err
 	}

--- a/management/log.go
+++ b/management/log.go
@@ -185,20 +185,14 @@ func (l *Log) UnmarshalJSON(data []byte) error {
 }
 
 // LogManager manages Auth0 Log resources.
-type LogManager struct {
-	*Management
-}
-
-func newLogManager(m *Management) *LogManager {
-	return &LogManager{m}
-}
+type LogManager manager
 
 // Read the data related to the log entry identified by id. This returns a
 // single log entry representation as specified in the schema.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Logs/get_logs_by_id
 func (m *LogManager) Read(ctx context.Context, id string, opts ...RequestOption) (l *Log, err error) {
-	err = m.Request(ctx, "GET", m.URI("logs", id), &l, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("logs", id), &l, opts...)
 	return
 }
 
@@ -211,7 +205,7 @@ func (m *LogManager) Read(ctx context.Context, id string, opts ...RequestOption)
 //
 // See: https://auth0.com/docs/api/management/v2#!/Logs/get_logs
 func (m *LogManager) List(ctx context.Context, opts ...RequestOption) (l []*Log, err error) {
-	err = m.Request(ctx, "GET", m.URI("logs"), &l, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("logs"), &l, opts...)
 	return
 }
 

--- a/management/log_stream.go
+++ b/management/log_stream.go
@@ -199,26 +199,20 @@ type LogStreamSinkMixpanel struct {
 }
 
 // LogStreamManager manages Auth0 LogStream resources.
-type LogStreamManager struct {
-	*Management
-}
-
-func newLogStreamManager(m *Management) *LogStreamManager {
-	return &LogStreamManager{m}
-}
+type LogStreamManager manager
 
 // Create a log stream.
 //
 // See: https://auth0.com/docs/api/management/v2#!/log-streams
 func (m *LogStreamManager) Create(ctx context.Context, l *LogStream, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("log-streams"), l, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("log-streams"), l, opts...)
 }
 
 // Read a log stream.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams_by_id
 func (m *LogStreamManager) Read(ctx context.Context, id string, opts ...RequestOption) (l *LogStream, err error) {
-	err = m.Request(ctx, "GET", m.URI("log-streams", id), &l, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("log-streams", id), &l, opts...)
 	return
 }
 
@@ -226,7 +220,7 @@ func (m *LogStreamManager) Read(ctx context.Context, id string, opts ...RequestO
 //
 // See: https://auth0.com/docs/api/management/v2#!/log-streams/get_log_streams
 func (m *LogStreamManager) List(ctx context.Context, opts ...RequestOption) (ls []*LogStream, err error) {
-	err = m.Request(ctx, "GET", m.URI("log-streams"), &ls, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("log-streams"), &ls, opts...)
 	return
 }
 
@@ -239,12 +233,12 @@ func (m *LogStreamManager) List(ctx context.Context, opts ...RequestOption) (ls 
 //
 // See: https://auth0.com/docs/api/management/v2#!/log-streams
 func (m *LogStreamManager) Update(ctx context.Context, id string, l *LogStream, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("log-streams", id), l, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("log-streams", id), l, opts...)
 }
 
 // Delete a log stream.
 //
 // See: https://auth0.com/docs/api/management/v2#!/log-streams
 func (m *LogStreamManager) Delete(ctx context.Context, id string, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "DELETE", m.URI("log-streams", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("log-streams", id), nil, opts...)
 }

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -6285,11 +6285,6 @@ func (m *MultiFactor) String() string {
 	return Stringify(m)
 }
 
-// String returns a string representation of MultiFactorDUO.
-func (m *MultiFactorDUO) String() string {
-	return Stringify(m)
-}
-
 // GetHostname returns the Hostname field if it's non-nil, zero value otherwise.
 func (m *MultiFactorDUOSettings) GetHostname() string {
 	if m == nil || m.Hostname == nil {
@@ -6316,21 +6311,6 @@ func (m *MultiFactorDUOSettings) GetSecretKey() string {
 
 // String returns a string representation of MultiFactorDUOSettings.
 func (m *MultiFactorDUOSettings) String() string {
-	return Stringify(m)
-}
-
-// String returns a string representation of MultiFactorEmail.
-func (m *MultiFactorEmail) String() string {
-	return Stringify(m)
-}
-
-// String returns a string representation of MultiFactorOTP.
-func (m *MultiFactorOTP) String() string {
-	return Stringify(m)
-}
-
-// String returns a string representation of MultiFactorPhone.
-func (m *MultiFactorPhone) String() string {
 	return Stringify(m)
 }
 
@@ -6429,11 +6409,6 @@ func (m *MultiFactorProviderTwilio) String() string {
 	return Stringify(m)
 }
 
-// String returns a string representation of MultiFactorPush.
-func (m *MultiFactorPush) String() string {
-	return Stringify(m)
-}
-
 // GetAppleAppLink returns the AppleAppLink field if it's non-nil, zero value otherwise.
 func (m *MultiFactorPushCustomApp) GetAppleAppLink() string {
 	if m == nil || m.AppleAppLink == nil {
@@ -6513,16 +6488,6 @@ func (m *MultiFactorPushDirectFCM) String() string {
 	return Stringify(m)
 }
 
-// String returns a string representation of MultiFactorRecoveryCode.
-func (m *MultiFactorRecoveryCode) String() string {
-	return Stringify(m)
-}
-
-// String returns a string representation of MultiFactorSMS.
-func (m *MultiFactorSMS) String() string {
-	return Stringify(m)
-}
-
 // GetEnrollmentMessage returns the EnrollmentMessage field if it's non-nil, zero value otherwise.
 func (m *MultiFactorSMSTemplate) GetEnrollmentMessage() string {
 	if m == nil || m.EnrollmentMessage == nil {
@@ -6541,16 +6506,6 @@ func (m *MultiFactorSMSTemplate) GetVerificationMessage() string {
 
 // String returns a string representation of MultiFactorSMSTemplate.
 func (m *MultiFactorSMSTemplate) String() string {
-	return Stringify(m)
-}
-
-// String returns a string representation of MultiFactorWebAuthnPlatform.
-func (m *MultiFactorWebAuthnPlatform) String() string {
-	return Stringify(m)
-}
-
-// String returns a string representation of MultiFactorWebAuthnRoaming.
-func (m *MultiFactorWebAuthnRoaming) String() string {
 	return Stringify(m)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -7952,14 +7952,6 @@ func TestMultiFactor_String(t *testing.T) {
 	}
 }
 
-func TestMultiFactorDUO_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &MultiFactorDUO{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
 func TestMultiFactorDUOSettings_GetHostname(tt *testing.T) {
 	var zeroValue string
 	m := &MultiFactorDUOSettings{Hostname: &zeroValue}
@@ -7993,30 +7985,6 @@ func TestMultiFactorDUOSettings_GetSecretKey(tt *testing.T) {
 func TestMultiFactorDUOSettings_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &MultiFactorDUOSettings{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
-func TestMultiFactorEmail_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &MultiFactorEmail{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
-func TestMultiFactorOTP_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &MultiFactorOTP{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
-func TestMultiFactorPhone_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &MultiFactorPhone{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
@@ -8146,14 +8114,6 @@ func TestMultiFactorProviderTwilio_String(t *testing.T) {
 	}
 }
 
-func TestMultiFactorPush_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &MultiFactorPush{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
 func TestMultiFactorPushCustomApp_GetAppleAppLink(tt *testing.T) {
 	var zeroValue string
 	m := &MultiFactorPushCustomApp{AppleAppLink: &zeroValue}
@@ -8258,22 +8218,6 @@ func TestMultiFactorPushDirectFCM_String(t *testing.T) {
 	}
 }
 
-func TestMultiFactorRecoveryCode_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &MultiFactorRecoveryCode{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
-func TestMultiFactorSMS_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &MultiFactorSMS{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
 func TestMultiFactorSMSTemplate_GetEnrollmentMessage(tt *testing.T) {
 	var zeroValue string
 	m := &MultiFactorSMSTemplate{EnrollmentMessage: &zeroValue}
@@ -8297,22 +8241,6 @@ func TestMultiFactorSMSTemplate_GetVerificationMessage(tt *testing.T) {
 func TestMultiFactorSMSTemplate_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &MultiFactorSMSTemplate{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
-func TestMultiFactorWebAuthnPlatform_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &MultiFactorWebAuthnPlatform{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
-func TestMultiFactorWebAuthnRoaming_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &MultiFactorWebAuthnRoaming{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/management/management.go
+++ b/management/management.go
@@ -114,6 +114,11 @@ type Management struct {
 	tokenSource     oauth2.TokenSource
 	http            *http.Client
 	auth0ClientInfo *client.Auth0ClientInfo
+	common          manager
+}
+
+type manager struct {
+	management *Management
 }
 
 // New creates a new Auth0 Management client by authenticating using the
@@ -153,36 +158,52 @@ func New(domain string, options ...Option) (*Management, error) {
 		client.WithAuth0ClientInfo(m.auth0ClientInfo),
 	)
 
-	m.Client = newClientManager(m)
-	m.ClientGrant = newClientGrantManager(m)
-	m.Connection = newConnectionManager(m)
-	m.CustomDomain = newCustomDomainManager(m)
-	m.Grant = newGrantManager(m)
-	m.LogStream = newLogStreamManager(m)
-	m.Log = newLogManager(m)
-	m.ResourceServer = newResourceServerManager(m)
-	m.Role = newRoleManager(m)
-	m.Rule = newRuleManager(m)
-	m.Hook = newHookManager(m)
-	m.RuleConfig = newRuleConfigManager(m)
-	m.EmailTemplate = newEmailTemplateManager(m)
-	m.Email = newEmailManager(m)
-	m.User = newUserManager(m)
-	m.Job = newJobManager(m)
-	m.Tenant = newTenantManager(m)
-	m.Ticket = newTicketManager(m)
-	m.Stat = newStatManager(m)
-	m.Branding = newBrandingManager(m)
-	m.Guardian = newGuardianManager(m)
-	m.Prompt = newPromptManager(m)
-	m.Blacklist = newBlacklistManager(m)
-	m.SigningKey = newSigningKeyManager(m)
-	m.Anomaly = newAnomalyManager(m)
-	m.Action = newActionManager(m)
-	m.Organization = newOrganizationManager(m)
-	m.AttackProtection = newAttackProtectionManager(m)
-	m.BrandingTheme = newBrandingThemeManager(m)
-	m.EmailProvider = newEmailProviderManager(m)
+	m.common.management = m
+
+	m.Action = (*ActionManager)(&m.common)
+	m.Anomaly = (*AnomalyManager)(&m.common)
+	m.AttackProtection = (*AttackProtectionManager)(&m.common)
+	m.Blacklist = (*BlacklistManager)(&m.common)
+	m.Branding = (*BrandingManager)(&m.common)
+	m.BrandingTheme = (*BrandingThemeManager)(&m.common)
+	m.Client = (*ClientManager)(&m.common)
+	m.ClientGrant = (*ClientGrantManager)(&m.common)
+	m.Connection = (*ConnectionManager)(&m.common)
+	m.CustomDomain = (*CustomDomainManager)(&m.common)
+	m.Email = (*EmailManager)(&m.common)
+	m.EmailProvider = (*EmailProviderManager)(&m.common)
+	m.EmailTemplate = (*EmailTemplateManager)(&m.common)
+	m.Grant = (*GrantManager)(&m.common)
+	m.Guardian = &GuardianManager{
+		Enrollment: (*EnrollmentManager)(&m.common),
+		MultiFactor: &MultiFactorManager{
+			manager:          m.common,
+			DUO:              (*MultiFactorDUO)(&m.common),
+			Email:            (*MultiFactorEmail)(&m.common),
+			OTP:              (*MultiFactorOTP)(&m.common),
+			Phone:            (*MultiFactorPhone)(&m.common),
+			Push:             (*MultiFactorPush)(&m.common),
+			RecoveryCode:     (*MultiFactorRecoveryCode)(&m.common),
+			SMS:              (*MultiFactorSMS)(&m.common),
+			WebAuthnPlatform: (*MultiFactorWebAuthnPlatform)(&m.common),
+			WebAuthnRoaming:  (*MultiFactorWebAuthnRoaming)(&m.common),
+		},
+	}
+	m.Hook = (*HookManager)(&m.common)
+	m.Job = (*JobManager)(&m.common)
+	m.Log = (*LogManager)(&m.common)
+	m.LogStream = (*LogStreamManager)(&m.common)
+	m.Organization = (*OrganizationManager)(&m.common)
+	m.Prompt = (*PromptManager)(&m.common)
+	m.ResourceServer = (*ResourceServerManager)(&m.common)
+	m.Role = (*RoleManager)(&m.common)
+	m.Rule = (*RuleManager)(&m.common)
+	m.RuleConfig = (*RuleConfigManager)(&m.common)
+	m.SigningKey = (*SigningKeyManager)(&m.common)
+	m.Stat = (*StatManager)(&m.common)
+	m.Tenant = (*TenantManager)(&m.common)
+	m.Ticket = (*TicketManager)(&m.common)
+	m.User = (*UserManager)(&m.common)
 
 	return m, nil
 }

--- a/management/organization.go
+++ b/management/organization.go
@@ -175,19 +175,13 @@ type OrganizationList struct {
 }
 
 // OrganizationManager is used for managing an Organization.
-type OrganizationManager struct {
-	*Management
-}
-
-func newOrganizationManager(m *Management) *OrganizationManager {
-	return &OrganizationManager{m}
-}
+type OrganizationManager manager
 
 // List available organizations.
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_organizations
 func (m *OrganizationManager) List(ctx context.Context, opts ...RequestOption) (o *OrganizationList, err error) {
-	err = m.Request(ctx, "GET", m.URI("organizations"), &o, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("organizations"), &o, applyListDefaults(opts))
 	return
 }
 
@@ -195,7 +189,7 @@ func (m *OrganizationManager) List(ctx context.Context, opts ...RequestOption) (
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/post_organizations
 func (m *OrganizationManager) Create(ctx context.Context, o *Organization, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "POST", m.URI("organizations"), &o, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("organizations"), &o, opts...)
 	return
 }
 
@@ -203,7 +197,7 @@ func (m *OrganizationManager) Create(ctx context.Context, o *Organization, opts 
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_organizations_by_id
 func (m *OrganizationManager) Read(ctx context.Context, id string, opts ...RequestOption) (o *Organization, err error) {
-	err = m.Request(ctx, "GET", m.URI("organizations", id), &o, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("organizations", id), &o, opts...)
 	return
 }
 
@@ -211,7 +205,7 @@ func (m *OrganizationManager) Read(ctx context.Context, id string, opts ...Reque
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/delete_organizations_by_id
 func (m *OrganizationManager) Delete(ctx context.Context, id string, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "DELETE", m.URI("organizations", id), nil, opts...)
+	err = m.management.Request(ctx, "DELETE", m.management.URI("organizations", id), nil, opts...)
 	return
 }
 
@@ -219,7 +213,7 @@ func (m *OrganizationManager) Delete(ctx context.Context, id string, opts ...Req
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/patch_organizations_by_id
 func (m *OrganizationManager) Update(ctx context.Context, id string, o *Organization, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "PATCH", m.URI("organizations", id), &o, opts...)
+	err = m.management.Request(ctx, "PATCH", m.management.URI("organizations", id), &o, opts...)
 	return
 }
 
@@ -227,7 +221,7 @@ func (m *OrganizationManager) Update(ctx context.Context, id string, o *Organiza
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_name_by_name
 func (m *OrganizationManager) ReadByName(ctx context.Context, name string, opts ...RequestOption) (o *Organization, err error) {
-	err = m.Request(ctx, "GET", m.URI("organizations", "name", name), &o, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("organizations", "name", name), &o, opts...)
 	return
 }
 
@@ -235,7 +229,7 @@ func (m *OrganizationManager) ReadByName(ctx context.Context, name string, opts 
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_enabled_connections
 func (m *OrganizationManager) Connections(ctx context.Context, id string, opts ...RequestOption) (c *OrganizationConnectionList, err error) {
-	err = m.Request(ctx, "GET", m.URI("organizations", id, "enabled_connections"), &c, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("organizations", id, "enabled_connections"), &c, applyListDefaults(opts))
 	return
 }
 
@@ -243,7 +237,7 @@ func (m *OrganizationManager) Connections(ctx context.Context, id string, opts .
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/post_enabled_connections
 func (m *OrganizationManager) AddConnection(ctx context.Context, id string, c *OrganizationConnection, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "POST", m.URI("organizations", id, "enabled_connections"), &c, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("organizations", id, "enabled_connections"), &c, opts...)
 	return
 }
 
@@ -251,7 +245,7 @@ func (m *OrganizationManager) AddConnection(ctx context.Context, id string, c *O
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_enabled_connections_by_connectionId
 func (m *OrganizationManager) Connection(ctx context.Context, id string, connectionID string, opts ...RequestOption) (c *OrganizationConnection, err error) {
-	err = m.Request(ctx, "GET", m.URI("organizations", id, "enabled_connections", connectionID), &c, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("organizations", id, "enabled_connections", connectionID), &c, opts...)
 	return
 }
 
@@ -259,7 +253,7 @@ func (m *OrganizationManager) Connection(ctx context.Context, id string, connect
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/delete_enabled_connections_by_connectionId
 func (m *OrganizationManager) DeleteConnection(ctx context.Context, id string, connectionID string, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "DELETE", m.URI("organizations", id, "enabled_connections", connectionID), nil, opts...)
+	err = m.management.Request(ctx, "DELETE", m.management.URI("organizations", id, "enabled_connections", connectionID), nil, opts...)
 	return
 }
 
@@ -267,7 +261,7 @@ func (m *OrganizationManager) DeleteConnection(ctx context.Context, id string, c
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/patch_enabled_connections_by_connectionId
 func (m *OrganizationManager) UpdateConnection(ctx context.Context, id string, connectionID string, c *OrganizationConnection, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "PATCH", m.URI("organizations", id, "enabled_connections", connectionID), &c, opts...)
+	err = m.management.Request(ctx, "PATCH", m.management.URI("organizations", id, "enabled_connections", connectionID), &c, opts...)
 	return
 }
 
@@ -277,7 +271,7 @@ func (m *OrganizationManager) UpdateConnection(ctx context.Context, id string, c
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_invitations
 func (m *OrganizationManager) Invitations(ctx context.Context, id string, opts ...RequestOption) (i *OrganizationInvitationList, err error) {
-	err = m.Request(ctx, "GET", m.URI("organizations", id, "invitations"), &i, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("organizations", id, "invitations"), &i, applyListDefaults(opts))
 	return
 }
 
@@ -285,7 +279,7 @@ func (m *OrganizationManager) Invitations(ctx context.Context, id string, opts .
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/post_invitations
 func (m *OrganizationManager) CreateInvitation(ctx context.Context, id string, i *OrganizationInvitation, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "POST", m.URI("organizations", id, "invitations"), &i, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("organizations", id, "invitations"), &i, opts...)
 	return
 }
 
@@ -293,7 +287,7 @@ func (m *OrganizationManager) CreateInvitation(ctx context.Context, id string, i
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_invitations_by_invitation_id
 func (m *OrganizationManager) Invitation(ctx context.Context, id string, invitationID string, opts ...RequestOption) (i *OrganizationInvitation, err error) {
-	err = m.Request(ctx, "GET", m.URI("organizations", id, "invitations", invitationID), &i, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("organizations", id, "invitations", invitationID), &i, opts...)
 	return
 }
 
@@ -301,7 +295,7 @@ func (m *OrganizationManager) Invitation(ctx context.Context, id string, invitat
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/delete_invitations_by_invitation_id
 func (m *OrganizationManager) DeleteInvitation(ctx context.Context, id string, invitationID string, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "DELETE", m.URI("organizations", id, "invitations", invitationID), nil, opts...)
+	err = m.management.Request(ctx, "DELETE", m.management.URI("organizations", id, "invitations", invitationID), nil, opts...)
 	return
 }
 
@@ -309,7 +303,7 @@ func (m *OrganizationManager) DeleteInvitation(ctx context.Context, id string, i
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_members
 func (m *OrganizationManager) Members(ctx context.Context, id string, opts ...RequestOption) (o *OrganizationMemberList, err error) {
-	err = m.Request(ctx, "GET", m.URI("organizations", id, "members"), &o, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("organizations", id, "members"), &o, applyListDefaults(opts))
 	return
 }
 
@@ -322,7 +316,7 @@ func (m *OrganizationManager) AddMembers(ctx context.Context, id string, memberI
 	}{
 		Members: memberIDs,
 	}
-	err = m.Request(ctx, "POST", m.URI("organizations", id, "members"), &body, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("organizations", id, "members"), &body, opts...)
 	return
 }
 
@@ -335,7 +329,7 @@ func (m *OrganizationManager) DeleteMember(ctx context.Context, id string, membe
 	}{
 		Members: memberIDs,
 	}
-	err = m.Request(ctx, "DELETE", m.URI("organizations", id, "members"), &body, opts...)
+	err = m.management.Request(ctx, "DELETE", m.management.URI("organizations", id, "members"), &body, opts...)
 	return
 }
 
@@ -343,7 +337,7 @@ func (m *OrganizationManager) DeleteMember(ctx context.Context, id string, membe
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Organizations/get_organization_member_roles
 func (m *OrganizationManager) MemberRoles(ctx context.Context, id string, memberID string, opts ...RequestOption) (r *OrganizationMemberRoleList, err error) {
-	err = m.Request(ctx, "GET", m.URI("organizations", id, "members", memberID, "roles"), &r, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("organizations", id, "members", memberID, "roles"), &r, applyListDefaults(opts))
 	return
 }
 
@@ -356,7 +350,7 @@ func (m *OrganizationManager) AssignMemberRoles(ctx context.Context, id string, 
 	}{
 		Roles: roles,
 	}
-	err = m.Request(ctx, "POST", m.URI("organizations", id, "members", memberID, "roles"), &body, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("organizations", id, "members", memberID, "roles"), &body, opts...)
 	return
 }
 
@@ -369,6 +363,6 @@ func (m *OrganizationManager) DeleteMemberRoles(ctx context.Context, id string, 
 	}{
 		Roles: roles,
 	}
-	err = m.Request(ctx, "DELETE", m.URI("organizations", id, "members", memberID, "roles"), &body, opts...)
+	err = m.management.Request(ctx, "DELETE", m.management.URI("organizations", id, "members", memberID, "roles"), &body, opts...)
 	return
 }

--- a/management/prompt.go
+++ b/management/prompt.go
@@ -17,19 +17,13 @@ type Prompt struct {
 }
 
 // PromptManager is used for managing a Prompt.
-type PromptManager struct {
-	*Management
-}
-
-func newPromptManager(m *Management) *PromptManager {
-	return &PromptManager{m}
-}
+type PromptManager manager
 
 // Read retrieves prompts settings.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Prompts/get_prompts
 func (m *PromptManager) Read(ctx context.Context, opts ...RequestOption) (p *Prompt, err error) {
-	err = m.Request(ctx, "GET", m.URI("prompts"), &p, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("prompts"), &p, opts...)
 	return
 }
 
@@ -37,14 +31,14 @@ func (m *PromptManager) Read(ctx context.Context, opts ...RequestOption) (p *Pro
 //
 // See: https://auth0.com/docs/api/management/v2#!/Prompts/patch_prompts
 func (m *PromptManager) Update(ctx context.Context, p *Prompt, opts ...RequestOption) error {
-	return m.Request(ctx, "PATCH", m.URI("prompts"), p, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("prompts"), p, opts...)
 }
 
 // CustomText retrieves the custom text for a specific prompt and language.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
 func (m *PromptManager) CustomText(ctx context.Context, p string, l string, opts ...RequestOption) (t map[string]interface{}, err error) {
-	err = m.Request(ctx, "GET", m.URI("prompts", p, "custom-text", l), &t, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("prompts", p, "custom-text", l), &t, opts...)
 	return
 }
 
@@ -52,6 +46,6 @@ func (m *PromptManager) CustomText(ctx context.Context, p string, l string, opts
 //
 // See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
 func (m *PromptManager) SetCustomText(ctx context.Context, p string, l string, b map[string]interface{}, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "PUT", m.URI("prompts", p, "custom-text", l), &b, opts...)
+	err = m.management.Request(ctx, "PUT", m.management.URI("prompts", p, "custom-text", l), &b, opts...)
 	return
 }

--- a/management/resource_server.go
+++ b/management/resource_server.go
@@ -69,26 +69,20 @@ type ResourceServerList struct {
 }
 
 // ResourceServerManager is used for managing a ResourceServer.
-type ResourceServerManager struct {
-	*Management
-}
-
-func newResourceServerManager(m *Management) *ResourceServerManager {
-	return &ResourceServerManager{m}
-}
+type ResourceServerManager manager
 
 // Create a resource server.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Resource_Servers/post_resource_servers
 func (m *ResourceServerManager) Create(ctx context.Context, rs *ResourceServer, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "POST", m.URI("resource-servers"), rs, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("resource-servers"), rs, opts...)
 }
 
 // Read retrieves a resource server by its id or audience.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Resource_Servers/get_resource_servers_by_id
 func (m *ResourceServerManager) Read(ctx context.Context, id string, opts ...RequestOption) (rs *ResourceServer, err error) {
-	err = m.Request(ctx, "GET", m.URI("resource-servers", id), &rs, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("resource-servers", id), &rs, opts...)
 	return
 }
 
@@ -96,21 +90,21 @@ func (m *ResourceServerManager) Read(ctx context.Context, id string, opts ...Req
 //
 // See: https://auth0.com/docs/api/management/v2#!/Resource_Servers/patch_resource_servers_by_id
 func (m *ResourceServerManager) Update(ctx context.Context, id string, rs *ResourceServer, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("resource-servers", id), rs, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("resource-servers", id), rs, opts...)
 }
 
 // Delete a resource server.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Resource_Servers/delete_resource_servers_by_id
 func (m *ResourceServerManager) Delete(ctx context.Context, id string, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "DELETE", m.URI("resource-servers", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("resource-servers", id), nil, opts...)
 }
 
 // List all resource server.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Resource_Servers/get_resource_servers
 func (m *ResourceServerManager) List(ctx context.Context, opts ...RequestOption) (rl *ResourceServerList, err error) {
-	err = m.Request(ctx, "GET", m.URI("resource-servers"), &rl, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("resource-servers"), &rl, applyListDefaults(opts))
 	return
 }
 

--- a/management/role.go
+++ b/management/role.go
@@ -42,26 +42,20 @@ type PermissionList struct {
 }
 
 // RoleManager manages Auth0 Role resources.
-type RoleManager struct {
-	*Management
-}
-
-func newRoleManager(m *Management) *RoleManager {
-	return &RoleManager{m}
-}
+type RoleManager manager
 
 // Create a new role.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/post_roles
 func (m *RoleManager) Create(ctx context.Context, r *Role, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("roles"), r, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("roles"), r, opts...)
 }
 
 // Retrieve a role.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/get_roles_by_id
 func (m *RoleManager) Read(ctx context.Context, id string, opts ...RequestOption) (r *Role, err error) {
-	err = m.Request(ctx, "GET", m.URI("roles", id), &r, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("roles", id), &r, opts...)
 	return
 }
 
@@ -69,7 +63,7 @@ func (m *RoleManager) Read(ctx context.Context, id string, opts ...RequestOption
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/patch_roles_by_id
 func (m *RoleManager) Update(ctx context.Context, id string, r *Role, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("roles", id), r, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("roles", id), r, opts...)
 }
 
 // Delete a role.
@@ -80,14 +74,14 @@ func (m *RoleManager) Delete(ctx context.Context, id string, opts ...RequestOpti
 	// triggers decoding of the response payload.
 	//
 	// In order to avoid Unmarshal(nil) errors, we pass an empty &Role{}.
-	return m.Request(ctx, "DELETE", m.URI("roles", id), &Role{}, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("roles", id), &Role{}, opts...)
 }
 
 // List all roles that can be assigned to users or groups.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/get_roles
 func (m *RoleManager) List(ctx context.Context, opts ...RequestOption) (r *RoleList, err error) {
-	err = m.Request(ctx, "GET", m.URI("roles"), &r, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("roles"), &r, applyListDefaults(opts))
 	return
 }
 
@@ -100,14 +94,14 @@ func (m *RoleManager) AssignUsers(ctx context.Context, id string, users []*User,
 	for i, user := range users {
 		u["users"][i] = user.ID
 	}
-	return m.Request(ctx, "POST", m.URI("roles", id, "users"), &u, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("roles", id, "users"), &u, opts...)
 }
 
 // Users retrieves all users associated with a role.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/get_role_user
 func (m *RoleManager) Users(ctx context.Context, id string, opts ...RequestOption) (u *UserList, err error) {
-	err = m.Request(ctx, "GET", m.URI("roles", id, "users"), &u, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("roles", id, "users"), &u, applyListDefaults(opts))
 	return
 }
 
@@ -117,14 +111,14 @@ func (m *RoleManager) Users(ctx context.Context, id string, opts ...RequestOptio
 func (m *RoleManager) AssociatePermissions(ctx context.Context, id string, permissions []*Permission, opts ...RequestOption) error {
 	p := make(map[string][]*Permission)
 	p["permissions"] = permissions
-	return m.Request(ctx, "POST", m.URI("roles", id, "permissions"), &p, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("roles", id, "permissions"), &p, opts...)
 }
 
 // Permissions retrieves all permissions granted by a role.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/get_role_permission
 func (m *RoleManager) Permissions(ctx context.Context, id string, opts ...RequestOption) (p *PermissionList, err error) {
-	err = m.Request(ctx, "GET", m.URI("roles", id, "permissions"), &p, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("roles", id, "permissions"), &p, applyListDefaults(opts))
 	return
 }
 
@@ -134,5 +128,5 @@ func (m *RoleManager) Permissions(ctx context.Context, id string, opts ...Reques
 func (m *RoleManager) RemovePermissions(ctx context.Context, id string, permissions []*Permission, opts ...RequestOption) error {
 	p := make(map[string][]*Permission)
 	p["permissions"] = permissions
-	return m.Request(ctx, "DELETE", m.URI("roles", id, "permissions"), &p, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("roles", id, "permissions"), &p, opts...)
 }

--- a/management/rule.go
+++ b/management/rule.go
@@ -30,13 +30,7 @@ type RuleList struct {
 }
 
 // RuleManager manages Auth0 Rule resources.
-type RuleManager struct {
-	*Management
-}
-
-func newRuleManager(m *Management) *RuleManager {
-	return &RuleManager{m}
-}
+type RuleManager manager
 
 // Create a new rule.
 //
@@ -45,14 +39,14 @@ func newRuleManager(m *Management) *RuleManager {
 //
 // See: https://auth0.com/docs/api/management/v2#!/Rules/post_rules
 func (m *RuleManager) Create(ctx context.Context, r *Rule, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("rules"), r, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("rules"), r, opts...)
 }
 
 // Retrieve rule details. Accepts a list of fields to include or exclude in the result.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Rules/get_rules_by_id
 func (m *RuleManager) Read(ctx context.Context, id string, opts ...RequestOption) (r *Rule, err error) {
-	err = m.Request(ctx, "GET", m.URI("rules", id), &r, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("rules", id), &r, opts...)
 	return
 }
 
@@ -60,20 +54,20 @@ func (m *RuleManager) Read(ctx context.Context, id string, opts ...RequestOption
 //
 // See: https://auth0.com/docs/api/management/v2#!/Rules/patch_rules_by_id
 func (m *RuleManager) Update(ctx context.Context, id string, r *Rule, opts ...RequestOption) error {
-	return m.Request(ctx, "PATCH", m.URI("rules", id), r, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("rules", id), r, opts...)
 }
 
 // Delete a rule.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Rules/delete_rules_by_id
 func (m *RuleManager) Delete(ctx context.Context, id string, opts ...RequestOption) error {
-	return m.Request(ctx, "DELETE", m.URI("rules", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("rules", id), nil, opts...)
 }
 
 // List all rules.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Rules/get_rules
 func (m *RuleManager) List(ctx context.Context, opts ...RequestOption) (r *RuleList, err error) {
-	err = m.Request(ctx, "GET", m.URI("rules"), &r, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("rules"), &r, applyListDefaults(opts))
 	return
 }

--- a/management/rule_config.go
+++ b/management/rule_config.go
@@ -12,19 +12,13 @@ type RuleConfig struct {
 }
 
 // RuleConfigManager manages Auth0 RuleConfig resources.
-type RuleConfigManager struct {
-	*Management
-}
-
-func newRuleConfigManager(m *Management) *RuleConfigManager {
-	return &RuleConfigManager{m}
-}
+type RuleConfigManager manager
 
 // Upsert sets a rule configuration variable.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Rules_Configs/put_rules_configs_by_key
 func (m *RuleConfigManager) Upsert(ctx context.Context, key string, r *RuleConfig, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PUT", m.URI("rules-configs", key), r, opts...)
+	return m.management.Request(ctx, "PUT", m.management.URI("rules-configs", key), r, opts...)
 }
 
 // Read a rule configuration variable by key.
@@ -50,13 +44,13 @@ func (m *RuleConfigManager) Read(ctx context.Context, key string, opts ...Reques
 //
 // See: https://auth0.com/docs/api/management/v2#!/Rules_Configs/delete_rules_configs_by_key
 func (m *RuleConfigManager) Delete(ctx context.Context, key string, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "DELETE", m.URI("rules-configs", key), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("rules-configs", key), nil, opts...)
 }
 
 // List all rule configuration variables.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Rules_Configs/get_rules_configs
 func (m *RuleConfigManager) List(ctx context.Context, opts ...RequestOption) (r []*RuleConfig, err error) {
-	err = m.Request(ctx, "GET", m.URI("rules-configs"), &r, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("rules-configs"), &r, applyListDefaults(opts))
 	return
 }

--- a/management/signing_key.go
+++ b/management/signing_key.go
@@ -45,19 +45,13 @@ type SigningKey struct {
 }
 
 // SigningKeyManager manages Auth0 SigningKey resources.
-type SigningKeyManager struct {
-	*Management
-}
-
-func newSigningKeyManager(m *Management) *SigningKeyManager {
-	return &SigningKeyManager{m}
-}
+type SigningKeyManager manager
 
 // List all Application Signing Keys.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Keys/get_signing_keys
 func (m *SigningKeyManager) List(ctx context.Context, opts ...RequestOption) (ks []*SigningKey, err error) {
-	err = m.Request(ctx, "GET", m.URI("keys", "signing"), &ks, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("keys", "signing"), &ks, opts...)
 	return
 }
 
@@ -65,7 +59,7 @@ func (m *SigningKeyManager) List(ctx context.Context, opts ...RequestOption) (ks
 //
 // See: https://auth0.com/docs/api/management/v2#!/Keys/get_signing_key
 func (m *SigningKeyManager) Read(ctx context.Context, kid string, opts ...RequestOption) (k *SigningKey, err error) {
-	err = m.Request(ctx, "GET", m.URI("keys", "signing", kid), &k, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("keys", "signing", kid), &k, opts...)
 	return
 }
 
@@ -73,7 +67,7 @@ func (m *SigningKeyManager) Read(ctx context.Context, kid string, opts ...Reques
 //
 // See: https://auth0.com/docs/api/management/v2#!/Keys/post_signing_keys
 func (m *SigningKeyManager) Rotate(ctx context.Context, opts ...RequestOption) (k *SigningKey, err error) {
-	err = m.Request(ctx, "POST", m.URI("keys", "signing", "rotate"), &k, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("keys", "signing", "rotate"), &k, opts...)
 	return
 }
 
@@ -81,6 +75,6 @@ func (m *SigningKeyManager) Rotate(ctx context.Context, opts ...RequestOption) (
 //
 // See: https://auth0.com/docs/api/management/v2#!/Keys/put_signing_keys
 func (m *SigningKeyManager) Revoke(ctx context.Context, kid string, opts ...RequestOption) (k *SigningKey, err error) {
-	err = m.Request(ctx, "PUT", m.URI("keys", "signing", kid, "revoke"), &k, opts...)
+	err = m.management.Request(ctx, "PUT", m.management.URI("keys", "signing", kid, "revoke"), &k, opts...)
 	return
 }

--- a/management/stat.go
+++ b/management/stat.go
@@ -6,20 +6,14 @@ import (
 )
 
 // StatManager manages Auth0 DailyStat resources.
-type StatManager struct {
-	*Management
-}
-
-func newStatManager(m *Management) *StatManager {
-	return &StatManager{m}
-}
+type StatManager manager
 
 // ActiveUsers retrieves the number of active users that logged in during the
 // last 30 days.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Stats/get_active_users
 func (m *StatManager) ActiveUsers(ctx context.Context, opts ...RequestOption) (i int, err error) {
-	err = m.Request(ctx, "GET", m.URI("stats", "active-users"), &i, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("stats", "active-users"), &i, opts...)
 	return
 }
 
@@ -39,6 +33,6 @@ type DailyStat struct {
 //
 // See: https://auth0.com/docs/api/management/v2#!/Stats/get_daily
 func (m *StatManager) Daily(ctx context.Context, opts ...RequestOption) (ds []*DailyStat, err error) {
-	err = m.Request(ctx, "GET", m.URI("stats", "daily"), &ds, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("stats", "daily"), &ds, opts...)
 	return
 }

--- a/management/tenant.go
+++ b/management/tenant.go
@@ -352,20 +352,14 @@ type TenantSessionCookie struct {
 }
 
 // TenantManager manages Auth0 Tenant resources.
-type TenantManager struct {
-	*Management
-}
-
-func newTenantManager(m *Management) *TenantManager {
-	return &TenantManager{m}
-}
+type TenantManager manager
 
 // Read tenant settings.
 // A list of fields to include or exclude may also be specified.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Tenants/get_settings
 func (m *TenantManager) Read(ctx context.Context, opts ...RequestOption) (t *Tenant, err error) {
-	err = m.Request(ctx, "GET", m.URI("tenants", "settings"), &t, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("tenants", "settings"), &t, opts...)
 	return
 }
 
@@ -373,5 +367,5 @@ func (m *TenantManager) Read(ctx context.Context, opts ...RequestOption) (t *Ten
 //
 // See: https://auth0.com/docs/api/management/v2#!/Tenants/patch_settings
 func (m *TenantManager) Update(ctx context.Context, t *Tenant, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("tenants", "settings"), t, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("tenants", "settings"), t, opts...)
 }

--- a/management/ticket.go
+++ b/management/ticket.go
@@ -58,24 +58,18 @@ type Ticket struct {
 }
 
 // TicketManager manages Auth0 Ticket resources.
-type TicketManager struct {
-	*Management
-}
-
-func newTicketManager(m *Management) *TicketManager {
-	return &TicketManager{m}
-}
+type TicketManager manager
 
 // VerifyEmail creates a ticket to verify a user's email address.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification
 func (m *TicketManager) VerifyEmail(ctx context.Context, t *Ticket, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("tickets", "email-verification"), t, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("tickets", "email-verification"), t, opts...)
 }
 
 // ChangePassword creates a password change ticket for a user.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Tickets/post_password_change
 func (m *TicketManager) ChangePassword(ctx context.Context, t *Ticket, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("tickets", "password-change"), t, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("tickets", "password-change"), t, opts...)
 }

--- a/management/user.go
+++ b/management/user.go
@@ -375,14 +375,9 @@ type AuthenticationMethodList struct {
 }
 
 // UserManager manages Auth0 User resources.
-type UserManager struct {
-	*Management
-}
+type UserManager manager
 
 // newUserManager returns a new instance of a user manager.
-func newUserManager(m *Management) *UserManager {
-	return &UserManager{m}
-}
 
 // Create a new user. It works only for database and passwordless connections.
 //
@@ -393,14 +388,14 @@ func newUserManager(m *Management) *UserManager {
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/post_users
 func (m *UserManager) Create(ctx context.Context, u *User, opts ...RequestOption) error {
-	return m.Request(ctx, "POST", m.URI("users"), u, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("users"), u, opts...)
 }
 
 // Read user details for a given user_id.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_users_by_id
 func (m *UserManager) Read(ctx context.Context, id string, opts ...RequestOption) (u *User, err error) {
-	err = m.Request(ctx, "GET", m.URI("users", id), &u, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("users", id), &u, opts...)
 	return
 }
 
@@ -426,21 +421,21 @@ func (m *UserManager) Read(ctx context.Context, id string, opts ...RequestOption
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id
 func (m *UserManager) Update(ctx context.Context, id string, u *User, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "PATCH", m.URI("users", id), u, opts...)
+	return m.management.Request(ctx, "PATCH", m.management.URI("users", id), u, opts...)
 }
 
 // Delete a single user based on its id.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/delete_users_by_id
 func (m *UserManager) Delete(ctx context.Context, id string, opts ...RequestOption) (err error) {
-	return m.Request(ctx, "DELETE", m.URI("users", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("users", id), nil, opts...)
 }
 
 // List all users. This method forces the `include_totals` option.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_users
 func (m *UserManager) List(ctx context.Context, opts ...RequestOption) (ul *UserList, err error) {
-	err = m.Request(ctx, "GET", m.URI("users"), &ul, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("users"), &ul, applyListDefaults(opts))
 	return
 }
 
@@ -465,7 +460,7 @@ func (m *UserManager) Search(ctx context.Context, opts ...RequestOption) (ul *Us
 // See: https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email
 func (m *UserManager) ListByEmail(ctx context.Context, email string, opts ...RequestOption) (us []*User, err error) {
 	opts = append(opts, Parameter("email", email))
-	err = m.Request(ctx, "GET", m.URI("users-by-email"), &us, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("users-by-email"), &us, opts...)
 	return
 }
 
@@ -473,7 +468,7 @@ func (m *UserManager) ListByEmail(ctx context.Context, email string, opts ...Req
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_user_roles
 func (m *UserManager) Roles(ctx context.Context, id string, opts ...RequestOption) (r *RoleList, err error) {
-	err = m.Request(ctx, "GET", m.URI("users", id, "roles"), &r, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("users", id, "roles"), &r, applyListDefaults(opts))
 	return
 }
 
@@ -486,7 +481,7 @@ func (m *UserManager) AssignRoles(ctx context.Context, id string, roles []*Role,
 	for i, role := range roles {
 		r["roles"][i] = role.ID
 	}
-	return m.Request(ctx, "POST", m.URI("users", id, "roles"), &r, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("users", id, "roles"), &r, opts...)
 }
 
 // RemoveRoles removes any roles associated to a user.
@@ -498,14 +493,14 @@ func (m *UserManager) RemoveRoles(ctx context.Context, id string, roles []*Role,
 	for i, role := range roles {
 		r["roles"][i] = role.ID
 	}
-	return m.Request(ctx, "DELETE", m.URI("users", id, "roles"), &r, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("users", id, "roles"), &r, opts...)
 }
 
 // Permissions lists the permissions associated to the user.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_permissions
 func (m *UserManager) Permissions(ctx context.Context, id string, opts ...RequestOption) (p *PermissionList, err error) {
-	err = m.Request(ctx, "GET", m.URI("users", id, "permissions"), &p, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("users", id, "permissions"), &p, applyListDefaults(opts))
 	return
 }
 
@@ -515,7 +510,7 @@ func (m *UserManager) Permissions(ctx context.Context, id string, opts ...Reques
 func (m *UserManager) AssignPermissions(ctx context.Context, id string, permissions []*Permission, opts ...RequestOption) error {
 	p := make(map[string][]*Permission)
 	p["permissions"] = permissions
-	return m.Request(ctx, "POST", m.URI("users", id, "permissions"), &p, opts...)
+	return m.management.Request(ctx, "POST", m.management.URI("users", id, "permissions"), &p, opts...)
 }
 
 // RemovePermissions removes any permissions associated to a user.
@@ -524,7 +519,7 @@ func (m *UserManager) AssignPermissions(ctx context.Context, id string, permissi
 func (m *UserManager) RemovePermissions(ctx context.Context, id string, permissions []*Permission, opts ...RequestOption) error {
 	p := make(map[string][]*Permission)
 	p["permissions"] = permissions
-	return m.Request(ctx, "DELETE", m.URI("users", id, "permissions"), &p, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("users", id, "permissions"), &p, opts...)
 }
 
 // Blocks retrieves a list of blocked IP addresses of a particular user using the
@@ -533,7 +528,7 @@ func (m *UserManager) RemovePermissions(ctx context.Context, id string, permissi
 // See: https://auth0.com/docs/api/management/v2#!/User_Blocks/get_user_blocks_by_id
 func (m *UserManager) Blocks(ctx context.Context, id string, opts ...RequestOption) ([]*UserBlock, error) {
 	b := new(userBlock)
-	err := m.Request(ctx, "GET", m.URI("user-blocks", id), &b, opts...)
+	err := m.management.Request(ctx, "GET", m.management.URI("user-blocks", id), &b, opts...)
 	return b.BlockedFor, err
 }
 
@@ -544,7 +539,7 @@ func (m *UserManager) Blocks(ctx context.Context, id string, opts ...RequestOpti
 func (m *UserManager) BlocksByIdentifier(ctx context.Context, identifier string, opts ...RequestOption) ([]*UserBlock, error) {
 	b := new(userBlock)
 	opts = append(opts, Parameter("identifier", identifier))
-	err := m.Request(ctx, "GET", m.URI("user-blocks"), &b, opts...)
+	err := m.management.Request(ctx, "GET", m.management.URI("user-blocks"), &b, opts...)
 	return b.BlockedFor, err
 }
 
@@ -555,7 +550,7 @@ func (m *UserManager) BlocksByIdentifier(ctx context.Context, identifier string,
 //
 // See: https://auth0.com/docs/api/management/v2#!/User_Blocks/delete_user_blocks_by_id
 func (m *UserManager) Unblock(ctx context.Context, id string, opts ...RequestOption) error {
-	return m.Request(ctx, "DELETE", m.URI("user-blocks", id), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("user-blocks", id), nil, opts...)
 }
 
 // UnblockByIdentifier a user that was blocked due to an excessive amount of incorrectly
@@ -566,14 +561,14 @@ func (m *UserManager) Unblock(ctx context.Context, id string, opts ...RequestOpt
 // See: https://auth0.com/docs/api/management/v2#!/User_Blocks/delete_user_blocks
 func (m *UserManager) UnblockByIdentifier(ctx context.Context, identifier string, opts ...RequestOption) error {
 	opts = append(opts, Parameter("identifier", identifier))
-	return m.Request(ctx, "DELETE", m.URI("user-blocks"), nil, opts...)
+	return m.management.Request(ctx, "DELETE", m.management.URI("user-blocks"), nil, opts...)
 }
 
 // Enrollments retrieves all Guardian enrollments for a user.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_enrollments
 func (m *UserManager) Enrollments(ctx context.Context, id string, opts ...RequestOption) (enrolls []*UserEnrollment, err error) {
-	err = m.Request(ctx, "GET", m.URI("users", id, "enrollments"), &enrolls, opts...)
+	err = m.management.Request(ctx, "GET", m.management.URI("users", id, "enrollments"), &enrolls, opts...)
 	return
 }
 
@@ -582,7 +577,7 @@ func (m *UserManager) Enrollments(ctx context.Context, id string, opts ...Reques
 // See: https://auth0.com/docs/api/management/v2#!/Users/post_recovery_code_regeneration
 func (m *UserManager) RegenerateRecoveryCode(ctx context.Context, id string, opts ...RequestOption) (*UserRecoveryCode, error) {
 	r := new(UserRecoveryCode)
-	err := m.Request(ctx, "POST", m.URI("users", id, "recovery-code-regeneration"), &r, opts...)
+	err := m.management.Request(ctx, "POST", m.management.URI("users", id, "recovery-code-regeneration"), &r, opts...)
 	return r, err
 }
 
@@ -590,14 +585,14 @@ func (m *UserManager) RegenerateRecoveryCode(ctx context.Context, id string, opt
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/post_invalidate_remember_browser
 func (m *UserManager) InvalidateRememberBrowser(ctx context.Context, id string, opts ...RequestOption) error {
-	uri := m.URI(
+	uri := m.management.URI(
 		"users",
 		id,
 		"multifactor",
 		"actions",
 		"invalidate-remember-browser",
 	)
-	err := m.Request(ctx, "POST", uri, nil, opts...)
+	err := m.management.Request(ctx, "POST", uri, nil, opts...)
 	return err
 }
 
@@ -605,12 +600,12 @@ func (m *UserManager) InvalidateRememberBrowser(ctx context.Context, id string, 
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/post_identities
 func (m *UserManager) Link(ctx context.Context, id string, il *UserIdentityLink, opts ...RequestOption) (uIDs []UserIdentity, err error) {
-	request, err := m.NewRequest(ctx, "POST", m.URI("users", id, "identities"), il, opts...)
+	request, err := m.management.NewRequest(ctx, "POST", m.management.URI("users", id, "identities"), il, opts...)
 	if err != nil {
 		return uIDs, err
 	}
 
-	response, err := m.Do(request)
+	response, err := m.management.Do(request)
 	if err != nil {
 		return uIDs, err
 	}
@@ -638,7 +633,7 @@ func (m *UserManager) Link(ctx context.Context, id string, il *UserIdentityLink,
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/delete_user_identity_by_user_id
 func (m *UserManager) Unlink(ctx context.Context, id, provider, userID string, opts ...RequestOption) (uIDs []UserIdentity, err error) {
-	err = m.Request(ctx, "DELETE", m.URI("users", id, "identities", provider, userID), &uIDs, opts...)
+	err = m.management.Request(ctx, "DELETE", m.management.URI("users", id, "identities", provider, userID), &uIDs, opts...)
 	return
 }
 
@@ -646,7 +641,7 @@ func (m *UserManager) Unlink(ctx context.Context, id, provider, userID string, o
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_organizations
 func (m *UserManager) Organizations(ctx context.Context, id string, opts ...RequestOption) (p *OrganizationList, err error) {
-	err = m.Request(ctx, "GET", m.URI("users", id, "organizations"), &p, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("users", id, "organizations"), &p, applyListDefaults(opts))
 	return
 }
 
@@ -654,7 +649,7 @@ func (m *UserManager) Organizations(ctx context.Context, id string, opts ...Requ
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_authentication_methods
 func (m *UserManager) ListAuthenticationMethods(ctx context.Context, userID string, opts ...RequestOption) (a *AuthenticationMethodList, err error) {
-	err = m.Request(ctx, "GET", m.URI("users", userID, "authentication-methods"), &a, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("users", userID, "authentication-methods"), &a, applyListDefaults(opts))
 	return
 }
 
@@ -662,7 +657,7 @@ func (m *UserManager) ListAuthenticationMethods(ctx context.Context, userID stri
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_authentication_methods_by_authentication_method_id
 func (m *UserManager) GetAuthenticationMethodByID(ctx context.Context, userID string, id string, opts ...RequestOption) (a *AuthenticationMethod, err error) {
-	err = m.Request(ctx, "GET", m.URI("users", userID, "authentication-methods", id), &a, applyListDefaults(opts))
+	err = m.management.Request(ctx, "GET", m.management.URI("users", userID, "authentication-methods", id), &a, applyListDefaults(opts))
 	return
 }
 
@@ -670,7 +665,7 @@ func (m *UserManager) GetAuthenticationMethodByID(ctx context.Context, userID st
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/post_authentication_methods
 func (m *UserManager) CreateAuthenticationMethod(ctx context.Context, userID string, a *AuthenticationMethod, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "POST", m.URI("users", userID, "authentication-methods"), &a, opts...)
+	err = m.management.Request(ctx, "POST", m.management.URI("users", userID, "authentication-methods"), &a, opts...)
 	return
 }
 
@@ -678,7 +673,7 @@ func (m *UserManager) CreateAuthenticationMethod(ctx context.Context, userID str
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/put_authentication_methods
 func (m *UserManager) UpdateAllAuthenticationMethods(ctx context.Context, userID string, a *[]AuthenticationMethod, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "PUT", m.URI("users", userID, "authentication-methods"), &a, opts...)
+	err = m.management.Request(ctx, "PUT", m.management.URI("users", userID, "authentication-methods"), &a, opts...)
 	return
 }
 
@@ -686,7 +681,7 @@ func (m *UserManager) UpdateAllAuthenticationMethods(ctx context.Context, userID
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/patch_authentication_methods_by_authentication_method_id
 func (m *UserManager) UpdateAuthenticationMethod(ctx context.Context, userID string, id string, a *AuthenticationMethod, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "PATCH", m.URI("users", userID, "authentication-methods", id), &a, opts...)
+	err = m.management.Request(ctx, "PATCH", m.management.URI("users", userID, "authentication-methods", id), &a, opts...)
 	return
 }
 
@@ -694,7 +689,7 @@ func (m *UserManager) UpdateAuthenticationMethod(ctx context.Context, userID str
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/delete_authentication_methods_by_authentication_method_id
 func (m *UserManager) DeleteAuthenticationMethod(ctx context.Context, userID string, id string, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "DELETE", m.URI("users", userID, "authentication-methods", id), nil, opts...)
+	err = m.management.Request(ctx, "DELETE", m.management.URI("users", userID, "authentication-methods", id), nil, opts...)
 	return
 }
 
@@ -702,6 +697,6 @@ func (m *UserManager) DeleteAuthenticationMethod(ctx context.Context, userID str
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/delete_authentication_methods
 func (m *UserManager) DeleteAllAuthenticationMethods(ctx context.Context, userID string, opts ...RequestOption) (err error) {
-	err = m.Request(ctx, "DELETE", m.URI("users", userID, "authentication-methods"), nil, opts...)
+	err = m.management.Request(ctx, "DELETE", m.management.URI("users", userID, "authentication-methods"), nil, opts...)
 	return
 }


### PR DESCRIPTION
### 🔧 Changes

Refactors how the management struct is implemented to avoid an issue where the individual managers could be chained like `api.Action.Client.Action.Client.Create()`

This change will now also improve code completion as only the relevant methods will be suggested rather than all Managers.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
