### PR TITLE
Add docs for passwordless request and response properties

### DIFF
--- a/authentication/passwordless/passwordless.go
+++ b/authentication/passwordless/passwordless.go
@@ -5,52 +5,71 @@ import "github.com/auth0/go-auth0/authentication/oauth"
 // SendEmailRequest defines the request body for starting a passwordless flow via email.
 type SendEmailRequest struct {
 	oauth.ClientAuthentication
-	Connection string                 `json:"connection,omitempty"`
-	Email      string                 `json:"email,omitempty"`
-	Send       string                 `json:"send,omitempty"`
+	Connection string `json:"connection,omitempty"`
+	// The users's email address.
+	Email string `json:"email,omitempty"`
+	// Use `link` to send a link or `code` to send a verification code. If omitted, a `link` will be sent.
+	Send string `json:"send,omitempty"`
+	// Append or override the link parameters (like scope, redirect_uri, protocol, response_type), when you send a link.
 	AuthParams map[string]interface{} `json:"authParams,omitempty"`
 }
 
 // SendEmailResponse defines the response from the `SendEmail` request.
 type SendEmailResponse struct {
-	ID            string `json:"_id,omitempty"`
-	Email         string `json:"email,omitempty"`
-	EmailVerified bool   `json:"email_verified,omitempty"`
+	// The identifier of the request.
+	ID string `json:"_id,omitempty"`
+	// The user's email address.
+	Email string `json:"email,omitempty"`
+	// Whether the user's email address is verified.
+	EmailVerified bool `json:"email_verified,omitempty"`
 }
 
 // LoginWithEmailRequest defines the request body for exchanging a code requested by `SendEmail` for a token.
 type LoginWithEmailRequest struct {
 	oauth.ClientAuthentication
-	Audience  string `json:"audience,omitempty"`
-	Code      string `json:"otp,omitempty"`
+	// API Identifier of the API for which you want to get an Access Token.
+	Audience string `json:"audience,omitempty"`
+	// The user's verification code.
+	Code string `json:"otp,omitempty"`
+	// The user's email address.
 	Email     string `json:"username,omitempty"`
 	GrantType string `json:"grant_type,omitempty"`
 	Realm     string `json:"realm,omitempty"`
-	Scope     string `json:"scope,omitempty"`
+	// Use openid to get an ID Token, or openid profile email to also include user profile information in the ID Token.
+	Scope string `json:"scope,omitempty"`
 }
 
 // SendSMSRequest defines the request body for starting a passwordless flow via email.
 type SendSMSRequest struct {
 	oauth.ClientAuthentication
-	Connection  string                 `json:"connection,omitempty"`
-	PhoneNumber string                 `json:"phone_number,omitempty"`
-	AuthParams  map[string]interface{} `json:"authParams,omitempty"`
+	Connection string `json:"connection,omitempty"`
+	// The user's phone number.
+	PhoneNumber string `json:"phone_number,omitempty"`
+	// Append or override the link parameters (like scope, redirect_uri, protocol, response_type), when you send a link.
+	AuthParams map[string]interface{} `json:"authParams,omitempty"`
 }
 
 // SendSMSResponse defines the response from the `SendSMS` request.
 type SendSMSResponse struct {
-	ID            string `json:"_id,omitempty"`
-	PhoneNumber   string `json:"phone_number,omitempty"`
-	PhoneVerified bool   `json:"phone_verified,omitempty"`
+	// The identifier of the request.
+	ID string `json:"_id,omitempty"`
+	// The user's phone number.
+	PhoneNumber string `json:"phone_number,omitempty"`
+	// Whether the users phone number is verified.
+	PhoneVerified bool `json:"phone_verified,omitempty"`
 }
 
 // LoginWithSMSRequest defines the request body for exchanging a code requested by `SendSMS` for a token.
 type LoginWithSMSRequest struct {
 	oauth.ClientAuthentication
-	Audience    string `json:"audience,omitempty"`
-	Code        string `json:"otp,omitempty"`
+	// API Identifier of the API for which you want to get an Access Token.
+	Audience string `json:"audience,omitempty"`
+	// The user's verification code.
+	Code string `json:"otp,omitempty"`
+	// The user's phone number.
 	PhoneNumber string `json:"username,omitempty"`
 	GrantType   string `json:"grant_type,omitempty"`
 	Realm       string `json:"realm,omitempty"`
-	Scope       string `json:"scope,omitempty"`
+	// Use openid to get an ID Token, or openid profile email to also include user profile information in the ID Token.
+	Scope string `json:"scope,omitempty"`
 }

