### PR TITLE
[SDK-4329] Introduce auth0client information into the authentication client

### DIFF
--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -159,6 +159,12 @@ func New(ctx context.Context, domain string, options ...Option) (*Authentication
 		option(a)
 	}
 
+	a.http = client.Wrap(
+		a.http,
+		client.WithDebug(a.debug),
+		client.WithAuth0ClientInfo(a.auth0ClientInfo),
+	)
+
 	a.common.authentication = a
 	a.Database = (*Database)(&a.common)
 	a.OAuth = (*OAuth)(&a.common)

--- a/authentication/authentication_option.go
+++ b/authentication/authentication_option.go
@@ -3,6 +3,8 @@ package authentication
 import (
 	"net/http"
 	"time"
+
+	"github.com/auth0/go-auth0/internal/client"
 )
 
 // Option is used for passing options to the Authentication client.
@@ -40,5 +42,35 @@ func WithIDTokenClockTolerance(clockTolerance time.Duration) Option {
 func WithClient(client *http.Client) Option {
 	return func(a *Authentication) {
 		a.http = client
+	}
+}
+
+// WithAuth0ClientInfo configures the authentication client to use the provided client information
+// instead of the default one.
+func WithAuth0ClientInfo(auth0ClientInfo client.Auth0ClientInfo) Option {
+	return func(a *Authentication) {
+		if !auth0ClientInfo.IsEmpty() {
+			a.auth0ClientInfo = &auth0ClientInfo
+		}
+	}
+}
+
+// WithNoAuth0ClientInfo configures the management client to not send the "Auth0-Client" header
+// at all.
+func WithNoAuth0ClientInfo() Option {
+	return func(a *Authentication) {
+		a.auth0ClientInfo = nil
+	}
+}
+
+// WithAuth0ClientEnvEntry allows adding extra environment keys to the client information.
+func WithAuth0ClientEnvEntry(key string, value string) Option {
+	return func(a *Authentication) {
+		if !a.auth0ClientInfo.IsEmpty() {
+			if a.auth0ClientInfo.Env == nil {
+				a.auth0ClientInfo.Env = map[string]string{}
+			}
+			a.auth0ClientInfo.Env[key] = value
+		}
 	}
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -291,8 +291,8 @@ func WithAuth0ClientInfo(auth0ClientInfo *Auth0ClientInfo) Option {
 	}
 }
 
-// Wrap the base client with transports that enable OAuth2 authentication.
-func Wrap(base *http.Client, tokenSource oauth2.TokenSource, options ...Option) *http.Client {
+// WrapWithTokenSource wraps the base client with transports that enable OAuth2 authentication.
+func WrapWithTokenSource(base *http.Client, tokenSource oauth2.TokenSource, options ...Option) *http.Client {
 	if base == nil {
 		base = http.DefaultClient
 	}
@@ -303,10 +303,20 @@ func Wrap(base *http.Client, tokenSource oauth2.TokenSource, options ...Option) 
 			Source: tokenSource,
 		},
 	}
-	for _, option := range options {
-		option(client)
+
+	return Wrap(client, options...)
+}
+
+// Wrap the base client with just the internal transports.
+func Wrap(base *http.Client, options ...Option) *http.Client {
+	if base == nil {
+		base = http.DefaultClient
 	}
-	return client
+
+	for _, option := range options {
+		option(base)
+	}
+	return base
 }
 
 // OAuth2ClientCredentials sets the oauth2 client credentials.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -32,7 +32,7 @@ func TestRetries(t *testing.T) {
 		s := httptest.NewServer(h)
 		defer s.Close()
 
-		c := Wrap(s.Client(), StaticToken(""), WithRetries(DefaultRetryOptions))
+		c := WrapWithTokenSource(s.Client(), StaticToken(""), WithRetries(DefaultRetryOptions))
 		r, err := c.Get(s.URL)
 		assert.NoError(t, err)
 
@@ -59,7 +59,7 @@ func TestRetries(t *testing.T) {
 		defer s.Close()
 
 		rc := RetryOptions{MaxRetries: 5, Statuses: []int{http.StatusGatewayTimeout}}
-		c := Wrap(s.Client(), StaticToken(""), WithRetries(rc))
+		c := WrapWithTokenSource(s.Client(), StaticToken(""), WithRetries(rc))
 		r, err := c.Get(s.URL)
 
 		assert.Equal(t, http.StatusOK, r.StatusCode)
@@ -81,7 +81,7 @@ func TestRetries(t *testing.T) {
 		s := httptest.NewServer(h)
 		defer s.Close()
 
-		c := Wrap(s.Client(), StaticToken(""), WithRetries(RetryOptions{}))
+		c := WrapWithTokenSource(s.Client(), StaticToken(""), WithRetries(RetryOptions{}))
 		r, err := c.Get(s.URL)
 
 		assert.Equal(t, http.StatusGatewayTimeout, r.StatusCode)
@@ -95,7 +95,7 @@ func TestRetries(t *testing.T) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
 		s := httptest.NewUnstartedServer(h)
-		c := Wrap(s.Client(), StaticToken(""), WithRetries(DefaultRetryOptions))
+		c := WrapWithTokenSource(s.Client(), StaticToken(""), WithRetries(DefaultRetryOptions))
 		_, err := c.Get(s.URL)
 
 		assert.Error(t, err)
@@ -113,7 +113,7 @@ func TestRetries(t *testing.T) {
 		})
 
 		s := httptest.NewTLSServer(h)
-		c := Wrap(http.DefaultClient, StaticToken(""), WithRetries(DefaultRetryOptions))
+		c := WrapWithTokenSource(http.DefaultClient, StaticToken(""), WithRetries(DefaultRetryOptions))
 		_, err := c.Get(s.URL)
 
 		elapsed := time.Since(start).Milliseconds()
@@ -142,7 +142,7 @@ func TestRetries(t *testing.T) {
 		s := httptest.NewServer(h)
 		defer s.Close()
 
-		c := Wrap(s.Client(), StaticToken(""), WithRetries(DefaultRetryOptions))
+		c := WrapWithTokenSource(s.Client(), StaticToken(""), WithRetries(DefaultRetryOptions))
 		r, err := c.Get(s.URL)
 		assert.NoError(t, err)
 
@@ -174,7 +174,7 @@ func TestRetries(t *testing.T) {
 		s := httptest.NewServer(h)
 		defer s.Close()
 
-		c := Wrap(s.Client(), StaticToken(""), WithRetries(DefaultRetryOptions))
+		c := WrapWithTokenSource(s.Client(), StaticToken(""), WithRetries(DefaultRetryOptions))
 		r, err := c.Get(s.URL)
 		assert.NoError(t, err)
 
@@ -198,7 +198,7 @@ func TestWrapUserAgent(t *testing.T) {
 	testServer := httptest.NewServer(testHandler)
 	defer testServer.Close()
 
-	httpClient := Wrap(testServer.Client(), StaticToken(""), WithUserAgent(UserAgent))
+	httpClient := WrapWithTokenSource(testServer.Client(), StaticToken(""), WithUserAgent(UserAgent))
 	_, err := httpClient.Get(testServer.URL)
 	assert.NoError(t, err)
 }
@@ -256,7 +256,7 @@ func TestWrapAuth0ClientInfo(t *testing.T) {
 			testServer.Close()
 		})
 
-		httpClient := Wrap(testServer.Client(), StaticToken(""), WithAuth0ClientInfo(DefaultAuth0ClientInfo))
+		httpClient := WrapWithTokenSource(testServer.Client(), StaticToken(""), WithAuth0ClientInfo(DefaultAuth0ClientInfo))
 		_, err := httpClient.Get(testServer.URL)
 		assert.NoError(t, err)
 	})
@@ -290,7 +290,7 @@ func TestWrapAuth0ClientInfo(t *testing.T) {
 				testServer.Close()
 			})
 
-			httpClient := Wrap(testServer.Client(), StaticToken(""), WithAuth0ClientInfo(&testCase.given))
+			httpClient := WrapWithTokenSource(testServer.Client(), StaticToken(""), WithAuth0ClientInfo(&testCase.given))
 			_, err := httpClient.Get(testServer.URL)
 			assert.NoError(t, err)
 		})

--- a/management/management.go
+++ b/management/management.go
@@ -147,7 +147,7 @@ func New(domain string, options ...Option) (*Management, error) {
 		option(m)
 	}
 
-	m.http = client.Wrap(
+	m.http = client.WrapWithTokenSource(
 		m.http,
 		m.tokenSource,
 		client.WithDebug(m.debug),


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

By default the client information sent is for the go-auth0 package, it can be disabled using `WithNoAuth0ClientInfo` on an `authentication.New` call, and the `env` data can be added to by using the `WithAuth0ClientEnvEntry` on a `authentication.New`

### 📚 References

Based on #164

### 🔬 Testing

Validated it shows in the manage logs

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
