### PR TITLE
chore(security): Pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
           AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
 
       - name: Update codecov report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # pin@3.1.4
         with:
           files: ./coverage.out
           fail_ci_if_error: false

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -5,16 +5,16 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: '30 0 1,15 * *'
+    - cron: "30 0 1,15 * *"
 
 jobs:
   scan:
     runs-on: ubuntu-latest
-    
+
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v3
       - name: Scan for Vulnerabilities in Code
-        uses: Templum/govulncheck-action@main
+        uses: Templum/govulncheck-action@435a35e28c7e56076f6daf838b81c1aa76ee0c95 # pin@0.10.1
         with:
           go-version: 1.19
           package: ./...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         run: go build ./...
 
       - name: Check for linting errors
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # pin@3.6.0
         with:
           version: latest
           args: -v -c .golangci.yml
@@ -50,7 +50,7 @@ jobs:
         run: make test
 
       - name: Update codecov report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # pin@3.1.4
         with:
           files: ./coverage.out
           fail_ci_if_error: false


### PR DESCRIPTION
This PR pins the `Templum/govulncheck-action`, `golangci/golangci-lint-action`, and `codecov/codecov-action` third-party actions to the full-length commit SHAs for their most recent releases.

Pinning an action to a full-length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository. [docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

Note: I've set the `beta` branch as the target for this PR merge to avoid creating complications during the eventual GA merge. Please adjust if you feel otherwise.