--- a/authentication/passwordless/passwordless.go
+++ b/authentication/passwordless/passwordless.go
@@ -10,7 +10,7 @@ type SendEmailRequest struct {
 	Email string `json:"email,omitempty"`
 	// Use `link` to send a link or `code` to send a verification code. If omitted, a `link` will be sent.
 	Send string `json:"send,omitempty"`
-	// Append or override the link parameters (like scope, redirect_uri, protocol, response_type), when you send a link.
+	// Append or override the link parameters (like `scope`, `redirect_uri`, `protocol`, `response_type`), when you send a link.
 	AuthParams map[string]interface{} `json:"authParams,omitempty"`
 }
 
@@ -27,7 +27,7 @@ type SendEmailResponse struct {
 // LoginWithEmailRequest defines the request body for exchanging a code requested by `SendEmail` for a token.
 type LoginWithEmailRequest struct {
 	oauth.ClientAuthentication
-	// API Identifier of the API for which you want to get an Access Token.
+	// API Identifier of the API for which you want to get an access token.
 	Audience string `json:"audience,omitempty"`
 	// The user's verification code.
 	Code string `json:"otp,omitempty"`
@@ -35,7 +35,7 @@ type LoginWithEmailRequest struct {
 	Email     string `json:"username,omitempty"`
 	GrantType string `json:"grant_type,omitempty"`
 	Realm     string `json:"realm,omitempty"`
-	// Use openid to get an ID Token, or openid profile email to also include user profile information in the ID Token.
+	// Use `openid` to get an ID token, or `openid profile email` to also include user profile information in the ID token.
 	Scope string `json:"scope,omitempty"`
 }
 
@@ -45,7 +45,7 @@ type SendSMSRequest struct {
 	Connection string `json:"connection,omitempty"`
 	// The user's phone number.
 	PhoneNumber string `json:"phone_number,omitempty"`
-	// Append or override the link parameters (like scope, redirect_uri, protocol, response_type), when you send a link.
+	// Append or override the link parameters (like `scope`, `redirect_uri`, `protocol`, `response_type`), when you send a link.
 	AuthParams map[string]interface{} `json:"authParams,omitempty"`
 }
 
@@ -62,7 +62,7 @@ type SendSMSResponse struct {
 // LoginWithSMSRequest defines the request body for exchanging a code requested by `SendSMS` for a token.
 type LoginWithSMSRequest struct {
 	oauth.ClientAuthentication
-	// API Identifier of the API for which you want to get an Access Token.
+	// API Identifier of the API for which you want to get an access token.
 	Audience string `json:"audience,omitempty"`
 	// The user's verification code.
 	Code string `json:"otp,omitempty"`
@@ -70,6 +70,6 @@ type LoginWithSMSRequest struct {
 	PhoneNumber string `json:"username,omitempty"`
 	GrantType   string `json:"grant_type,omitempty"`
 	Realm       string `json:"realm,omitempty"`
-	// Use openid to get an ID Token, or openid profile email to also include user profile information in the ID Token.
+	// Use `openid` to get an ID token, or `openid profile email` to also include user profile information in the ID token.
 	Scope string `json:"scope,omitempty"`
 }


### PR DESCRIPTION
### 🔧 Changes

Improves the documentation on properties in the passwordless response and request structs. Properties that a developer should not set themselves (`Connection`, `GrantType`, and `Realm`) have not had docs added.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
