### PR TITLE
[SDK-4367] Don't use internal client structs as parameters

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -201,7 +201,7 @@ This logic can be customised by using the `management.WithRetries` helper, and c
 m, err := management.New(
     domain,
     management.WithClientCredentials(context.Background(), id, secret),
-    management.WithRetries(RetryOptions{MaxRetries: 3, Statuses: []int{http.StatusTooManyRequests, http.StatusBadGateway}}),
+    management.WithRetries(3, []int{http.StatusTooManyRequests, http.StatusBadGateway}),
 )
 
 // Disable retries

--- a/management/management_option.go
+++ b/management/management_option.go
@@ -77,16 +77,6 @@ func WithClient(client *http.Client) Option {
 	}
 }
 
-// WithAuth0ClientInfo configures the management client to use the provided client information
-// instead of the default one.
-func WithAuth0ClientInfo(auth0ClientInfo client.Auth0ClientInfo) Option {
-	return func(m *Management) {
-		if !auth0ClientInfo.IsEmpty() {
-			m.auth0ClientInfo = &auth0ClientInfo
-		}
-	}
-}
-
 // WithAuth0ClientEnvEntry allows adding extra environment keys to the client information.
 func WithAuth0ClientEnvEntry(key string, value string) Option {
 	return func(m *Management) {
@@ -108,9 +98,12 @@ func WithNoAuth0ClientInfo() Option {
 }
 
 // WithRetries configures the management client to only retry under the conditions provided.
-func WithRetries(retryConfig client.RetryOptions) Option {
+func WithRetries(maxRetries int, statuses []int) Option {
 	return func(m *Management) {
-		m.retryStrategy = retryConfig
+		m.retryStrategy = client.RetryOptions{
+			MaxRetries: maxRetries,
+			Statuses:   statuses,
+		}
 	}
 }
 

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -283,27 +283,6 @@ func TestAuth0Client(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Allows passing custom Auth0ClientInfo", func(t *testing.T) {
-		customClient := client.Auth0ClientInfo{Name: "test-client", Version: "1.0.0"}
-
-		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			header := r.Header.Get("Auth0-Client")
-			assert.Equal(t, "eyJuYW1lIjoidGVzdC1jbGllbnQiLCJ2ZXJzaW9uIjoiMS4wLjAifQ==", header)
-		})
-		s := httptest.NewServer(h)
-
-		m, err := New(
-			s.URL,
-			WithInsecure(),
-			WithAuth0ClientInfo(customClient),
-		)
-		assert.NoError(t, err)
-
-		_, err = m.User.Read(context.Background(), "123")
-
-		assert.NoError(t, err)
-	})
-
 	t.Run("Allows disabling Auth0ClientInfo", func(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			rawHeader := r.Header.Get("Auth0-Client")
@@ -341,25 +320,6 @@ func TestAuth0Client(t *testing.T) {
 		m, err := New(
 			s.URL,
 			WithInsecure(),
-			WithAuth0ClientEnvEntry("foo", "bar"),
-		)
-		assert.NoError(t, err)
-		_, err = m.User.Read(context.Background(), "123")
-		assert.NoError(t, err)
-	})
-
-	t.Run("Allows passing extra env info with custom client", func(t *testing.T) {
-		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			header := r.Header.Get("Auth0-Client")
-			assert.Equal(t, "eyJuYW1lIjoidGVzdC1jbGllbnQiLCJ2ZXJzaW9uIjoiMS4wLjAiLCJlbnYiOnsiZm9vIjoiYmFyIn19", header)
-		})
-		s := httptest.NewServer(h)
-		customClient := client.Auth0ClientInfo{Name: "test-client", Version: "1.0.0"}
-
-		m, err := New(
-			s.URL,
-			WithInsecure(),
-			WithAuth0ClientInfo(customClient),
 			WithAuth0ClientEnvEntry("foo", "bar"),
 		)
 		assert.NoError(t, err)
@@ -451,7 +411,7 @@ func TestRetries(t *testing.T) {
 		m, err := New(
 			s.URL,
 			WithInsecure(),
-			WithRetries(client.RetryOptions{MaxRetries: 1, Statuses: []int{http.StatusBadGateway}}),
+			WithRetries(1, []int{http.StatusBadGateway}),
 		)
 		assert.NoError(t, err)
 
@@ -503,7 +463,7 @@ func TestRetries(t *testing.T) {
 		m, err := New(
 			s.URL,
 			WithInsecure(),
-			WithRetries(client.RetryOptions{MaxRetries: 3, Statuses: []int{http.StatusBadGateway}}),
+			WithRetries(3, []int{http.StatusBadGateway}),
 		)
 		assert.NoError(t, err)
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Given that these referenced structs from the internal client package they were unusable externally.
So change the WithRetries to accept individual arguments that are then turned into a retry strategy
and remove the WithAuth0ClientInfo as in retrospect it isn't necessary and was superseded by the
WithAuth0ClientEnvEntry helper.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
