### PR TITLE
[SDK-4231] Implement initial structure of auth client

### DIFF
--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -1,0 +1,61 @@
+package authentication
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/auth0/go-auth0/internal/client"
+)
+
+// Authentication is the auth client.
+type Authentication struct {
+	Database *Database
+	OAuth    *OAuth
+
+	url             *url.URL
+	basePath        string
+	debug           bool
+	http            *http.Client
+	auth0ClientInfo *client.Auth0ClientInfo
+	common          manager
+	clientID        string
+	clientSecret    string
+}
+
+type manager struct {
+	authentication *Authentication
+}
+
+// New creates an auth client.
+func New(domain string, options ...Option) (*Authentication, error) {
+	// Ignore the scheme if it was defined in the domain variable, then prefix
+	// with https as it's the only scheme supported by the Auth0 API.
+	if i := strings.Index(domain, "//"); i != -1 {
+		domain = domain[i+2:]
+	}
+	domain = "https://" + domain
+
+	u, err := url.Parse(domain)
+	if err != nil {
+		return nil, err
+	}
+
+	a := &Authentication{
+		url:             u,
+		basePath:        "",
+		debug:           false,
+		http:            http.DefaultClient,
+		auth0ClientInfo: client.DefaultAuth0ClientInfo,
+	}
+
+	for _, option := range options {
+		option(a)
+	}
+
+	a.common.authentication = a
+	a.Database = (*Database)(&a.common)
+	a.OAuth = (*OAuth)(&a.common)
+
+	return a, nil
+}

--- a/authentication/authentication_error.go
+++ b/authentication/authentication_error.go
@@ -26,7 +26,6 @@ func newError(response *http.Response) error {
 	// This can happen in case the error message structure changes.
 	// If that happens we still want to display the correct code.
 	if apiError.Status() == 0 {
-		// Always set status code as it is not returned from te
 		apiError.StatusCode = response.StatusCode
 		apiError.Err = http.StatusText(response.StatusCode)
 	}

--- a/authentication/authentication_error.go
+++ b/authentication/authentication_error.go
@@ -1,0 +1,45 @@
+package authentication
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type authenticationError struct {
+	StatusCode int    `json:"statusCode"`
+	Err        string `json:"error"`
+	Message    string `json:"error_description"`
+}
+
+func newError(response *http.Response) error {
+	apiError := &authenticationError{}
+
+	if err := json.NewDecoder(response.Body).Decode(apiError); err != nil {
+		return &authenticationError{
+			StatusCode: response.StatusCode,
+			Err:        http.StatusText(response.StatusCode),
+			Message:    fmt.Errorf("failed to decode json error response payload: %w", err).Error(),
+		}
+	}
+
+	// This can happen in case the error message structure changes.
+	// If that happens we still want to display the correct code.
+	if apiError.Status() == 0 {
+		// Always set status code as it is not returned from te
+		apiError.StatusCode = response.StatusCode
+		apiError.Err = http.StatusText(response.StatusCode)
+	}
+
+	return apiError
+}
+
+// Error formats the error into a string representation.
+func (a *authenticationError) Error() string {
+	return fmt.Sprintf("%d %s: %s", a.StatusCode, a.Err, a.Message)
+}
+
+// Status returns the status code of the error.
+func (a *authenticationError) Status() int {
+	return a.StatusCode
+}

--- a/authentication/authentication_error_test.go
+++ b/authentication/authentication_error_test.go
@@ -1,0 +1,61 @@
+package authentication
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_newError(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		givenResponse http.Response
+		expectedError authenticationError
+	}{
+		{
+			name: "it fails to decode if body is not a json",
+			givenResponse: http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader("Hello, I'm not a JSON.")),
+			},
+			expectedError: authenticationError{
+				StatusCode: 403,
+				Err:        "Forbidden",
+				Message:    "failed to decode json error response payload: invalid character 'H' looking for beginning of value",
+			},
+		},
+		{
+			name: "it correctly decodes the error response payload",
+			givenResponse: http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       io.NopCloser(strings.NewReader(`{"statusCode":400,"error":"invalid_scope","error_description":"Scope must be an array or a string"}`)),
+			},
+			expectedError: authenticationError{
+				StatusCode: 400,
+				Err:        "invalid_scope",
+				Message:    "Scope must be an array or a string",
+			},
+		},
+		{
+			name: "it will still post the correct status code if the body doesn't have the correct structure",
+			givenResponse: http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader(`{"errorMessage":"wrongStruct"}`)),
+			},
+			expectedError: authenticationError{
+				StatusCode: 500,
+				Err:        "Internal Server Error",
+				Message:    "",
+			},
+		},
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actualError := newError(&testCase.givenResponse)
+			assert.Equal(t, &testCase.expectedError, actualError)
+		})
+	}
+}

--- a/authentication/authentication_error_test.go
+++ b/authentication/authentication_error_test.go
@@ -51,6 +51,19 @@ func Test_newError(t *testing.T) {
 				Message:    "",
 			},
 		},
