### PR TITLE
[SDK-4220] Remove no longer supported connection strategies

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -220,12 +220,12 @@ Some APIs have been renamed or removed in order to ensure consistency in the SDK
 |-----------|--------------|--------------|
 |`Organization.DeleteMember`|Renamed to align with other APIs|`Organization.DeleteMembers`|
 |`ResourceServer.Stream`|Removed to allow potential for consistent pagination functionality across the SDK| Implement pagination manually similar to other APIs|
-|`ConnectionStrategyDiscord`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
-|`ConnectionStrategyImgur`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
-|`ConnectionStrategySpotify`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
-|`ConnectionStrategyFigma`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
-|`ConnectionStrategySlack`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
 |`ConnectionStrategyDigitalOcean`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategyDiscord`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategyFigma`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategyImgur`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategySlack`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategySpotify`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
 |`ConnectionStrategyTwitch`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
 |`ConnectionStrategyVimeo`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -220,6 +220,14 @@ Some APIs have been renamed or removed in order to ensure consistency in the SDK
 |-----------|--------------|--------------|
 |`Organization.DeleteMember`|Renamed to align with other APIs|`Organization.DeleteMembers`|
 |`ResourceServer.Stream`|Removed to allow potential for consistent pagination functionality across the SDK| Implement pagination manually similar to other APIs|
+|`ConnectionStrategyDiscord`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategyImgur`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategySpotify`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategyFigma`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategySlack`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategyDigitalOcean`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategyTwitch`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
+|`ConnectionStrategyVimeo`|No longer supported as a strategy type|Use the `ConnectionStrategyOAuth2` strategy|
 
 ### Changes To Default User Agent
 

--- a/management/connection.go
+++ b/management/connection.go
@@ -67,24 +67,8 @@ const (
 	ConnectionStrategyBox = "box"
 	// ConnectionStrategyWordpress constant.
 	ConnectionStrategyWordpress = "wordpress"
-	// ConnectionStrategyDiscord constant.
-	ConnectionStrategyDiscord = "discord"
-	// ConnectionStrategyImgur constant.
-	ConnectionStrategyImgur = "imgur"
-	// ConnectionStrategySpotify constant.
-	ConnectionStrategySpotify = "spotify"
 	// ConnectionStrategyShopify constant.
 	ConnectionStrategyShopify = "shopify"
-	// ConnectionStrategyFigma constant.
-	ConnectionStrategyFigma = "figma"
-	// ConnectionStrategySlack constant.
-	ConnectionStrategySlack = "slack-oauth-2"
-	// ConnectionStrategyDigitalOcean constant.
-	ConnectionStrategyDigitalOcean = "digitalocean"
-	// ConnectionStrategyTwitch constant.
-	ConnectionStrategyTwitch = "twitch"
-	// ConnectionStrategyVimeo constant.
-	ConnectionStrategyVimeo = "vimeo"
 	// ConnectionStrategyCustom constant.
 	ConnectionStrategyCustom = "custom"
 	// ConnectionStrategyPingFederate constant.
@@ -220,15 +204,7 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 			ConnectionStrategyYahoo,
 			ConnectionStrategyBox,
 			ConnectionStrategyWordpress,
-			ConnectionStrategyDiscord,
-			ConnectionStrategyImgur,
-			ConnectionStrategySpotify,
 			ConnectionStrategyShopify,
-			ConnectionStrategyFigma,
-			ConnectionStrategySlack,
-			ConnectionStrategyDigitalOcean,
-			ConnectionStrategyTwitch,
-			ConnectionStrategyVimeo,
 			ConnectionStrategyCustom:
 			v = &ConnectionOptionsOAuth2{}
 		case ConnectionStrategyAD:


### PR DESCRIPTION
### 🔧 Changes

Removes the following connection strategies are they are no longer supported and will be rejected by the API if used.

- DigitalOcean
- Discord
- Figma
- Imgur
- Slack
- Spotify
- Twitch
- Vimeo

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
