### PR TITLE
Allow using a custom object when reading users

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -399,6 +399,15 @@ func (m *UserManager) Read(ctx context.Context, id string, opts ...RequestOption
 	return
 }
 
+// Read user details for a given user_id into the provided destination. This allows access
+// to custom or non-standard user properties on the user profile.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Users/get_users_by_id
+func (m *UserManager) ReadCustom(ctx context.Context, id string, destination any, opts ...RequestOption) (err error) {
+	err = m.management.Request(ctx, "GET", m.management.URI("users", id), destination, opts...)
+	return
+}
+
 // Update user.
 //
 // The following attributes can be updated at the root level:

--- a/test/data/recordings/TestUserManager_ReadCustom.yaml
+++ b/test/data/recordings/TestUserManager_ReadCustom.yaml
@@ -1,0 +1,110 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 480
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"connection":"Username-Password-Authentication","email":"chuck878@example.com","given_name":"Chuck","family_name":"Sanchez","username":"test-user636","nickname":"Chucky","password":"Passwords hide their chuck","user_metadata":{"favourite_attack":"roundhouse_kick"},"verify_email":false,"app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]},"picture":"https://example-picture-url.jpg","blocked":false,"email_verified":true}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 661
+        uncompressed: false
+        body: '{"blocked":false,"created_at":"2023-01-25T19:00:26.539Z","email":"chuck878@example.com","email_verified":true,"family_name":"Sanchez","given_name":"Chuck","identities":[{"connection":"Username-Password-Authentication","user_id":"63d17c4a9d503d76c056c160","provider":"auth0","isSocial":false}],"name":"chuck878@example.com","nickname":"Chucky","picture":"https://example-picture-url.jpg","updated_at":"2023-01-25T19:00:26.539Z","user_id":"auth0|63d17c4a9d503d76c056c160","user_metadata":{"favourite_attack":"roundhouse_kick"},"username":"test-user636","app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 230.616541ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C63d17c4a9d503d76c056c160
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"blocked":false,"created_at":"2023-01-25T19:00:26.539Z","email":"chuck878@example.com","email_verified":true,"family_name":"Sanchez","given_name":"Chuck","identities":[{"connection":"Username-Password-Authentication","user_id":"63d17c4a9d503d76c056c160","provider":"auth0","isSocial":false}],"name":"chuck878@example.com","nickname":"Chucky","picture":"https://example-picture-url.jpg","updated_at":"2023-01-25T19:00:26.539Z","user_id":"auth0|63d17c4a9d503d76c056c160","user_metadata":{"favourite_attack":"roundhouse_kick"},"username":"test-user636","app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 112.955666ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/latest
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C63d17c4a9d503d76c056c160
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 193.526ms


### PR DESCRIPTION
The new v1 interface made the underlying `Management` client private, no longer allowing a custom API client call by users of this library.

We used to have a custom method like this that allowed us to unmarshal additional fields on the user profile, such as `locale` or `upn`, which are present for some other connection types.

	// ReadUser is a wrapper to use our CustomUser type, but is otherwise identical to
	// calling `manager.ReadUser(subject)`.
	func (a *Auth0UserClient) ReadUser(ctx context.Context, subject string) (u *CustomUser, err error) {
		err = a.Users.Request("GET", a.Users.URI("users", subject), &u, management.Context(ctx))
		return
	}

We can no longer do this with the v1 library, as the `Request` and `URI` methods are now inaccessible.

Thus, implement a new ReadCustom method that allows passing in a destination object to unmarshal to. This pattern should be familiar to anyone that has called `json.Unmarshal`. As seen in the test, you can wrap the existing user with a custom object to add any fields your particular business logic requires.

Naming is hard- I went with `ReadCustom` but am more than open to any better naming suggestions on the method name.

Alternatives I considered but discarded - also willing to change course here if desired:
* It would be possible to add the UPN and Locale struct fields to the User object. However, we see many other fields come across from our WAAD connection (tenantid, job_title, etc.), and I am unable to enumerate them in every other connection type. I used https://auth0.com/docs/manage-users/user-accounts/user-profiles/sample-user-profiles to get an idea of what other connection types might have additional properties.
* Re-expose the underlying low-level client in some way?
* Add a `OtherProperties map[string]interface{}` to the `User` object, and implement custom unmarshalling logic to put any unknown properties there. This felt error prone.