### PR TITLE
[SDK-4335] Add passwordless authentication APIs 

### DIFF
--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -110,8 +110,9 @@ func (u *UserInfoResponse) UnmarshalJSON(b []byte) error {
 
 // Authentication is the auth client.
 type Authentication struct {
-	Database *Database
-	OAuth    *OAuth
+	Database     *Database
+	OAuth        *OAuth
+	Passwordless *Passwordless
 
 	url             *url.URL
 	basePath        string
@@ -156,6 +157,7 @@ func New(domain string, options ...Option) (*Authentication, error) {
 	a.common.authentication = a
 	a.Database = (*Database)(&a.common)
 	a.OAuth = (*OAuth)(&a.common)
+	a.Passwordless = (*Passwordless)(&a.common)
 
 	return a, nil
 }

--- a/authentication/oauth/oauth.go
+++ b/authentication/oauth/oauth.go
@@ -3,10 +3,10 @@ package oauth
 // ClientAuthentication defines the authentication options that can be overridden per request.
 type ClientAuthentication struct {
 	// ClientID to use for the specific request.
-	ClientID string
+	ClientID string `json:"client_id,omitempty"`
 	// ClientSecret to use for the specific request. Required when Client Secret Basic or Client
 	// Secret Post is the application authentication method.
-	ClientSecret string
+	ClientSecret string `json:"client_secret,omitempty"`
 }
 
 // TokenSet defines the response of the OAuth endpoints.

--- a/authentication/oauth/oauth.go
+++ b/authentication/oauth/oauth.go
@@ -90,10 +90,7 @@ type RefreshTokenRequest struct {
 
 // RevokeRefreshTokenRequest defines the request body for logging in with Authorization Code grant.
 type RevokeRefreshTokenRequest struct {
-	// The client_id of your client.
-	ClientID string `json:"client_id,omitempty"`
-	// The client_secret of your client.
-	ClientSecret string `json:"client_secret,omitempty"`
+	ClientAuthentication
 	// The refresh token you want to revoke.
 	Token string `json:"token,omitempty"`
 	// Extra parameters to be merged into the request body. Values set here will override any existing values.

--- a/authentication/passwordless.go
+++ b/authentication/passwordless.go
@@ -17,13 +17,7 @@ type Passwordless manager
 //
 // See: https://auth0.com/docs/api/authentication?http#get-code-or-link
 func (p *Passwordless) SendEmail(ctx context.Context, params passwordless.SendEmailRequest, opts ...RequestOption) (r *passwordless.SendEmailResponse, err error) {
-	if params.ClientID == "" {
-		params.ClientID = p.authentication.clientID
-	}
-
-	if params.ClientSecret == "" && p.authentication.clientSecret != "" {
-		params.ClientSecret = p.authentication.clientSecret
-	}
+	p.addClientAuthentication(&params.ClientAuthentication)
 
 	params.Connection = "email"
 
@@ -35,13 +29,7 @@ func (p *Passwordless) SendEmail(ctx context.Context, params passwordless.SendEm
 //
 // See: https://auth0.com/docs/api/authentication?http#authenticate-user
 func (p *Passwordless) LoginWithEmail(ctx context.Context, params passwordless.LoginWithEmailRequest, opts ...RequestOption) (t *oauth.TokenSet, err error) {
-	if params.ClientID == "" {
-		params.ClientID = p.authentication.clientID
-	}
-
-	if params.ClientSecret == "" && p.authentication.clientSecret != "" {
-		params.ClientSecret = p.authentication.clientSecret
-	}
+	p.addClientAuthentication(&params.ClientAuthentication)
 
 	params.GrantType = "http://auth0.com/oauth/grant-type/passwordless/otp"
 	params.Realm = "email"
@@ -57,13 +45,7 @@ func (p *Passwordless) LoginWithEmail(ctx context.Context, params passwordless.L
 //
 // See: https://auth0.com/docs/api/authentication?http#get-code-or-link
 func (p *Passwordless) SendSMS(ctx context.Context, params passwordless.SendSMSRequest, opts ...RequestOption) (r *passwordless.SendSMSResponse, err error) {
-	if params.ClientID == "" {
-		params.ClientID = p.authentication.clientID
-	}
-
-	if params.ClientSecret == "" && p.authentication.clientSecret != "" {
-		params.ClientSecret = p.authentication.clientSecret
-	}
+	p.addClientAuthentication(&params.ClientAuthentication)
 
 	params.Connection = "sms"
 
@@ -75,6 +57,16 @@ func (p *Passwordless) SendSMS(ctx context.Context, params passwordless.SendSMSR
 //
 // See: https://auth0.com/docs/api/authentication?http#authenticate-user
 func (p *Passwordless) LoginWithSMS(ctx context.Context, params passwordless.LoginWithSMSRequest, opts ...RequestOption) (t *oauth.TokenSet, err error) {
+	p.addClientAuthentication(&params.ClientAuthentication)
+
+	params.GrantType = "http://auth0.com/oauth/grant-type/passwordless/otp"
+	params.Realm = "sms"
+
+	err = p.authentication.Request(ctx, "POST", p.authentication.URI("oauth", "token"), params, &t, opts...)
+	return
+}
+
+func (p *Passwordless) addClientAuthentication(params *oauth.ClientAuthentication) {
 	if params.ClientID == "" {
 		params.ClientID = p.authentication.clientID
 	}
@@ -82,10 +74,4 @@ func (p *Passwordless) LoginWithSMS(ctx context.Context, params passwordless.Log
 	if params.ClientSecret == "" && p.authentication.clientSecret != "" {
 		params.ClientSecret = p.authentication.clientSecret
 	}
-
-	params.GrantType = "http://auth0.com/oauth/grant-type/passwordless/otp"
-	params.Realm = "sms"
-
-	err = p.authentication.Request(ctx, "POST", p.authentication.URI("oauth", "token"), params, &t, opts...)
-	return
 }

--- a/authentication/passwordless.go
+++ b/authentication/passwordless.go
@@ -1,0 +1,85 @@
+package authentication
+
+import (
+	"context"
+
+	"github.com/auth0/go-auth0/authentication/oauth"
+	"github.com/auth0/go-auth0/authentication/passwordless"
+)
+
+// Passwordless exposes logging in using the passwordless APIs.
+type Passwordless manager
+
+// SendEmail starts a passwordless flow by sending a link or code via email.
+//
+// See: https://auth0.com/docs/api/authentication?http#get-code-or-link
+func (p *Passwordless) SendEmail(ctx context.Context, params passwordless.SendEmailRequest, opts ...RequestOption) (r *passwordless.SendEmailResponse, err error) {
+	if params.ClientID == "" {
+		params.ClientID = p.authentication.clientID
+	}
+
+	if params.ClientSecret == "" && p.authentication.clientSecret != "" {
+		params.ClientSecret = p.authentication.clientSecret
+	}
+
+	params.Connection = "email"
+
+	err = p.authentication.Request(ctx, "POST", p.authentication.URI("passwordless", "start"), params, &r, opts...)
+	return
+}
+
+// LoginWithEmail completes the passwordless flow started in `SendEmail` by exchanging the code for a token.
+//
+// See: https://auth0.com/docs/api/authentication?http#authenticate-user
+func (p *Passwordless) LoginWithEmail(ctx context.Context, params passwordless.LoginWithEmailRequest, opts ...RequestOption) (t *oauth.TokenSet, err error) {
+	if params.ClientID == "" {
+		params.ClientID = p.authentication.clientID
+	}
+
+	if params.ClientSecret == "" && p.authentication.clientSecret != "" {
+		params.ClientSecret = p.authentication.clientSecret
+	}
+
+	params.GrantType = "http://auth0.com/oauth/grant-type/passwordless/otp"
+	params.Realm = "email"
+
+	err = p.authentication.Request(ctx, "POST", p.authentication.URI("oauth", "token"), params, &t, opts...)
+	return
+}
+
+// SendSMS starts a passwordless flow by sending a code via SMS.
+//
+// See: https://auth0.com/docs/api/authentication?http#get-code-or-link
+func (p *Passwordless) SendSMS(ctx context.Context, params passwordless.SendSMSRequest, opts ...RequestOption) (r *passwordless.SendSMSResponse, err error) {
+	if params.ClientID == "" {
+		params.ClientID = p.authentication.clientID
+	}
+
+	if params.ClientSecret == "" && p.authentication.clientSecret != "" {
+		params.ClientSecret = p.authentication.clientSecret
+	}
+
+	params.Connection = "sms"
+
+	err = p.authentication.Request(ctx, "POST", p.authentication.URI("passwordless", "start"), params, &r, opts...)
+	return
+}
+
+// LoginWithSMS completes the passwordless flow started in `SendSMS` by exchanging the code for a token.
+//
+// See: https://auth0.com/docs/api/authentication?http#authenticate-user
+func (p *Passwordless) LoginWithSMS(ctx context.Context, params passwordless.LoginWithSMSRequest, opts ...RequestOption) (t *oauth.TokenSet, err error) {
+	if params.ClientID == "" {
+		params.ClientID = p.authentication.clientID
+	}
+
+	if params.ClientSecret == "" && p.authentication.clientSecret != "" {
+		params.ClientSecret = p.authentication.clientSecret
+	}
+
+	params.GrantType = "http://auth0.com/oauth/grant-type/passwordless/otp"
+	params.Realm = "sms"
+
+	err = p.authentication.Request(ctx, "POST", p.authentication.URI("oauth", "token"), params, &t, opts...)
+	return
+}

--- a/authentication/passwordless.go
+++ b/authentication/passwordless.go
@@ -12,7 +12,7 @@ type Passwordless manager
 
 // SendEmail starts a passwordless flow by sending a link or code via email.
 //
-// In order to set the `x-request-language` header when sending this request, use the `Header`RequestOption
+// In order to set the `x-request-language` header when sending this request, use the `Header` RequestOption
 // helper.
 //
 // See: https://auth0.com/docs/api/authentication?http#get-code-or-link
@@ -52,7 +52,7 @@ func (p *Passwordless) LoginWithEmail(ctx context.Context, params passwordless.L
 
 // SendSMS starts a passwordless flow by sending a code via SMS.
 //
-// In order to set the `x-request-language` header when sending this request, use the `Header`RequestOption
+// In order to set the `x-request-language` header when sending this request, use the `Header` RequestOption
 // helper.
 //
 // See: https://auth0.com/docs/api/authentication?http#get-code-or-link

--- a/authentication/passwordless.go
+++ b/authentication/passwordless.go
@@ -12,6 +12,9 @@ type Passwordless manager
 
 // SendEmail starts a passwordless flow by sending a link or code via email.
 //
+// In order to set the `x-request-language` header when sending this request, use the `Header`RequestOption
+// helper.
+//
 // See: https://auth0.com/docs/api/authentication?http#get-code-or-link
 func (p *Passwordless) SendEmail(ctx context.Context, params passwordless.SendEmailRequest, opts ...RequestOption) (r *passwordless.SendEmailResponse, err error) {
 	if params.ClientID == "" {
@@ -48,6 +51,9 @@ func (p *Passwordless) LoginWithEmail(ctx context.Context, params passwordless.L
 }
 
 // SendSMS starts a passwordless flow by sending a code via SMS.
+//
+// In order to set the `x-request-language` header when sending this request, use the `Header`RequestOption
+// helper.
 //
 // See: https://auth0.com/docs/api/authentication?http#get-code-or-link
 func (p *Passwordless) SendSMS(ctx context.Context, params passwordless.SendSMSRequest, opts ...RequestOption) (r *passwordless.SendSMSResponse, err error) {

--- a/authentication/passwordless/passwordless.go
+++ b/authentication/passwordless/passwordless.go
@@ -1,0 +1,57 @@
+package passwordless
+
+import "github.com/auth0/go-auth0/authentication/oauth"
+
+// SendEmailRequest defines the request body for starting a passwordless flow via email.
+type SendEmailRequest struct {
+	oauth.ClientAuthentication
+	Connection string                 `json:"connection,omitempty"`
+	Email      string                 `json:"email,omitempty"`
+	Send       string                 `json:"send,omitempty"`
+	AuthParams map[string]interface{} `json:"authParams,omitempty"`
+}
+
+// SendEmailResponse defines the response from the `SendEmail` request.
+type SendEmailResponse struct {
+	ID            string `json:"_id,omitempty"`
+	Email         string `json:"email,omitempty"`
+	EmailVerified bool   `json:"email_verified,omitempty"`
+}
+
+// LoginWithEmailRequest defines the request body for exchanging a code requested by `SendEmail` for a token.
+type LoginWithEmailRequest struct {
+	oauth.ClientAuthentication
+	Audience  string `json:"audience,omitempty"`
+	Code      string `json:"otp,omitempty"`
+	Email     string `json:"username,omitempty"`
+	GrantType string `json:"grant_type,omitempty"`
+	Realm     string `json:"realm,omitempty"`
+	Scope     string `json:"scope,omitempty"`
+}
+
+// SendSMSRequest defines the request body for starting a passwordless flow via email.
+type SendSMSRequest struct {
+	oauth.ClientAuthentication
+	Connection  string                 `json:"connection,omitempty"`
+	PhoneNumber string                 `json:"phone_number,omitempty"`
+	AuthParams  map[string]interface{} `json:"authParams,omitempty"`
+}
+
+// SendSMSResponse defines the response from the `SendSMS` request.
+type SendSMSResponse struct {
+	ID              string `json:"_id,omitempty"`
+	PhoneNumber     string `json:"phone_number,omitempty"`
+	PhoneVerified   bool   `json:"phone_verified,omitempty"`
+	RequestLanguage string `json:"request_language,omitempty"`
+}
+
+// LoginWithSMSRequest defines the request body for exchanging a code requested by `SendSMS` for a token.
+type LoginWithSMSRequest struct {
+	oauth.ClientAuthentication
+	Audience    string `json:"audience,omitempty"`
+	Code        string `json:"otp,omitempty"`
+	PhoneNumber string `json:"username,omitempty"`
+	GrantType   string `json:"grant_type,omitempty"`
+	Realm       string `json:"realm,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+}

--- a/authentication/passwordless/passwordless.go
+++ b/authentication/passwordless/passwordless.go
@@ -39,10 +39,9 @@ type SendSMSRequest struct {
 
 // SendSMSResponse defines the response from the `SendSMS` request.
 type SendSMSResponse struct {
-	ID              string `json:"_id,omitempty"`
-	PhoneNumber     string `json:"phone_number,omitempty"`
-	PhoneVerified   bool   `json:"phone_verified,omitempty"`
-	RequestLanguage string `json:"request_language,omitempty"`
+	ID            string `json:"_id,omitempty"`
+	PhoneNumber   string `json:"phone_number,omitempty"`
+	PhoneVerified bool   `json:"phone_verified,omitempty"`
 }
 
 // LoginWithSMSRequest defines the request body for exchanging a code requested by `SendSMS` for a token.

--- a/authentication/passwordless_test.go
+++ b/authentication/passwordless_test.go
@@ -1,0 +1,64 @@
+package authentication
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/auth0/go-auth0/authentication/passwordless"
+)
+
+func TestSendEmail(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	r, err := authAPI.Passwordless.SendEmail(context.Background(), passwordless.SendEmailRequest{
+		Email: "test-email@example.com",
+		Send:  "code",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "test-email@example.com", r.Email)
+	assert.Equal(t, true, r.EmailVerified)
+}
+
+func TestLoginWithEmail(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	token, err := authAPI.Passwordless.LoginWithEmail(context.Background(), passwordless.LoginWithEmailRequest{
+		Code:  "123456",
+		Email: "test-email@example.com",
+		Scope: "openid profile email offline_access",
+	})
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, token.AccessToken)
+	assert.NotEmpty(t, token.RefreshToken)
+}
+
+func TestSendSMS(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	r, err := authAPI.Passwordless.SendSMS(context.Background(), passwordless.SendSMSRequest{
+		PhoneNumber: "+123456789",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "+123456789", r.PhoneNumber)
+	assert.Equal(t, true, r.PhoneVerified)
+	assert.Equal(t, "en", r.RequestLanguage)
+}
+
+func TestLoginWithSMS(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	token, err := authAPI.Passwordless.LoginWithSMS(context.Background(), passwordless.LoginWithSMSRequest{
+		PhoneNumber: "+123456789",
+		Code:        "123456",
+		Scope:       "openid profile email offline_access",
+	})
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, token.AccessToken)
+	assert.NotEmpty(t, token.RefreshToken)
+}

--- a/authentication/passwordless_test.go
+++ b/authentication/passwordless_test.go
@@ -26,9 +26,10 @@ func TestLoginWithEmail(t *testing.T) {
 	configureHTTPTestRecordings(t)
 
 	token, err := authAPI.Passwordless.LoginWithEmail(context.Background(), passwordless.LoginWithEmailRequest{
-		Code:  "123456",
-		Email: "test-email@example.com",
-		Scope: "openid profile email offline_access",
+		Code:     "123456",
+		Email:    "test-email@example.com",
+		Scope:    "openid profile email offline_access",
+		Audience: "https://api.example.com",
 	})
 
 	assert.NoError(t, err)
@@ -46,7 +47,6 @@ func TestSendSMS(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "+123456789", r.PhoneNumber)
 	assert.Equal(t, true, r.PhoneVerified)
-	assert.Equal(t, "en", r.RequestLanguage)
 }
 
 func TestLoginWithSMS(t *testing.T) {
@@ -56,6 +56,7 @@ func TestLoginWithSMS(t *testing.T) {
 		PhoneNumber: "+123456789",
 		Code:        "123456",
 		Scope:       "openid profile email offline_access",
+		Audience:    "https://api.example.com",
 	})
 
 	assert.NoError(t, err)

--- a/test/data/recordings/authentication/TestLoginWithEmail.yaml
+++ b/test/data/recordings/authentication/TestLoginWithEmail.yaml
@@ -12,7 +12,7 @@ interactions:
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: '{"client_id":"test-client_id","grant_type":"http://auth0.com/oauth/grant-type/passwordless/otp","otp":"123456","realm":"email","scope":"openid profile email offline_access","username":"test-email@example.com"}'
+        body: '{"client_id":"test-client_id","grant_type":"http://auth0.com/oauth/grant-type/passwordless/otp","otp":"123456","realm":"email","scope":"openid profile email offline_access","username":"test-email@example.com","audience":"https://api.example.com"}'
         form: {}
         headers:
             Content-Type:

--- a/test/data/recordings/authentication/TestLoginWithEmail.yaml
+++ b/test/data/recordings/authentication/TestLoginWithEmail.yaml
@@ -1,0 +1,36 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 226
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"client_id":"test-client_id","grant_type":"http://auth0.com/oauth/grant-type/passwordless/otp","otp":"123456","realm":"email","scope":"openid profile email offline_access","username":"test-email@example.com"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://go-auth0-dev.eu.auth0.com/oauth/token
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"access_token":"test-access-token","expires_in":86400,"id_token":"test-id-token","refresh_token":"test-refresh-token","token_type":"Bearer"}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 328.364125ms

--- a/test/data/recordings/authentication/TestLoginWithSMS.yaml
+++ b/test/data/recordings/authentication/TestLoginWithSMS.yaml
@@ -12,7 +12,7 @@ interactions:
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: '{"client_id":"test-client_id","grant_type":"http://auth0.com/oauth/grant-type/passwordless/otp","otp":"123456","realm":"sms","scope":"openid profile email offline_access","username":"+123456789"}'
+        body: '{"client_id":"test-client_id","grant_type":"http://auth0.com/oauth/grant-type/passwordless/otp","otp":"123456","realm":"sms","scope":"openid profile email offline_access","username":"+123456789","audience":"https://api.example.com"}'
         form: {}
         headers:
             Content-Type:

--- a/test/data/recordings/authentication/TestLoginWithSMS.yaml
+++ b/test/data/recordings/authentication/TestLoginWithSMS.yaml
@@ -1,0 +1,36 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 226
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"client_id":"test-client_id","grant_type":"http://auth0.com/oauth/grant-type/passwordless/otp","otp":"123456","realm":"sms","scope":"openid profile email offline_access","username":"+123456789"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://go-auth0-dev.eu.auth0.com/oauth/token
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"access_token":"test-access-token","expires_in":86400,"id_token":"test-id-token","refresh_token":"test-refresh-token","token_type":"Bearer"}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 328.364125ms

--- a/test/data/recordings/authentication/TestSendEmail.yaml
+++ b/test/data/recordings/authentication/TestSendEmail.yaml
@@ -1,0 +1,36 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 114
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"client_id":"test-client_id","connection":"email","email":"test-email@example.com","send":"code"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://go-auth0-dev.eu.auth0.com/passwordless/start
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"_id":"6492b5a75bedeae7449299fa","email":"test-email@example.com","email_verified":true}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 546.050417ms

--- a/test/data/recordings/authentication/TestSendSMS.yaml
+++ b/test/data/recordings/authentication/TestSendSMS.yaml
@@ -27,7 +27,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"_id":"6492b5a75bedeae7449299fa","phone_number":"+123456789","phone_verified":true,"request_language":"en"}'
+        body: '{"_id":"6492b5a75bedeae7449299fa","phone_number":"+123456789","phone_verified":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/authentication/TestSendSMS.yaml
+++ b/test/data/recordings/authentication/TestSendSMS.yaml
@@ -1,0 +1,36 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 114
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"client_id":"test-client_id","connection":"sms","phone_number":"+123456789"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://go-auth0-dev.eu.auth0.com/passwordless/start
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"_id":"6492b5a75bedeae7449299fa","phone_number":"+123456789","phone_verified":true,"request_language":"en"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 546.050417ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This implements the passwordless APIs on the authentication client:

* SendEmail
* LoginWithEmail
* SendSMS
* LoginWithSMS

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Covered by tests and test email manually. Currently testing SMS once I get twilio working

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
