### PR TITLE
[SDK-4330] Add retry support and configuration to the authentication client

### DIFF
--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -126,6 +126,7 @@ type Authentication struct {
 	idTokenSigningAlg     string
 	idTokenValidator      *idtokenvalidator.IDTokenValidator
 	url                   *url.URL
+	retryStrategy         client.RetryOptions
 }
 
 type manager struct {
@@ -153,6 +154,7 @@ func New(ctx context.Context, domain string, options ...Option) (*Authentication
 		http:              http.DefaultClient,
 		auth0ClientInfo:   client.DefaultAuth0ClientInfo,
 		idTokenSigningAlg: "RS256",
+		retryStrategy:     client.DefaultRetryOptions,
 	}
 
 	for _, option := range options {
@@ -163,6 +165,7 @@ func New(ctx context.Context, domain string, options ...Option) (*Authentication
 		a.http,
 		client.WithDebug(a.debug),
 		client.WithAuth0ClientInfo(a.auth0ClientInfo),
+		client.WithRetries(a.retryStrategy),
 	)
 
 	a.common.authentication = a

--- a/authentication/authentication_option.go
+++ b/authentication/authentication_option.go
@@ -74,3 +74,20 @@ func WithAuth0ClientEnvEntry(key string, value string) Option {
 		}
 	}
 }
+
+// WithRetries configures the management client to only retry under the conditions provided.
+func WithRetries(maxRetries int, statuses []int) Option {
+	return func(a *Authentication) {
+		a.retryStrategy = client.RetryOptions{
+			MaxRetries: maxRetries,
+			Statuses:   statuses,
+		}
+	}
+}
+
+// WithNoRetries configures the management client to only retry under the conditions provided.
+func WithNoRetries() Option {
+	return func(a *Authentication) {
+		a.retryStrategy = client.RetryOptions{}
+	}
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Exposes configuring the retry logic on the authentication client, similar to the management client, 
by default it will retry a request 2 times, when there is a 429 status code or if there is an error 
returned (except for a select couple of errors that are not recoverable). The X-RateLimit-Reset
is consulted to ensure that the request will work, unless the time until the request is more than 
the maximum wait time.

The configuration of the max retries and status codes that will be retried on by providing a
RetryOptions struct with the required values with the WithRetryOptions function, and retries
can be disabled by passing the WithNoRetries function

### 📚 References

Based on #216

### 🔬 Testing


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
