### PR TITLE
[SDK-4224] Allow configuration and disabling of retry strategy

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -192,7 +192,7 @@ emailProviderConfig := &management.EmailProvider{
 
 Previously, when retrying requests the SDK would retry only for 429 status codes, waiting until the time indicated by the `X-RateLimit-Reset` header and would not have a maximum number of requests (i.e would retry infinitely).
 
-Now, by default the SDK will retry 429 status codes and request errors that are deemed to be recoverable, and will retry a maximum of 2 times. The SDK will instead use an exponential backoff with a minimum time of 250 milliseconds, and a maximum delay time of 10 seconds and consult the `X-Ratelimit-Reset` header to ensure that the next request will pass.
+Now, by default the SDK will retry 429 status codes and request errors that are deemed to be recoverable, and will retry a maximum of 2 times. The SDK will instead use an exponential backoff with a minimum time of 250 milliseconds, and a maximum delay time of 10 seconds and consult the `X-RateLimit-Reset` header to ensure that the next request will pass.
 
 This logic can be customised by using the `management.WithRetries` helper, and can be disabled using the `management.WithNoRetries` method.
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -192,7 +192,7 @@ emailProviderConfig := &management.EmailProvider{
 
 Previously, when retrying requests the SDK would retry only for 429 status codes, waiting until the time indicated by the `X-RateLimit-Reset` header and would not have a maximum number of requests (i.e would retry infinitely).
 
-Now, by default the SDK will retry 429 status codes and request errors that are deemed to be recoverable, and will retry a maximum of 2 times. Instead of waiting for the `X-RateLimit-Reset` header value, it will instead use an exponential backoff with a minimum time of 250 milliseconds.
+Now, by default the SDK will retry 429 status codes and request errors that are deemed to be recoverable, and will retry a maximum of 2 times. The SDK will instead use an exponential backoff with a minimum time of 250 milliseconds, and a maximum delay time of 10 seconds and consult the `X-Ratelimit-Reset` header to ensure that the next request will pass.
 
 This logic can be customised by using the `management.WithRetries` helper, and can be disabled using the `management.WithNoRetries` method.
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -6,6 +6,8 @@
 - [Public API Changes](#public-api-changes)
   - [Improve Typing Of Client Addons](#improve-typing-of-client-addons)
   - [Require Passing Context To APIs](#require-passing-context-to-apis)
+  - [Removal Of Manager Chaining](#removal-of-manager-chaining)
+  - [Changes To Retry Strategy](#changes-to-retry-strategy)
 
 ## Public API Changes
 
@@ -185,3 +187,27 @@ emailProviderConfig := &management.EmailProvider{
 </td>
 </tr>
 </table>
+
+### Changes To Retry Strategy
+
+Previously, when retrying requests the SDK would retry only for 429 status codes, waiting until the time indicated by the `X-RateLimit-Reset` header and would not have a maximum number of requests (i.e would retry infinitely).
+
+Now, by default the SDK will retry 429 status codes and request errors that are deemed to be recoverable, and will retry a maximum of 2 times. Instead of waiting for the `X-RateLimit-Reset` header value, it will instead use an exponential backoff with a minimum time of 250 milliseconds.
+
+This logic can be customised by using the `management.WithRetries` helper, and can be disabled using the `management.WithNoRetries`
+
+```go
+// Enable a retry strategy with 3 retries that will retry on 429 and 503 status codes
+m, err := management.New(
+    domain,
+    management.WithClientCredentials(context.Background(), id, secret),
+    management.WithRetries(RetryOptions{MaxRetries: 3, Statuses: []int{http.StatusTooManyRequests, http.StatusBadGateway}}),
+)
+
+// Disable retries
+m, err := management.New(
+    domain,
+    management.WithClientCredentials(context.Background(), id, secret),
+    management.WithNoRetries(),
+)
+```

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -194,7 +194,7 @@ Previously, when retrying requests the SDK would retry only for 429 status codes
 
 Now, by default the SDK will retry 429 status codes and request errors that are deemed to be recoverable, and will retry a maximum of 2 times. Instead of waiting for the `X-RateLimit-Reset` header value, it will instead use an exponential backoff with a minimum time of 250 milliseconds.
 
-This logic can be customised by using the `management.WithRetries` helper, and can be disabled using the `management.WithNoRetries`
+This logic can be customised by using the `management.WithRetries` helper, and can be disabled using the `management.WithNoRetries` method.
 
 ```go
 // Enable a retry strategy with 3 retries that will retry on 429 and 503 status codes

--- a/Makefile
+++ b/Makefile
@@ -87,4 +87,5 @@ test-e2e: ## Run tests without http recordings. To run a specific test pass the 
 		-cover \
 		-covermode=atomic \
 		-coverprofile=coverage.out \
+		-timeout 20m \
 		./...

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -114,7 +114,7 @@ func RetriesTransport(base http.RoundTripper, r RetryOptions) http.RoundTripper 
 	return tr
 }
 
-// Matches the error returned by net/http when the configured number of
+// Matches the error returned by net/http when the configured number of redirects
 // is exhausted.
 var redirectsErrorRe = regexp.MustCompile(`stopped after \d+ redirects\z`)
 
@@ -149,7 +149,7 @@ func retryErrors(err error) bool {
 // and a minimum value.
 func backoffDelay() rehttp.DelayFn {
 	// Disable gosec lint for as we don't need secure randomness here and the error
-	// handling of an error adds needless complexity
+	// handling of an error adds needless complexity.
 	//nolint:gosec
 	PRNG := rand.New(rand.NewSource(time.Now().UnixNano()))
 	minDelay := float64(250 * time.Millisecond)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -39,8 +39,8 @@ func TestRetries(t *testing.T) {
 		assert.Equal(t, http.StatusOK, r.StatusCode)
 
 		elapsed := time.Since(start).Milliseconds()
-		assert.Greater(t, elapsed, int64(250))
-		assert.Less(t, elapsed, int64(500))
+		assert.GreaterOrEqual(t, elapsed, int64(250))
+		assert.LessOrEqual(t, elapsed, int64(500))
 		assert.Equal(t, 2, i)
 	})
 
@@ -99,9 +99,9 @@ func TestRetries(t *testing.T) {
 		_, err := c.Get(s.URL)
 
 		assert.Error(t, err)
-		elapsed := time.Since(start).Milliseconds()
-		assert.Greater(t, elapsed, int64(250))
-		assert.Greater(t, elapsed, int64(500))
+		elapsed := time.Since(start).Seconds()
+		assert.GreaterOrEqual(t, elapsed, float64(1))
+		assert.LessOrEqual(t, elapsed, float64(2))
 	})
 
 	t.Run("Should not retry some errors", func(t *testing.T) {
@@ -149,8 +149,8 @@ func TestRetries(t *testing.T) {
 		assert.Equal(t, http.StatusOK, r.StatusCode)
 
 		elapsed := time.Since(start).Seconds()
-		assert.Greater(t, elapsed, float64(2))
-		assert.Less(t, elapsed, float64(3))
+		assert.GreaterOrEqual(t, elapsed, float64(2))
+		assert.LessOrEqual(t, elapsed, float64(3))
 		assert.Equal(t, 2, i)
 	})
 
@@ -182,7 +182,7 @@ func TestRetries(t *testing.T) {
 
 		elapsed := time.Since(start).Milliseconds()
 		assert.GreaterOrEqual(t, elapsed, int64(250))
-		assert.Less(t, elapsed, int64(500))
+		assert.LessOrEqual(t, elapsed, int64(500))
 		assert.Equal(t, 2, i)
 	})
 }

--- a/management/log_test.go
+++ b/management/log_test.go
@@ -40,19 +40,25 @@ func TestLogManager_CheckpointPagination(t *testing.T) {
 
 	logList, err := api.Log.List(context.Background(), Page(1), PerPage(10))
 	assert.NoError(t, err)
-	assert.Greater(t, len(logList), 0, "can't seem to find any logs, have you ran any tests before?")
+	assert.Len(t, logList, 10, "required number of logs not returned")
 
-	from := logList[9].GetID()
+	// Below is in an if statement to prevent panics during tests
+	if len(logList) == 10 {
+		from := logList[9].GetID()
 
-	// Take the first 2 entries from the 10th log
-	logs, err := api.Log.List(context.Background(), Take(2), From(from))
-	assert.NoError(t, err)
-	assert.Len(t, logs, 2)
+		// Take the first 2 entries from the 10th log
+		logs, err := api.Log.List(context.Background(), Take(2), From(from))
+		assert.NoError(t, err)
+		assert.Len(t, logs, 2, "required number of logs not returned")
 
-	log1 := logList[8]
-	log2 := logList[7]
-	assert.Equal(t, log1.GetID(), logs[0].GetID())
-	assert.Equal(t, log2.GetID(), logs[1].GetID())
+		if len(logs) == 2 {
+			log1 := logList[8]
+			log2 := logList[7]
+
+			assert.Equal(t, log1.GetID(), logs[0].GetID())
+			assert.Equal(t, log2.GetID(), logs[1].GetID())
+		}
+	}
 }
 
 func TestLogManagerScope_UnmarshalJSON(t *testing.T) {

--- a/management/management.go
+++ b/management/management.go
@@ -111,6 +111,7 @@ type Management struct {
 	http            *http.Client
 	auth0ClientInfo *client.Auth0ClientInfo
 	common          manager
+	retryStrategy   client.RetryOptions
 }
 
 type manager struct {
@@ -139,6 +140,7 @@ func New(domain string, options ...Option) (*Management, error) {
 		debug:           false,
 		http:            http.DefaultClient,
 		auth0ClientInfo: client.DefaultAuth0ClientInfo,
+		retryStrategy:   client.DefaultRetryOptions,
 	}
 
 	for _, option := range options {
@@ -150,8 +152,8 @@ func New(domain string, options ...Option) (*Management, error) {
 		m.tokenSource,
 		client.WithDebug(m.debug),
 		client.WithUserAgent(m.userAgent),
-		client.WithRateLimit(),
 		client.WithAuth0ClientInfo(m.auth0ClientInfo),
+		client.WithRetries(m.retryStrategy),
 	)
 
 	m.common.management = m

--- a/management/management_option.go
+++ b/management/management_option.go
@@ -69,6 +69,8 @@ func WithInsecure() Option {
 }
 
 // WithClient configures management to use the provided client.
+// Note: If you are providing a client with a retry strategy, then you should
+// also pass `WithNoRetries` so that the default retry strategy is not added.
 func WithClient(client *http.Client) Option {
 	return func(m *Management) {
 		m.http = client
@@ -102,5 +104,19 @@ func WithAuth0ClientEnvEntry(key string, value string) Option {
 func WithNoAuth0ClientInfo() Option {
 	return func(m *Management) {
 		m.auth0ClientInfo = nil
+	}
+}
+
+// WithRetries configures the management client to only retry under the conditions provided.
+func WithRetries(retryConfig client.RetryOptions) Option {
+	return func(m *Management) {
+		m.retryStrategy = retryConfig
+	}
+}
+
+// WithNoRetries configures the management client to only retry under the conditions provided.
+func WithNoRetries() Option {
+	return func(m *Management) {
+		m.retryStrategy = client.RetryOptions{}
 	}
 }

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -404,12 +404,12 @@ func TestApiCallContextCancel(t *testing.T) {
 func TestRetries(t *testing.T) {
 	t.Run("Default retry logic", func(t *testing.T) {
 		start := time.Now()
-		first := true
+		i := 0
 
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if first {
+			i++
+			if i == 1 {
 				w.WriteHeader(http.StatusTooManyRequests)
-				first = !first
 				return
 			}
 			w.WriteHeader(http.StatusOK)
@@ -427,9 +427,9 @@ func TestRetries(t *testing.T) {
 		_, err = m.User.Read(context.Background(), "123")
 		assert.NoError(t, err)
 
-		elapsed := time.Since(start)
-		assert.Greater(t, elapsed, 500*time.Millisecond)
-		assert.NoError(t, err)
+		elapsed := time.Since(start).Milliseconds()
+		assert.Greater(t, elapsed, int64(250))
+		assert.Equal(t, 2, i)
 	})
 
 	t.Run("Custom retry logic", func(t *testing.T) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This improves upon the existing retry logic implemented in the package by expanding the retry
conditions, allowing configuration of the retry conditions and allowing disabling retries.

By default the Management Client will retry a request 2 times, when there is a 429 status code
or if there is an error returned (except for a select couple of errors that are not recoverable). The `X-RateLimit-Reset` is consulted to ensure that the request will work, unless the time until the request is more than the maximum wait time.

The configuration of the max retries and status codes that will be retried on by providing a
`RetryOptions` struct with the required values with the `WithRetryOptions` function, and retries
can be disabled by passing the `WithNoRetries` function

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### ⚠️  Breaking Change

The SDK will now retry a request a maximum of 2 times by default, and will also retry on certain errors.