+		{
+			name: "it will handle a invalid sign up response",
+			givenResponse: http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       io.NopCloser(strings.NewReader(`{"name":"BadRequestError","code":"invalid_signup","description":"Invalid sign up","statusCode":400}`)),
+			},
+			expectedError: authenticationError{
+				StatusCode: 400,
+				Err:        "invalid_signup",
+				Message:    "Invalid sign up",
+			},
+		},
+	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/authentication/authentication_error_test.go
+++ b/authentication/authentication_error_test.go
@@ -16,10 +16,10 @@ func Test_newError(t *testing.T) {
 		expectedError authenticationError
 	}{
 		{
-			name: "it fails to decode if body is not a json",
+			name: "it fails to decode if body is not json",
 			givenResponse: http.Response{
 				StatusCode: http.StatusForbidden,
-				Body:       io.NopCloser(strings.NewReader("Hello, I'm not a JSON.")),
+				Body:       io.NopCloser(strings.NewReader("Hello, I'm not JSON.")),
 			},
 			expectedError: authenticationError{
 				StatusCode: 403,
@@ -52,7 +52,7 @@ func Test_newError(t *testing.T) {
 			},
 		},
 		{
-			name: "it will handle a invalid sign up response",
+			name: "it will handle an invalid sign up response",
 			givenResponse: http.Response{
 				StatusCode: http.StatusBadRequest,
 				Body:       io.NopCloser(strings.NewReader(`{"name":"BadRequestError","code":"invalid_signup","description":"Invalid sign up","statusCode":400}`)),

--- a/authentication/authentication_option.go
+++ b/authentication/authentication_option.go
@@ -10,7 +10,7 @@ func WithClientID(clientID string) Option {
 	}
 }
 
-// WithClientSecret configures the Client ID to be provided with requests if one is not provided.
+// WithClientSecret configures the Client secret to be provided with requests if one is not provided.
 func WithClientSecret(clientSecret string) Option {
 	return func(a *Authentication) {
 		a.clientSecret = clientSecret

--- a/authentication/authentication_option.go
+++ b/authentication/authentication_option.go
@@ -1,0 +1,18 @@
+package authentication
+
+// Option is used for passing options to the Authentication client.
+type Option func(*Authentication)
+
+// WithClientID configures the Client ID to be provided with requests if one is not provided.
+func WithClientID(clientID string) Option {
+	return func(a *Authentication) {
+		a.clientID = clientID
+	}
+}
+
+// WithClientSecret configures the Client ID to be provided with requests if one is not provided.
+func WithClientSecret(clientSecret string) Option {
+	return func(a *Authentication) {
+		a.clientSecret = clientSecret
+	}
+}

--- a/authentication/authentication_request.go
+++ b/authentication/authentication_request.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-// URI returns the absolute URL of the Management API with any path segments
+// URI returns the absolute URL of the Authentication API with any path segments
 // appended to the end.
 func (a *Authentication) URI(path ...string) string {
 	baseURL := &url.URL{
@@ -20,19 +20,7 @@ func (a *Authentication) URI(path ...string) string {
 		Path:   a.basePath + "/",
 	}
 
-	const escapedForwardSlash = "%2F"
-	var escapedPath []string
-	for _, unescapedPath := range path {
-		// Go's url.PathEscape will not escape "/", but some user IDs do have a valid "/" in them.
-		// See https://github.com/golang/go/blob/b55a2fb3b0d67b346bac871737b862f16e5a6447/src/net/url/url.go#L141.
-		defaultPathEscaped := url.PathEscape(unescapedPath)
-		escapedPath = append(
-			escapedPath,
-			strings.ReplaceAll(defaultPathEscaped, "/", escapedForwardSlash),
-		)
-	}
-
-	return baseURL.String() + strings.Join(escapedPath, "/")
+	return baseURL.String() + strings.Join(path, "/")
 }
 
 // NewRequest returns a new HTTP request. If the payload is not nil it will be
@@ -175,8 +163,7 @@ func (a *Authentication) FormRequest(ctx context.Context, method, uri string, pa
 	return nil
 }
 
-// RequestOption configures a call (typically to retrieve a resource) to Auth0 with
-// query parameters.
+// RequestOption configures a call to Auth0 with query parameters.
 type RequestOption interface {
 	apply(*http.Request, url.Values)
 }

--- a/authentication/authentication_request.go
+++ b/authentication/authentication_request.go
@@ -101,7 +101,7 @@ func (a *Authentication) Do(req *http.Request) (*http.Response, error) {
 
 // Request combines NewRequest and Do, while also handling decoding of response payload. If payload
 // is of type url.Values then a request with content type `application/x-www-form-urlencoded` will be
-// performed otherwise a a request of type `"application/json` will be performed
+// performed otherwise a a request of type `"application/json` will be performed.
 func (a *Authentication) Request(ctx context.Context, method, uri string, payload interface{}, resp interface{}, opts ...RequestOption) error {
 	var request *http.Request
 	var err error

--- a/authentication/authentication_request.go
+++ b/authentication/authentication_request.go
@@ -1,0 +1,201 @@
+package authentication
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// URI returns the absolute URL of the Management API with any path segments
+// appended to the end.
+func (a *Authentication) URI(path ...string) string {
+	baseURL := &url.URL{
+		Scheme: a.url.Scheme,
+		Host:   a.url.Host,
+		Path:   a.basePath + "/",
+	}
+
+	const escapedForwardSlash = "%2F"
+	var escapedPath []string
+	for _, unescapedPath := range path {
+		// Go's url.PathEscape will not escape "/", but some user IDs do have a valid "/" in them.
+		// See https://github.com/golang/go/blob/b55a2fb3b0d67b346bac871737b862f16e5a6447/src/net/url/url.go#L141.
+		defaultPathEscaped := url.PathEscape(unescapedPath)
+		escapedPath = append(
+			escapedPath,
+			strings.ReplaceAll(defaultPathEscaped, "/", escapedForwardSlash),
+		)
+	}
+
+	return baseURL.String() + strings.Join(escapedPath, "/")
+}
+
+// NewRequest returns a new HTTP request. If the payload is not nil it will be
+// encoded as JSON.
+func (a *Authentication) NewRequest(
+	ctx context.Context,
+	method,
+	uri string,
+	payload interface{},
+	opts ...RequestOption,
+) (*http.Request, error) {
+	var body bytes.Buffer
+	if payload != nil {
+		if err := json.NewEncoder(&body).Encode(payload); err != nil {
+			return nil, fmt.Errorf("encoding request payload failed: %w", err)
+		}
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, uri, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Add("Content-Type", "application/json")
+
+	for _, option := range opts {
+		option.apply(request, nil)
+	}
+
+	return request, nil
+}
+
+// Do triggers an HTTP request and returns an HTTP response,
+// handling any context cancellations or timeouts.
+func (a *Authentication) Do(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	response, err := a.http.Do(req)
+	if err != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			return nil, err
+		}
+	}
+
+	return response, nil
+}
+
+// Request combines NewRequest and Do, while also handling decoding of response payload.
+func (a *Authentication) Request(ctx context.Context, method, uri string, payload interface{}, resp interface{}) error {
+	request, err := a.NewRequest(ctx, method, uri, &payload)
+	if err != nil {
+		return fmt.Errorf("failed to create a new request: %w", err)
+	}
+
+	response, err := a.Do(request)
+	if err != nil {
+		return fmt.Errorf("failed to send the request: %w", err)
+	}
+	defer response.Body.Close()
+
+	// If the response contains a client or a server error then return the error.
+	if response.StatusCode >= http.StatusBadRequest {
+		return newError(response)
+	}
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read the response body: %w", err)
+	}
+
+	if len(responseBody) > 0 && string(responseBody) != "{}" {
+		if err = json.Unmarshal(responseBody, &resp); err != nil {
+			return fmt.Errorf("failed to unmarshal response payload: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// NewFormRequest returns a new HTTP request. If the payload is not nil it will be
+// encoded as JSON.
+func (a *Authentication) NewFormRequest(
+	ctx context.Context,
+	method,
+	uri string,
+	payload url.Values,
+	opts ...RequestOption,
+) (*http.Request, error) {
+	request, err := http.NewRequestWithContext(ctx, method, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	for _, option := range opts {
+		option.apply(request, payload)
+	}
+
+	body := strings.NewReader(payload.Encode())
+
+	request.Body = io.NopCloser(body)
+	request.ContentLength = int64(body.Len())
+
+	return request, nil
+}
+
+// FormRequest combines FormRequest and Do, while also handling decoding of response payload.
+func (a *Authentication) FormRequest(ctx context.Context, method, uri string, payload url.Values, resp interface{}, opts ...RequestOption) error {
+	request, err := a.NewFormRequest(ctx, method, uri, payload, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create a new request: %w", err)
+	}
+
+	response, err := a.Do(request)
+	if err != nil {
+		return fmt.Errorf("failed to send the request: %w", err)
+	}
+	defer response.Body.Close()
+
+	// If the response contains a client or a server error then return the error.
+	if response.StatusCode >= http.StatusBadRequest {
+		return newError(response)
+	}
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read the response body: %w", err)
+	}
+
+	if len(responseBody) > 0 && string(responseBody) != "{}" {
+		if err = json.Unmarshal(responseBody, &resp); err != nil {
+			return fmt.Errorf("failed to unmarshal response payload: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// RequestOption configures a call (typically to retrieve a resource) to Auth0 with
+// query parameters.
+type RequestOption interface {
+	apply(*http.Request, url.Values)
+}
+
+func newRequestOption(fn func(r *http.Request, b url.Values)) *requestOption {
+	return &requestOption{applyFn: fn}
+}
+
+type requestOption struct {
+	applyFn func(r *http.Request, b url.Values)
+}
+
+func (o *requestOption) apply(r *http.Request, b url.Values) {
+	o.applyFn(r, b)
+}
+
+// Header configures a request to add HTTP headers to requests made to Auth0.
+func Header(key, value string) RequestOption {
+	return newRequestOption(func(r *http.Request, b url.Values) {
+		r.Header.Set(key, value)
+	})
+}

--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -98,7 +98,7 @@ func TestAuthenticationApiCallContextCancel(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	_, err = a.Database.SignUp(ctx, database.SignUpRequest{
+	_, err = a.Database.Signup(ctx, database.SignupRequest{
 		Username: "test",
 		Password: "test",
 	})
@@ -117,7 +117,7 @@ func TestAuthenticationApiCallContextTimeout(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	_, err = a.Database.SignUp(ctx, database.SignUpRequest{
+	_, err = a.Database.Signup(ctx, database.SignupRequest{
 		Username: "test",
 		Password: "test",
 	})

--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -1,0 +1,91 @@
+package authentication
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/joho/godotenv/autoload"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/auth0/go-auth0/authentication/database"
+)
+
+var (
+	domain                = os.Getenv("AUTH0_DOMAIN")
+	clientID              = os.Getenv("AUTH0_AUTH_CLIENT_ID")
+	clientSecret          = os.Getenv("AUTH0_AUTH_CLIENT_SECRET")
+	debug                 = os.Getenv("AUTH0_DEBUG")
+	httpRecordings        = os.Getenv("AUTH0_HTTP_RECORDINGS")
+	httpRecordingsEnabled = false
+	authAPI               = &Authentication{}
+)
+
+func envVarEnabled(envVar string) bool {
+	return envVar == "true" || envVar == "1" || envVar == "on"
+}
+
+func TestMain(m *testing.M) {
+	httpRecordingsEnabled = envVarEnabled(httpRecordings)
+	initializeTestClient()
+
+	code := m.Run()
+	os.Exit(code)
+}
+
+func initializeTestClient() {
+	var err error
+
+	authAPI, err = New(
+		domain,
+		WithClientID(clientID),
+	)
+	if err != nil {
+		log.Fatal("failed to initialize the auth api client")
+	}
+}
+
+func TestAuthenticationNew(t *testing.T) {
+	for _, domain := range []string{
+		"example.com ",
+		" example.com",
+		" example.com ",
+		"%2Fexample.com",
+		" a.b.c.example.com",
+	} {
+		_, err := New(domain)
+		assert.Errorf(t, err, "expected New to fail with domain %q", domain)
+	}
+}
+
+func TestAuthenticatioNOptionHeader(t *testing.T) {
+	r, err := http.NewRequest("GET", "/", nil)
+	assert.NoError(t, err)
+
+	Header("foo", "bar").apply(r, url.Values{})
+
+	h := r.Header.Get("foo")
+	assert.Equal(t, h, "bar")
+}
+
+func TestAuthenticationRequestContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel the request.
+
+	err := authAPI.Request(ctx, "GET", "/", nil, nil)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestAuthenticationRequestContextTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	time.Sleep(50 * time.Millisecond) // Delay until the deadline is exceeded.
+
+	err := authAPI.Request(ctx, "GET", "/", nil, nil)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -18,8 +18,6 @@ import (
 var (
 	domain                = os.Getenv("AUTH0_DOMAIN")
 	clientID              = os.Getenv("AUTH0_AUTH_CLIENT_ID")
-	clientSecret          = os.Getenv("AUTH0_AUTH_CLIENT_SECRET")
-	debug                 = os.Getenv("AUTH0_DEBUG")
 	httpRecordings        = os.Getenv("AUTH0_HTTP_RECORDINGS")
 	httpRecordingsEnabled = false
 	authAPI               = &Authentication{}

--- a/authentication/database.go
+++ b/authentication/database.go
@@ -8,3 +8,12 @@ import (
 
 // Database manager.
 type Database manager
+
+// SignUp given a user's credentials, and a connection, will create a new user using active authentication.
+//
+// This endpoint only works for database connections.
+// See: https://auth0.com/docs/api/authentication?http#signup
+func (d *Database) SignUp(ctx context.Context, params database.SignUpRequest) (r *database.SignUpResponse, err error) {
+	err = d.authentication.Request(ctx, "POST", d.authentication.URI("dbconnections", "signup"), params, &r)
+	return
+}

--- a/authentication/database.go
+++ b/authentication/database.go
@@ -14,6 +14,10 @@ type Database manager
 // This endpoint only works for database connections.
 // See: https://auth0.com/docs/api/authentication?http#signup
 func (d *Database) SignUp(ctx context.Context, params database.SignUpRequest) (r *database.SignUpResponse, err error) {
+	if params.ClientID == "" {
+		params.ClientID = d.authentication.clientID
+	}
+
 	err = d.authentication.Request(ctx, "POST", d.authentication.URI("dbconnections", "signup"), params, &r)
 	return
 }

--- a/authentication/database.go
+++ b/authentication/database.go
@@ -1,0 +1,10 @@
+package authentication
+
+import (
+	"context"
+
+	"github.com/auth0/go-auth0/authentication/database"
+)
+
+// Database manager.
+type Database manager

--- a/authentication/database.go
+++ b/authentication/database.go
@@ -9,11 +9,11 @@ import (
 // Database manager.
 type Database manager
 
-// SignUp given a user's credentials, and a connection, will create a new user using active authentication.
+// Signup given a user's credentials and a connection, will create a new user using active authentication.
 //
 // This endpoint only works for database connections.
 // See: https://auth0.com/docs/api/authentication?http#signup
-func (d *Database) SignUp(ctx context.Context, params database.SignUpRequest) (r *database.SignUpResponse, err error) {
+func (d *Database) Signup(ctx context.Context, params database.SignupRequest) (r *database.SignupResponse, err error) {
 	if params.ClientID == "" {
 		params.ClientID = d.authentication.clientID
 	}

--- a/authentication/database/database.go
+++ b/authentication/database/database.go
@@ -6,8 +6,8 @@ import (
 	"go.devnw.com/structs"
 )
 
-// SignUpRequest is a sign up request.
-type SignUpRequest struct {
+// SignupRequest is a sign up request.
+type SignupRequest struct {
 	// The client_id of your client.
 	ClientID string `json:"client_id,omitempty"`
 	// The user's email address.
@@ -31,17 +31,17 @@ type SignUpRequest struct {
 	// The user metadata to be associated with the user. If set, the field must be an object containing no more than ten properties.
 	// Property names can have a maximum of 100 characters, and property values must be strings of no more than 500 characters.
 	UserMetadata *map[string]interface{} `json:"user_metadata,omitempty"`
-	// Extra parameters to be merged into the request body. Values set here will override any existing values
+	// Extra parameters to be merged into the request body. Values set here will override any existing values.
 	ExtraParameters map[string]string `json:"-"`
 }
 
-// SignUpResponse is a sign up response.
-type SignUpResponse struct {
+// SignupResponse is a sign up response.
+type SignupResponse struct {
 	// The user's email address.
 	Email string `json:"email,omitempty"`
 	// Indicates whether a user has verified their email address.
 	EmailVerified bool `json:"email_verified,omitempty"`
-	// The users ID
+	// The user's ID.
 	ID string `json:"_id,omitempty"`
 	// The user's username. Only valid if the connection requires a username.
 	Username string `json:"username,omitempty"`
@@ -64,7 +64,7 @@ type SignUpResponse struct {
 //
 // It is required to support adding parameters from the `ExtraParameters`
 // field onto the request object.
-func (s *SignUpRequest) MarshalJSON() ([]byte, error) {
+func (s *SignupRequest) MarshalJSON() ([]byte, error) {
 	n := structs.New(s)
 	n.TagName = "json"
 

--- a/authentication/database/database.go
+++ b/authentication/database/database.go
@@ -1,0 +1,77 @@
+package database
+
+import (
+	"encoding/json"
+
+	"go.devnw.com/structs"
+)
+
+// SignUpRequest is a sign up request.
+type SignUpRequest struct {
+	// The client_id of your client.
+	ClientID string `json:"client_id,omitempty"`
+	// The user's email address.
+	Email string `json:"email,omitempty"`
+	// The user's desired password.
+	Password string `json:"password,omitempty"`
+	// The name of the database configured to your client.
+	Connection string `json:"connection,omitempty"`
+	// The user's username. Only valid if the connection requires a username.
+	Username string `json:"username,omitempty"`
+	// The user's given name(s).
+	GivenName string `json:"given_name,omitempty"`
+	// The user's family name(s).
+	FamilyName string `json:"family_name,omitempty"`
+	// The user's full name.
+	Name string `json:"name,omitempty"`
+	// The user's nickname.
+	Nickname string `json:"nickname,omitempty"`
+	// A URI pointing to the user's picture.
+	Picture string `json:"picture,omitempty"`
+	// The user metadata to be associated with the user. If set, the field must be an object containing no more than ten properties.
+	// Property names can have a maximum of 100 characters, and property values must be strings of no more than 500 characters.
+	UserMetadata *map[string]interface{} `json:"user_metadata,omitempty"`
+	// Extra parameters to be merged into the request body. Values set here will override any existing values
+	ExtraParameters map[string]string `json:"-"`
+}
+
+// SignUpResponse is a sign up response.
+type SignUpResponse struct {
+	// The user's email address.
+	Email string `json:"email,omitempty"`
+	// Indicates whether a user has verified their email address.
+	EmailVerified bool `json:"email_verified,omitempty"`
+	// The users ID
+	ID string `json:"_id,omitempty"`
+	// The user's username. Only valid if the connection requires a username.
+	Username string `json:"username,omitempty"`
+	// The user's given name(s).
+	GivenName string `json:"given_name,omitempty"`
+	// The user's family name(s).
+	FamilyName string `json:"family_name,omitempty"`
+	// The user's full name.
+	Name string `json:"name,omitempty"`
+	// The user's nickname.
+	Nickname string `json:"nickname,omitempty"`
+	// A URI pointing to the user's picture.
+	Picture string `json:"picture,omitempty"`
+	// The user metadata to be associated with the user. If set, the field must be an object containing no more than ten properties.
+	// Property names can have a maximum of 100 characters, and property values must be strings of no more than 500 characters.
+	UserMetadata *map[string]interface{} `json:"user_metadata,omitempty"`
+}
+
+// MarshalJSON implements the json.Unmarshaler interface.
+//
+// It is required to support adding parameters from the `ExtraParameters`
+// field onto the request object.
+func (s *SignUpRequest) MarshalJSON() ([]byte, error) {
+	n := structs.New(s)
+	n.TagName = "json"
+
+	m := n.Map()
+	for k, v := range s.ExtraParameters {
+		m[k] = v
+	}
+
+	return json.Marshal(m)
+}

--- a/authentication/database_test.go
+++ b/authentication/database_test.go
@@ -12,14 +12,14 @@ import (
 func TestDatabaseSignUp(t *testing.T) {
 	configureHTTPTestRecordings(t)
 
-	userData := database.SignUpRequest{
+	userData := database.SignupRequest{
 		Connection: "Username-Password-Authentication",
 		Username:   "mytestaccount",
 		Password:   "mypassword",
 		Email:      "mytestaccount@example.com",
 	}
 
-	createdUser, err := authAPI.Database.SignUp(context.Background(), userData)
+	createdUser, err := authAPI.Database.Signup(context.Background(), userData)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, createdUser.ID)
 	assert.Equal(t, userData.Username, createdUser.Username)

--- a/authentication/database_test.go
+++ b/authentication/database_test.go
@@ -1,0 +1,26 @@
+package authentication
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/auth0/go-auth0/authentication/database"
+)
+
+func TestDatabaseSignUp(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	userData := database.SignUpRequest{
+		Connection: "Username-Password-Authentication",
+		Username:   "mytestaccount",
+		Password:   "mypassword",
+		Email:      "mytestaccount@example.com",
+	}
+
+	createdUser, err := authAPI.Database.SignUp(context.Background(), userData)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, createdUser.ID)
+	assert.Equal(t, userData.Username, createdUser.Username)
+}

--- a/authentication/http_recordings_test.go
+++ b/authentication/http_recordings_test.go
@@ -1,0 +1,95 @@
+package authentication
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/dnaeon/go-vcr.v3/cassette"
+	"gopkg.in/dnaeon/go-vcr.v3/recorder"
+)
+
+const (
+	recordingsDIR    = "./../test/data/recordings/authentication/"
+	recordingsDomain = "go-auth0-dev.eu.auth0.com"
+)
+
+func configureHTTPTestRecordings(t *testing.T) {
+	t.Helper()
+
+	if !httpRecordingsEnabled {
+		return
+	}
+
+	initialTransport := authAPI.http.Transport
+
+	recorderTransport, err := recorder.NewWithOptions(
+		&recorder.Options{
+			CassetteName:       recordingsDIR + t.Name(),
+			Mode:               recorder.ModeRecordOnce,
+			RealTransport:      authAPI.http.Transport,
+			SkipRequestLatency: true,
+		},
+	)
+	require.NoError(t, err)
+
+	removeSensitiveDataFromRecordings(recorderTransport)
+
+	authAPI.http.Transport = recorderTransport
+
+	t.Cleanup(func() {
+		err := recorderTransport.Stop()
+		require.NoError(t, err)
+		authAPI.http.Transport = initialTransport
+	})
+}
+
+func removeSensitiveDataFromRecordings(recorderTransport *recorder.Recorder) {
+	recorderTransport.AddHook(
+		func(i *cassette.Interaction) error {
+			skip429Response(i)
+			redactHeaders(i)
+
+			// Redact domain should always be ran last
+			redactDomain(i, domain)
+
+			return nil
+		},
+		recorder.BeforeSaveHook,
+	)
+}
+
+func skip429Response(i *cassette.Interaction) {
+	if i.Response.Code == http.StatusTooManyRequests {
+		i.DiscardOnSave = true
+	}
+}
+
+func redactHeaders(i *cassette.Interaction) {
+	allowedHeaders := map[string]bool{
+		"Content-Type": true,
+		"User-Agent":   true,
+	}
+
+	for header := range i.Request.Headers {
+		if _, ok := allowedHeaders[header]; !ok {
+			delete(i.Request.Headers, header)
+		}
+	}
+	for header := range i.Response.Headers {
+		if _, ok := allowedHeaders[header]; !ok {
+			delete(i.Response.Headers, header)
+		}
+	}
+}
+
+func redactDomain(i *cassette.Interaction, domain string) {
+	i.Request.Host = strings.ReplaceAll(i.Request.Host, domain, recordingsDomain)
+	i.Request.URL = strings.ReplaceAll(i.Request.URL, domain, recordingsDomain)
+
+	domainParts := strings.Split(domain, ".")
+
+	i.Response.Body = strings.ReplaceAll(i.Response.Body, domainParts[0], recordingsDomain)
+	i.Request.Body = strings.ReplaceAll(i.Request.Body, domainParts[0], recordingsDomain)
+}

--- a/authentication/oauth.go
+++ b/authentication/oauth.go
@@ -10,3 +10,71 @@ import (
 
 // OAuth exposes logging in using OAuth based APIs.
 type OAuth manager
+
+// LoginWithGrant allows logging in with an OAuth 2.0 grant. This should only be needed if a grant
+// type is not supported byt this SDK.
+func (o *OAuth) LoginWithGrant(ctx context.Context, grantType string, body url.Values, opts ...RequestOption) (t *oauth.TokenSet, err error) {
+	body.Add("grant_type", grantType)
+
+	err = o.authentication.FormRequest(ctx, "POST", o.authentication.URI("oauth", "token"), body, &t, opts...)
+	return
+}
+
+// LoginWithPassword is for logging in with information is typically received from a highly trusted
+// public client like a SPA.
+// For single-page applications and native/mobile apps, we recommend using web flows instead.)
+//
+// See: https://auth0.com/docs/api/authentication#resource-owner-password
+//
+// Use the `Header` RequestOption to set the `auth0-forwarded-for` header to an end-users IP if you
+// you want brute force protection to work in server-side scenarios
+// See See https://auth0.com/docs/get-started/authentication-and-authorization-flow/avoid-common-issues-with-resource-owner-password-flow-and-attack-protection
+func (o *OAuth) LoginWithPassword(ctx context.Context, body oauth.LoginWithPasswordRequest, opts ...RequestOption) (t *oauth.TokenSet, err error) {
+	grantType := "password"
+	data := url.Values{
+		"username": []string{body.Username},
+		"password": []string{body.Password},
+	}
+
+	if body.Realm != "" {
+		grantType = "http://auth0.com/oauth/grant-type/password-realm"
+		data.Set("realm", body.Realm)
+	}
+
+	if body.Scope != "" {
+		data.Set("scope", body.Scope)
+	}
+
+	for k, v := range body.ExtraParameters {
+		data.Set(k, v)
+	}
+
+	err = o.addClientAuthentication(body.ClientAuthentication, data, false)
+
+	if err != nil {
+		return
+	}
+
+	t, err = o.LoginWithGrant(ctx, grantType, data, opts...)
+	return
+}
+
+func (o *OAuth) addClientAuthentication(params oauth.ClientAuthentication, body url.Values, required bool) error {
+	if params.ClientID != "" {
+		body.Set("client_id", params.ClientID)
+	} else {
+		body.Set("client_id", o.authentication.clientID)
+	}
+
+	if params.ClientSecret != "" && body.Get("client_secret") == "" {
+		body.Set("client_secret", params.ClientSecret)
+	} else if o.authentication.clientSecret != "" {
+		body.Set("client_secret", o.authentication.clientSecret)
+	}
+
+	if required && body.Get("client_secret") == "" {
+		return errors.New("client_secret is required but not provided")
+	}
+
+	return nil
+}

--- a/authentication/oauth.go
+++ b/authentication/oauth.go
@@ -1,0 +1,12 @@
+package authentication
+
+import (
+	"context"
+	"errors"
+	"net/url"
+
+	"github.com/auth0/go-auth0/authentication/oauth"
+)
+
+// OAuth exposes logging in using OAuth based APIs.
+type OAuth manager

--- a/authentication/oauth.go
+++ b/authentication/oauth.go
@@ -20,15 +20,15 @@ func (o *OAuth) LoginWithGrant(ctx context.Context, grantType string, body url.V
 	return
 }
 
-// LoginWithPassword is for logging in with information is typically received from a highly trusted
+// LoginWithPassword is for logging in with information that is typically received from a highly trusted
 // public client like a SPA.
-// For single-page applications and native/mobile apps, we recommend using web flows instead.)
+// For single-page applications and native/mobile apps, we recommend using web flows instead.
 //
 // See: https://auth0.com/docs/api/authentication#resource-owner-password
 //
-// Use the `Header` RequestOption to set the `auth0-forwarded-for` header to an end-users IP if you
-// you want brute force protection to work in server-side scenarios
-// See See https://auth0.com/docs/get-started/authentication-and-authorization-flow/avoid-common-issues-with-resource-owner-password-flow-and-attack-protection
+// Use the `Header` RequestOption to set the `auth0-forwarded-for` header to an end-user's IP if you
+// you want brute force protection to work in server-side scenarios.
+// See https://auth0.com/docs/get-started/authentication-and-authorization-flow/avoid-common-issues-with-resource-owner-password-flow-and-attack-protection
 func (o *OAuth) LoginWithPassword(ctx context.Context, body oauth.LoginWithPasswordRequest, opts ...RequestOption) (t *oauth.TokenSet, err error) {
 	grantType := "password"
 	data := url.Values{

--- a/authentication/oauth.go
+++ b/authentication/oauth.go
@@ -16,7 +16,7 @@ type OAuth manager
 func (o *OAuth) LoginWithGrant(ctx context.Context, grantType string, body url.Values, opts ...RequestOption) (t *oauth.TokenSet, err error) {
 	body.Add("grant_type", grantType)
 
-	err = o.authentication.FormRequest(ctx, "POST", o.authentication.URI("oauth", "token"), body, &t, opts...)
+	err = o.authentication.Request(ctx, "POST", o.authentication.URI("oauth", "token"), body, &t, opts...)
 	return
 }
 

--- a/authentication/oauth/oauth.go
+++ b/authentication/oauth/oauth.go
@@ -4,7 +4,7 @@ package oauth
 type ClientAuthentication struct {
 	// ClientID to use for the specific request.
 	ClientID string
-	// ClientSecret to use for the specific request .Required when Client Secret Basic or Client
+	// ClientSecret to use for the specific request. Required when Client Secret Basic or Client
 	// Secret Post is the application authentication method.
 	ClientSecret string
 }
@@ -13,7 +13,7 @@ type ClientAuthentication struct {
 type TokenSet struct {
 	// The access token.
 	AccessToken string `json:"access_token,omitempty"`
-	// The duration in seconds. that the access token is valid.
+	// The duration in seconds that the access token is valid for.
 	ExpiresIn int64 `json:"expires_in,omitempty"`
 	// The user's ID token.
 	IDToken string `json:"id_token,omitempty"`
@@ -34,8 +34,8 @@ type LoginWithPasswordRequest struct {
 	Scope string
 	// The unique identifier of the target API you want to access.
 	Audience string
-	// String value of the realm the user belongs. Set this if you want to add realm support at this grant.
+	// String value of the realm the user belongs. Set this if you want to add realm support to this grant.
 	Realm string
-	// Extra parameters to be merged into the request body. Values set here will override any existing values
+	// Extra parameters to be merged into the request body. Values set here will override any existing values.
 	ExtraParameters map[string]string
 }

--- a/authentication/oauth/oauth.go
+++ b/authentication/oauth/oauth.go
@@ -1,0 +1,41 @@
+package oauth
+
+// ClientAuthentication defines the authentication options that can be overridden per request.
+type ClientAuthentication struct {
+	// ClientID to use for the specific request.
+	ClientID string
+	// ClientSecret to use for the specific request .Required when Client Secret Basic or Client
+	// Secret Post is the application authentication method.
+	ClientSecret string
+}
+
+// TokenSet defines the response of the OAuth endpoints.
+type TokenSet struct {
+	// The access token.
+	AccessToken string `json:"access_token,omitempty"`
+	// The duration in seconds. that the access token is valid.
+	ExpiresIn int64 `json:"expires_in,omitempty"`
+	// The user's ID token.
+	IDToken string `json:"id_token,omitempty"`
+	// The refresh token, only available if `offline_access` scope was provided.
+	RefreshToken string `json:"refresh_token,omitempty"`
+	// The type of the access token.
+	TokenType string `json:"token_type,omitempty"`
+}
+
+// LoginWithPasswordRequest defines the request body for logging in with a password grant.
+type LoginWithPasswordRequest struct {
+	ClientAuthentication
+	// The user's username.
+	Username string
+	// The user's password.
+	Password string
+	// String value of the different scopes the application is asking for. Multiple scopes are separated with whitespace.
+	Scope string
+	// The unique identifier of the target API you want to access.
+	Audience string
+	// String value of the realm the user belongs. Set this if you want to add realm support at this grant.
+	Realm string
+	// Extra parameters to be merged into the request body. Values set here will override any existing values
+	ExtraParameters map[string]string
+}

--- a/authentication/oauth_test.go
+++ b/authentication/oauth_test.go
@@ -1,0 +1,23 @@
+package authentication
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/auth0/go-auth0/authentication/oauth"
+)
+
+func TestOAuthLoginWithPassword(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	tokenSet, err := authAPI.OAuth.LoginWithPassword(context.Background(), oauth.LoginWithPasswordRequest{
+		Username: "testuser",
+		Password: "testuser123",
+	})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, tokenSet.AccessToken)
+	assert.NotEmpty(t, tokenSet.IDToken)
+	assert.Equal(t, "Bearer", tokenSet.TokenType)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/PuerkitoBio/rehttp v1.1.0
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.8.2
+	go.devnw.com/structs v1.0.0
 	golang.org/x/oauth2 v0.8.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.1.2
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+go.devnw.com/structs v1.0.0 h1:FFkBoBOkapCdxFEIkpOZRmMOMr9b9hxjKTD3bJYl9lk=
+go.devnw.com/structs v1.0.0/go.mod h1:wHBkdQpNeazdQHszJ2sxwVEpd8zGTEsKkeywDLGbrmg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -99,9 +99,9 @@ func TestRetries(t *testing.T) {
 		_, err := c.Get(s.URL)
 
 		assert.Error(t, err)
-		elapsed := time.Since(start).Seconds()
-		assert.GreaterOrEqual(t, elapsed, float64(1))
-		assert.LessOrEqual(t, elapsed, float64(2))
+		elapsed := time.Since(start).Milliseconds()
+		assert.GreaterOrEqual(t, elapsed, int64(750))
+		assert.LessOrEqual(t, elapsed, int64(2000))
 	})
 
 	t.Run("Should not retry some errors", func(t *testing.T) {

--- a/test/data/recordings/authentication/TestDatabaseSignUp.yaml
+++ b/test/data/recordings/authentication/TestDatabaseSignUp.yaml
@@ -6,14 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 137
+        content_length: 184
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            {"email":"mytestaccount@example.com","password":"mypassword","connection":"Username-Password-Authentication","username":"mytestaccount"}
+        body: '{"client_id":"test-client_id","connection":"Username-Password-Authentication","email":"mytestaccount@example.com","password":"mypassword","username":"mytestaccount"}'
         form: {}
         headers:
             Content-Type:
@@ -28,10 +27,10 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"_id":"64835565049355c8fda2b439","email_verified":false,"email":"mytestaccount@example.com","username":"mytestaccount","app_metadata":{},"user_metadata":{}}'
+        body: '{"_id":"6486fc52049355c8fda30e21","email_verified":false,"email":"mytestaccount@example.com","username":"mytestaccount","app_metadata":{},"user_metadata":{}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 370.480334ms
+        duration: 365.410542ms

--- a/test/data/recordings/authentication/TestDatabaseSignUp.yaml
+++ b/test/data/recordings/authentication/TestDatabaseSignUp.yaml
@@ -1,0 +1,37 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 137
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"email":"mytestaccount@example.com","password":"mypassword","connection":"Username-Password-Authentication","username":"mytestaccount"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://go-auth0-dev.eu.auth0.com/dbconnections/signup
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"_id":"64835565049355c8fda2b439","email_verified":false,"email":"mytestaccount@example.com","username":"mytestaccount","app_metadata":{},"user_metadata":{}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 370.480334ms

--- a/test/data/recordings/authentication/TestOAuthLoginWithPassword.yaml
+++ b/test/data/recordings/authentication/TestOAuthLoginWithPassword.yaml
@@ -1,0 +1,44 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 101
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: client_id=test-client_id&grant_type=password&password=testuser123&username=testuser
+        form:
+            client_id:
+                - test-client_id
+            grant_type:
+                - password
+            password:
+                - testuser123
+            username:
+                - testuser
+        headers:
+            Content-Type:
+                - application/x-www-form-urlencoded
+        url: https://go-auth0-dev.eu.auth0.com/oauth/token
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"access_token":"test-access-token","expires_in":86400,"id_token":"test-id-token","token_type":"Bearer"}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 330.676ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Implements the initial base structure of the authentication client along with 2 methods in OAuth and Database in order to facilitate testing of JSON and form encoded requests.

This does not implement aspects such as ID token verification, telemetry and rate limiting onto the client which will be done in a future PR.

There is testing setup for these methods but currently it is dependent on tenant state (i.e. signed up users), randomising this data, recording management API interactions etc. proved difficult so I will file a ticket to ensure that this is dealt with as part of this effort. Current ideas are:

* Script that uses Auth0 CLI to set up required user
* Have a default user that will be stored for recordings and override this if running against a live tenant

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Tested manually and covered by unit tests

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
