### PR TITLE
[SDK-4483] Add all known options to ad, adfs, pingfederate, saml, and waad (v0)

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -883,6 +883,11 @@ type ConnectionOptionsAD struct {
 	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`
 
 	UpstreamParams map[string]interface{} `json:"upstream_params,omitempty"`
+
+	Certs        *[]string `json:"certs,omitempty"`
+	AgentIP      *string   `json:"agentIP,omitempty"`
+	AgentVersion *string   `json:"agentVersion,omitempty"`
+	AgentMode    *bool     `json:"agentMode,omitempty"`
 }
 
 // ConnectionOptionsAzureAD is used to configure an AzureAD Connection.
@@ -920,6 +925,12 @@ type ConnectionOptionsAzureAD struct {
 	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`
 
 	UpstreamParams map[string]interface{} `json:"upstream_params,omitempty"`
+
+	AppDomain                *string   `json:"app_domain,omitempty"`
+	Thumbprints              *[]string `json:"thumbprints,omitempty"`
+	CertRolloverNotification *string   `json:"cert_rollover_notification,omitempty"`
+	Granted                  *bool     `json:"granted,omitempty"`
+	TenantID                 *string   `json:"tenantId,omitempty"`
 }
 
 // Scopes returns the scopes for ConnectionOptionsAzureAD.
@@ -948,6 +959,10 @@ type ConnectionOptionsADFS struct {
 
 	// Set to on_first_login to avoid setting user attributes at each login.
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
+
+	EntityID                 *string   `json:"entityID,omitempty"`
+	CertRolloverNotification *string   `json:"cert_rollover_notification,omitempty"`
+	PreviousThumbprints      *[]string `json:"prev_thumprints,omitempty"`
 }
 
 // ConnectionOptionsPingFederate is used to configure a Ping Federate Connection.
@@ -972,6 +987,30 @@ type ConnectionOptionsPingFederate struct {
 	NonPersistentAttrs  *[]string                          `json:"non_persistent_attrs,omitempty"`
 	UpstreamParams      map[string]interface{}             `json:"upstream_params,omitempty"`
 	SetUserAttributes   *string                            `json:"set_user_root_attributes,omitempty"`
+
+	APIEnableUsers           *bool                               `json:"api_enable_users,omitempty"`
+	SignOutEndpoint          *string                             `json:"signOuEndpoint,omitempty"`
+	Subject                  map[string]interface{}              `json:"subject,omitempty"`
+	DisableSignout           *bool                               `json:"disableSignout,omitempty"`
+	UserIDAttribute          *string                             `json:"user_id_attribute,omitempty"`
+	Debug                    *bool                               `json:"debug,omitempty"`
+	ProtocolBinding          *string                             `json:"protocolBinding,omitempty"`
+	RequestTemplate          *string                             `json:"requestTemplate,omitempty"`
+	BindingMethod            *string                             `json:"bindingMethod,omitempty"`
+	Thumbprints              *[]string                           `json:"thumbprints,omitempty"`
+	Expires                  *string                             `json:"expires,omitempty"`
+	MetadataURL              *string                             `json:"metadataUrl,omitempty"`
+	FieldsMap                map[string]interface{}              `json:"fields_map,omitempty"`
+	MetadataXML              *string                             `json:"metadataXml,omitempty"`
+	EntityID                 *string                             `json:"entityId,omitempty"`
+	CertRolloverNotification *string                             `json:"cert_rollover_notification,omitempty"`
+	SigningKey               *ConnectionOptionsSAMLSigningKey    `json:"signing_key,omitempty"`
+	DecryptionKey            *ConnectionOptionsSAMLDecryptionKey `json:"decryption_key,omitempty"`
+	AgentIP                  *string                             `json:"agentIP,omitempty"`
+	AgentVersion             *string                             `json:"agentVersion,omitempty"`
+	AgentMode                *bool                               `json:"agentMode,omitempty"`
+	ExtGroups                *bool                               `json:"ext_groups,omitempty"`
+	ExtProfile               *bool                               `json:"ext_profile,omitempty"`
 }
 
 // ConnectionOptionsSAML is used to configure a SAML Connection.
@@ -1001,6 +1040,14 @@ type ConnectionOptionsSAML struct {
 	UserIDAttribute    *string                             `json:"user_id_attribute,omitempty"`
 	LogoURL            *string                             `json:"icon_url,omitempty"`
 	EntityID           *string                             `json:"entityId,omitempty"`
+
+	BindingMethod            *string `json:"binding_method,omitempty"`
+	CertRolloverNotification *string `json:"cert_rollover_notification,omitempty"`
+	AgentIP                  *string `json:"agentIP,omitempty"`
+	AgentVersion             *string `json:"agentVersion,omitempty"`
+	AgentMode                *bool   `json:"agentMode,omitempty"`
+	ExtGroups                *bool   `json:"ext_groups,omitempty"`
+	ExtProfile               *bool   `json:"ext_profile,omitempty"`
 
 	SetUserAttributes  *string   `json:"set_user_root_attributes,omitempty"`
 	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1739,6 +1739,30 @@ func (c *ConnectionOptions) String() string {
 	return Stringify(c)
 }
 
+// GetAgentIP returns the AgentIP field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetAgentIP() string {
+	if c == nil || c.AgentIP == nil {
+		return ""
+	}
+	return *c.AgentIP
+}
+
+// GetAgentMode returns the AgentMode field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetAgentMode() bool {
+	if c == nil || c.AgentMode == nil {
+		return false
+	}
+	return *c.AgentMode
+}
+
+// GetAgentVersion returns the AgentVersion field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetAgentVersion() string {
+	if c == nil || c.AgentVersion == nil {
+		return ""
+	}
+	return *c.AgentVersion
+}
+
 // GetBruteForceProtection returns the BruteForceProtection field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsAD) GetBruteForceProtection() bool {
 	if c == nil || c.BruteForceProtection == nil {
@@ -1753,6 +1777,14 @@ func (c *ConnectionOptionsAD) GetCertAuth() bool {
 		return false
 	}
 	return *c.CertAuth
+}
+
+// GetCerts returns the Certs field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetCerts() []string {
+	if c == nil || c.Certs == nil {
+		return nil
+	}
+	return *c.Certs
 }
 
 // GetDisableCache returns the DisableCache field if it's non-nil, zero value otherwise.
@@ -1832,6 +1864,14 @@ func (c *ConnectionOptionsADFS) GetADFSServer() string {
 	return *c.ADFSServer
 }
 
+// GetCertRolloverNotification returns the CertRolloverNotification field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetCertRolloverNotification() string {
+	if c == nil || c.CertRolloverNotification == nil {
+		return ""
+	}
+	return *c.CertRolloverNotification
+}
+
 // GetDomainAliases returns the DomainAliases field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsADFS) GetDomainAliases() []string {
 	if c == nil || c.DomainAliases == nil {
@@ -1846,6 +1886,14 @@ func (c *ConnectionOptionsADFS) GetEnableUsersAPI() bool {
 		return false
 	}
 	return *c.EnableUsersAPI
+}
+
+// GetEntityID returns the EntityID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetEntityID() string {
+	if c == nil || c.EntityID == nil {
+		return ""
+	}
+	return *c.EntityID
 }
 
 // GetFedMetadataXML returns the FedMetadataXML field if it's non-nil, zero value otherwise.
@@ -1870,6 +1918,14 @@ func (c *ConnectionOptionsADFS) GetNonPersistentAttrs() []string {
 		return nil
 	}
 	return *c.NonPersistentAttrs
+}
+
+// GetPreviousThumbprints returns the PreviousThumbprints field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetPreviousThumbprints() []string {
+	if c == nil || c.PreviousThumbprints == nil {
+		return nil
+	}
+	return *c.PreviousThumbprints
 }
 
 // GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
@@ -2010,6 +2066,14 @@ func (c *ConnectionOptionsAzureAD) GetAgreedTerms() bool {
 	return *c.AgreedTerms
 }
 
+// GetAppDomain returns the AppDomain field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetAppDomain() string {
+	if c == nil || c.AppDomain == nil {
+		return ""
+	}
+	return *c.AppDomain
+}
+
 // GetAppID returns the AppID field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsAzureAD) GetAppID() string {
 	if c == nil || c.AppID == nil {
@@ -2032,6 +2096,14 @@ func (c *ConnectionOptionsAzureAD) GetBasicProfile() bool {
 		return false
 	}
 	return *c.BasicProfile
+}
+
+// GetCertRolloverNotification returns the CertRolloverNotification field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetCertRolloverNotification() string {
+	if c == nil || c.CertRolloverNotification == nil {
+		return ""
+	}
+	return *c.CertRolloverNotification
 }
 
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
@@ -2080,6 +2152,14 @@ func (c *ConnectionOptionsAzureAD) GetExtendedProfile() bool {
 		return false
 	}
 	return *c.ExtendedProfile
+}
+
+// GetGranted returns the Granted field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetGranted() bool {
+	if c == nil || c.Granted == nil {
+		return false
+	}
+	return *c.Granted
 }
 
 // GetGroups returns the Groups field if it's non-nil, zero value otherwise.
@@ -2152,6 +2232,22 @@ func (c *ConnectionOptionsAzureAD) GetTenantDomain() string {
 		return ""
 	}
 	return *c.TenantDomain
+}
+
+// GetTenantID returns the TenantID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetTenantID() string {
+	if c == nil || c.TenantID == nil {
+		return ""
+	}
+	return *c.TenantID
+}
+
+// GetThumbprints returns the Thumbprints field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetThumbprints() []string {
+	if c == nil || c.Thumbprints == nil {
+		return nil
+	}
+	return *c.Thumbprints
 }
 
 // GetTrustEmailVerified returns the TrustEmailVerified field if it's non-nil, zero value otherwise.
@@ -3686,12 +3782,76 @@ func (c *ConnectionOptionsOTP) String() string {
 	return Stringify(c)
 }
 
+// GetAgentIP returns the AgentIP field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetAgentIP() string {
+	if c == nil || c.AgentIP == nil {
+		return ""
+	}
+	return *c.AgentIP
+}
+
+// GetAgentMode returns the AgentMode field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetAgentMode() bool {
+	if c == nil || c.AgentMode == nil {
+		return false
+	}
+	return *c.AgentMode
+}
+
+// GetAgentVersion returns the AgentVersion field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetAgentVersion() string {
+	if c == nil || c.AgentVersion == nil {
+		return ""
+	}
+	return *c.AgentVersion
+}
+
+// GetAPIEnableUsers returns the APIEnableUsers field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetAPIEnableUsers() bool {
+	if c == nil || c.APIEnableUsers == nil {
+		return false
+	}
+	return *c.APIEnableUsers
+}
+
+// GetBindingMethod returns the BindingMethod field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetBindingMethod() string {
+	if c == nil || c.BindingMethod == nil {
+		return ""
+	}
+	return *c.BindingMethod
+}
+
 // GetCert returns the Cert field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsPingFederate) GetCert() string {
 	if c == nil || c.Cert == nil {
 		return ""
 	}
 	return *c.Cert
+}
+
+// GetCertRolloverNotification returns the CertRolloverNotification field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetCertRolloverNotification() string {
+	if c == nil || c.CertRolloverNotification == nil {
+		return ""
+	}
+	return *c.CertRolloverNotification
+}
+
+// GetDebug returns the Debug field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetDebug() bool {
+	if c == nil || c.Debug == nil {
+		return false
+	}
+	return *c.Debug
+}
+
+// GetDecryptionKey returns the DecryptionKey field.
+func (c *ConnectionOptionsPingFederate) GetDecryptionKey() *ConnectionOptionsSAMLDecryptionKey {
+	if c == nil {
+		return nil
+	}
+	return c.DecryptionKey
 }
 
 // GetDigestAlgorithm returns the DigestAlgorithm field if it's non-nil, zero value otherwise.
@@ -3702,12 +3862,52 @@ func (c *ConnectionOptionsPingFederate) GetDigestAlgorithm() string {
 	return *c.DigestAlgorithm
 }
 
+// GetDisableSignout returns the DisableSignout field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetDisableSignout() bool {
+	if c == nil || c.DisableSignout == nil {
+		return false
+	}
+	return *c.DisableSignout
+}
+
 // GetDomainAliases returns the DomainAliases field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsPingFederate) GetDomainAliases() []string {
 	if c == nil || c.DomainAliases == nil {
 		return nil
 	}
 	return *c.DomainAliases
+}
+
+// GetEntityID returns the EntityID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetEntityID() string {
+	if c == nil || c.EntityID == nil {
+		return ""
+	}
+	return *c.EntityID
+}
+
+// GetExpires returns the Expires field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetExpires() string {
+	if c == nil || c.Expires == nil {
+		return ""
+	}
+	return *c.Expires
+}
+
+// GetExtGroups returns the ExtGroups field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetExtGroups() bool {
+	if c == nil || c.ExtGroups == nil {
+		return false
+	}
+	return *c.ExtGroups
+}
+
+// GetExtProfile returns the ExtProfile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetExtProfile() bool {
+	if c == nil || c.ExtProfile == nil {
+		return false
+	}
+	return *c.ExtProfile
 }
 
 // GetIdpInitiated returns the IdpInitiated field.
@@ -3726,6 +3926,22 @@ func (c *ConnectionOptionsPingFederate) GetLogoURL() string {
 	return *c.LogoURL
 }
 
+// GetMetadataURL returns the MetadataURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetMetadataURL() string {
+	if c == nil || c.MetadataURL == nil {
+		return ""
+	}
+	return *c.MetadataURL
+}
+
+// GetMetadataXML returns the MetadataXML field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetMetadataXML() string {
+	if c == nil || c.MetadataXML == nil {
+		return ""
+	}
+	return *c.MetadataXML
+}
+
 // GetNonPersistentAttrs returns the NonPersistentAttrs field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsPingFederate) GetNonPersistentAttrs() []string {
 	if c == nil || c.NonPersistentAttrs == nil {
@@ -3740,6 +3956,22 @@ func (c *ConnectionOptionsPingFederate) GetPingFederateBaseURL() string {
 		return ""
 	}
 	return *c.PingFederateBaseURL
+}
+
+// GetProtocolBinding returns the ProtocolBinding field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetProtocolBinding() string {
+	if c == nil || c.ProtocolBinding == nil {
+		return ""
+	}
+	return *c.ProtocolBinding
+}
+
+// GetRequestTemplate returns the RequestTemplate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetRequestTemplate() string {
+	if c == nil || c.RequestTemplate == nil {
+		return ""
+	}
+	return *c.RequestTemplate
 }
 
 // GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
@@ -3774,6 +4006,22 @@ func (c *ConnectionOptionsPingFederate) GetSigningCert() string {
 	return *c.SigningCert
 }
 
+// GetSigningKey returns the SigningKey field.
+func (c *ConnectionOptionsPingFederate) GetSigningKey() *ConnectionOptionsSAMLSigningKey {
+	if c == nil {
+		return nil
+	}
+	return c.SigningKey
+}
+
+// GetSignOutEndpoint returns the SignOutEndpoint field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetSignOutEndpoint() string {
+	if c == nil || c.SignOutEndpoint == nil {
+		return ""
+	}
+	return *c.SignOutEndpoint
+}
+
 // GetSignSAMLRequest returns the SignSAMLRequest field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsPingFederate) GetSignSAMLRequest() bool {
 	if c == nil || c.SignSAMLRequest == nil {
@@ -3788,6 +4036,22 @@ func (c *ConnectionOptionsPingFederate) GetTenantDomain() string {
 		return ""
 	}
 	return *c.TenantDomain
+}
+
+// GetThumbprints returns the Thumbprints field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetThumbprints() []string {
+	if c == nil || c.Thumbprints == nil {
+		return nil
+	}
+	return *c.Thumbprints
+}
+
+// GetUserIDAttribute returns the UserIDAttribute field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPingFederate) GetUserIDAttribute() string {
+	if c == nil || c.UserIDAttribute == nil {
+		return ""
+	}
+	return *c.UserIDAttribute
 }
 
 // String returns a string representation of ConnectionOptionsPingFederate.
@@ -3848,12 +4112,52 @@ func (c *ConnectionOptionsSalesforce) String() string {
 	return Stringify(c)
 }
 
+// GetAgentIP returns the AgentIP field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetAgentIP() string {
+	if c == nil || c.AgentIP == nil {
+		return ""
+	}
+	return *c.AgentIP
+}
+
+// GetAgentMode returns the AgentMode field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetAgentMode() bool {
+	if c == nil || c.AgentMode == nil {
+		return false
+	}
+	return *c.AgentMode
+}
+
+// GetAgentVersion returns the AgentVersion field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetAgentVersion() string {
+	if c == nil || c.AgentVersion == nil {
+		return ""
+	}
+	return *c.AgentVersion
+}
+
+// GetBindingMethod returns the BindingMethod field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetBindingMethod() string {
+	if c == nil || c.BindingMethod == nil {
+		return ""
+	}
+	return *c.BindingMethod
+}
+
 // GetCert returns the Cert field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSAML) GetCert() string {
 	if c == nil || c.Cert == nil {
 		return ""
 	}
 	return *c.Cert
+}
+
+// GetCertRolloverNotification returns the CertRolloverNotification field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetCertRolloverNotification() string {
+	if c == nil || c.CertRolloverNotification == nil {
+		return ""
+	}
+	return *c.CertRolloverNotification
 }
 
 // GetDebug returns the Debug field if it's non-nil, zero value otherwise.
@@ -3910,6 +4214,22 @@ func (c *ConnectionOptionsSAML) GetExpires() string {
 		return ""
 	}
 	return *c.Expires
+}
+
+// GetExtGroups returns the ExtGroups field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetExtGroups() bool {
+	if c == nil || c.ExtGroups == nil {
+		return false
+	}
+	return *c.ExtGroups
+}
+
+// GetExtProfile returns the ExtProfile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetExtProfile() bool {
+	if c == nil || c.ExtProfile == nil {
+		return false
+	}
+	return *c.ExtProfile
 }
 
 // GetIdpInitiated returns the IdpInitiated field.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2205,6 +2205,36 @@ func TestConnectionOptions_String(t *testing.T) {
 	}
 }
 
+func TestConnectionOptionsAD_GetAgentIP(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsAD{AgentIP: &zeroValue}
+	c.GetAgentIP()
+	c = &ConnectionOptionsAD{}
+	c.GetAgentIP()
+	c = nil
+	c.GetAgentIP()
+}
+
+func TestConnectionOptionsAD_GetAgentMode(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsAD{AgentMode: &zeroValue}
+	c.GetAgentMode()
+	c = &ConnectionOptionsAD{}
+	c.GetAgentMode()
+	c = nil
+	c.GetAgentMode()
+}
+
+func TestConnectionOptionsAD_GetAgentVersion(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsAD{AgentVersion: &zeroValue}
+	c.GetAgentVersion()
+	c = &ConnectionOptionsAD{}
+	c.GetAgentVersion()
+	c = nil
+	c.GetAgentVersion()
+}
+
 func TestConnectionOptionsAD_GetBruteForceProtection(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptionsAD{BruteForceProtection: &zeroValue}
@@ -2223,6 +2253,16 @@ func TestConnectionOptionsAD_GetCertAuth(tt *testing.T) {
 	c.GetCertAuth()
 	c = nil
 	c.GetCertAuth()
+}
+
+func TestConnectionOptionsAD_GetCerts(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsAD{Certs: &zeroValue}
+	c.GetCerts()
+	c = &ConnectionOptionsAD{}
+	c.GetCerts()
+	c = nil
+	c.GetCerts()
 }
 
 func TestConnectionOptionsAD_GetDisableCache(tt *testing.T) {
@@ -2323,6 +2363,16 @@ func TestConnectionOptionsADFS_GetADFSServer(tt *testing.T) {
 	c.GetADFSServer()
 }
 
+func TestConnectionOptionsADFS_GetCertRolloverNotification(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsADFS{CertRolloverNotification: &zeroValue}
+	c.GetCertRolloverNotification()
+	c = &ConnectionOptionsADFS{}
+	c.GetCertRolloverNotification()
+	c = nil
+	c.GetCertRolloverNotification()
+}
+
 func TestConnectionOptionsADFS_GetDomainAliases(tt *testing.T) {
 	var zeroValue []string
 	c := &ConnectionOptionsADFS{DomainAliases: &zeroValue}
@@ -2341,6 +2391,16 @@ func TestConnectionOptionsADFS_GetEnableUsersAPI(tt *testing.T) {
 	c.GetEnableUsersAPI()
 	c = nil
 	c.GetEnableUsersAPI()
+}
+
+func TestConnectionOptionsADFS_GetEntityID(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsADFS{EntityID: &zeroValue}
+	c.GetEntityID()
+	c = &ConnectionOptionsADFS{}
+	c.GetEntityID()
+	c = nil
+	c.GetEntityID()
 }
 
 func TestConnectionOptionsADFS_GetFedMetadataXML(tt *testing.T) {
@@ -2371,6 +2431,16 @@ func TestConnectionOptionsADFS_GetNonPersistentAttrs(tt *testing.T) {
 	c.GetNonPersistentAttrs()
 	c = nil
 	c.GetNonPersistentAttrs()
+}
+
+func TestConnectionOptionsADFS_GetPreviousThumbprints(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsADFS{PreviousThumbprints: &zeroValue}
+	c.GetPreviousThumbprints()
+	c = &ConnectionOptionsADFS{}
+	c.GetPreviousThumbprints()
+	c = nil
+	c.GetPreviousThumbprints()
 }
 
 func TestConnectionOptionsADFS_GetSetUserAttributes(tt *testing.T) {
@@ -2549,6 +2619,16 @@ func TestConnectionOptionsAzureAD_GetAgreedTerms(tt *testing.T) {
 	c.GetAgreedTerms()
 }
 
+func TestConnectionOptionsAzureAD_GetAppDomain(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsAzureAD{AppDomain: &zeroValue}
+	c.GetAppDomain()
+	c = &ConnectionOptionsAzureAD{}
+	c.GetAppDomain()
+	c = nil
+	c.GetAppDomain()
+}
+
 func TestConnectionOptionsAzureAD_GetAppID(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsAzureAD{AppID: &zeroValue}
@@ -2577,6 +2657,16 @@ func TestConnectionOptionsAzureAD_GetBasicProfile(tt *testing.T) {
 	c.GetBasicProfile()
 	c = nil
 	c.GetBasicProfile()
+}
+
+func TestConnectionOptionsAzureAD_GetCertRolloverNotification(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsAzureAD{CertRolloverNotification: &zeroValue}
+	c.GetCertRolloverNotification()
+	c = &ConnectionOptionsAzureAD{}
+	c.GetCertRolloverNotification()
+	c = nil
+	c.GetCertRolloverNotification()
 }
 
 func TestConnectionOptionsAzureAD_GetClientID(tt *testing.T) {
@@ -2637,6 +2727,16 @@ func TestConnectionOptionsAzureAD_GetExtendedProfile(tt *testing.T) {
 	c.GetExtendedProfile()
 	c = nil
 	c.GetExtendedProfile()
+}
+
+func TestConnectionOptionsAzureAD_GetGranted(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsAzureAD{Granted: &zeroValue}
+	c.GetGranted()
+	c = &ConnectionOptionsAzureAD{}
+	c.GetGranted()
+	c = nil
+	c.GetGranted()
 }
 
 func TestConnectionOptionsAzureAD_GetGroups(tt *testing.T) {
@@ -2727,6 +2827,26 @@ func TestConnectionOptionsAzureAD_GetTenantDomain(tt *testing.T) {
 	c.GetTenantDomain()
 	c = nil
 	c.GetTenantDomain()
+}
+
+func TestConnectionOptionsAzureAD_GetTenantID(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsAzureAD{TenantID: &zeroValue}
+	c.GetTenantID()
+	c = &ConnectionOptionsAzureAD{}
+	c.GetTenantID()
+	c = nil
+	c.GetTenantID()
+}
+
+func TestConnectionOptionsAzureAD_GetThumbprints(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsAzureAD{Thumbprints: &zeroValue}
+	c.GetThumbprints()
+	c = &ConnectionOptionsAzureAD{}
+	c.GetThumbprints()
+	c = nil
+	c.GetThumbprints()
 }
 
 func TestConnectionOptionsAzureAD_GetTrustEmailVerified(tt *testing.T) {
@@ -4659,6 +4779,56 @@ func TestConnectionOptionsOTP_String(t *testing.T) {
 	}
 }
 
+func TestConnectionOptionsPingFederate_GetAgentIP(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{AgentIP: &zeroValue}
+	c.GetAgentIP()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetAgentIP()
+	c = nil
+	c.GetAgentIP()
+}
+
+func TestConnectionOptionsPingFederate_GetAgentMode(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsPingFederate{AgentMode: &zeroValue}
+	c.GetAgentMode()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetAgentMode()
+	c = nil
+	c.GetAgentMode()
+}
+
+func TestConnectionOptionsPingFederate_GetAgentVersion(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{AgentVersion: &zeroValue}
+	c.GetAgentVersion()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetAgentVersion()
+	c = nil
+	c.GetAgentVersion()
+}
+
+func TestConnectionOptionsPingFederate_GetAPIEnableUsers(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsPingFederate{APIEnableUsers: &zeroValue}
+	c.GetAPIEnableUsers()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetAPIEnableUsers()
+	c = nil
+	c.GetAPIEnableUsers()
+}
+
+func TestConnectionOptionsPingFederate_GetBindingMethod(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{BindingMethod: &zeroValue}
+	c.GetBindingMethod()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetBindingMethod()
+	c = nil
+	c.GetBindingMethod()
+}
+
 func TestConnectionOptionsPingFederate_GetCert(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsPingFederate{Cert: &zeroValue}
@@ -4667,6 +4837,33 @@ func TestConnectionOptionsPingFederate_GetCert(tt *testing.T) {
 	c.GetCert()
 	c = nil
 	c.GetCert()
+}
+
+func TestConnectionOptionsPingFederate_GetCertRolloverNotification(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{CertRolloverNotification: &zeroValue}
+	c.GetCertRolloverNotification()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetCertRolloverNotification()
+	c = nil
+	c.GetCertRolloverNotification()
+}
+
+func TestConnectionOptionsPingFederate_GetDebug(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsPingFederate{Debug: &zeroValue}
+	c.GetDebug()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetDebug()
+	c = nil
+	c.GetDebug()
+}
+
+func TestConnectionOptionsPingFederate_GetDecryptionKey(tt *testing.T) {
+	c := &ConnectionOptionsPingFederate{}
+	c.GetDecryptionKey()
+	c = nil
+	c.GetDecryptionKey()
 }
 
 func TestConnectionOptionsPingFederate_GetDigestAlgorithm(tt *testing.T) {
@@ -4679,6 +4876,16 @@ func TestConnectionOptionsPingFederate_GetDigestAlgorithm(tt *testing.T) {
 	c.GetDigestAlgorithm()
 }
 
+func TestConnectionOptionsPingFederate_GetDisableSignout(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsPingFederate{DisableSignout: &zeroValue}
+	c.GetDisableSignout()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetDisableSignout()
+	c = nil
+	c.GetDisableSignout()
+}
+
 func TestConnectionOptionsPingFederate_GetDomainAliases(tt *testing.T) {
 	var zeroValue []string
 	c := &ConnectionOptionsPingFederate{DomainAliases: &zeroValue}
@@ -4687,6 +4894,46 @@ func TestConnectionOptionsPingFederate_GetDomainAliases(tt *testing.T) {
 	c.GetDomainAliases()
 	c = nil
 	c.GetDomainAliases()
+}
+
+func TestConnectionOptionsPingFederate_GetEntityID(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{EntityID: &zeroValue}
+	c.GetEntityID()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetEntityID()
+	c = nil
+	c.GetEntityID()
+}
+
+func TestConnectionOptionsPingFederate_GetExpires(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{Expires: &zeroValue}
+	c.GetExpires()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetExpires()
+	c = nil
+	c.GetExpires()
+}
+
+func TestConnectionOptionsPingFederate_GetExtGroups(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsPingFederate{ExtGroups: &zeroValue}
+	c.GetExtGroups()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetExtGroups()
+	c = nil
+	c.GetExtGroups()
+}
+
+func TestConnectionOptionsPingFederate_GetExtProfile(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsPingFederate{ExtProfile: &zeroValue}
+	c.GetExtProfile()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetExtProfile()
+	c = nil
+	c.GetExtProfile()
 }
 
 func TestConnectionOptionsPingFederate_GetIdpInitiated(tt *testing.T) {
@@ -4704,6 +4951,26 @@ func TestConnectionOptionsPingFederate_GetLogoURL(tt *testing.T) {
 	c.GetLogoURL()
 	c = nil
 	c.GetLogoURL()
+}
+
+func TestConnectionOptionsPingFederate_GetMetadataURL(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{MetadataURL: &zeroValue}
+	c.GetMetadataURL()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetMetadataURL()
+	c = nil
+	c.GetMetadataURL()
+}
+
+func TestConnectionOptionsPingFederate_GetMetadataXML(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{MetadataXML: &zeroValue}
+	c.GetMetadataXML()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetMetadataXML()
+	c = nil
+	c.GetMetadataXML()
 }
 
 func TestConnectionOptionsPingFederate_GetNonPersistentAttrs(tt *testing.T) {
@@ -4724,6 +4991,26 @@ func TestConnectionOptionsPingFederate_GetPingFederateBaseURL(tt *testing.T) {
 	c.GetPingFederateBaseURL()
 	c = nil
 	c.GetPingFederateBaseURL()
+}
+
+func TestConnectionOptionsPingFederate_GetProtocolBinding(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{ProtocolBinding: &zeroValue}
+	c.GetProtocolBinding()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetProtocolBinding()
+	c = nil
+	c.GetProtocolBinding()
+}
+
+func TestConnectionOptionsPingFederate_GetRequestTemplate(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{RequestTemplate: &zeroValue}
+	c.GetRequestTemplate()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetRequestTemplate()
+	c = nil
+	c.GetRequestTemplate()
 }
 
 func TestConnectionOptionsPingFederate_GetSetUserAttributes(tt *testing.T) {
@@ -4766,6 +5053,23 @@ func TestConnectionOptionsPingFederate_GetSigningCert(tt *testing.T) {
 	c.GetSigningCert()
 }
 
+func TestConnectionOptionsPingFederate_GetSigningKey(tt *testing.T) {
+	c := &ConnectionOptionsPingFederate{}
+	c.GetSigningKey()
+	c = nil
+	c.GetSigningKey()
+}
+
+func TestConnectionOptionsPingFederate_GetSignOutEndpoint(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{SignOutEndpoint: &zeroValue}
+	c.GetSignOutEndpoint()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetSignOutEndpoint()
+	c = nil
+	c.GetSignOutEndpoint()
+}
+
 func TestConnectionOptionsPingFederate_GetSignSAMLRequest(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptionsPingFederate{SignSAMLRequest: &zeroValue}
@@ -4784,6 +5088,26 @@ func TestConnectionOptionsPingFederate_GetTenantDomain(tt *testing.T) {
 	c.GetTenantDomain()
 	c = nil
 	c.GetTenantDomain()
+}
+
+func TestConnectionOptionsPingFederate_GetThumbprints(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsPingFederate{Thumbprints: &zeroValue}
+	c.GetThumbprints()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetThumbprints()
+	c = nil
+	c.GetThumbprints()
+}
+
+func TestConnectionOptionsPingFederate_GetUserIDAttribute(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsPingFederate{UserIDAttribute: &zeroValue}
+	c.GetUserIDAttribute()
+	c = &ConnectionOptionsPingFederate{}
+	c.GetUserIDAttribute()
+	c = nil
+	c.GetUserIDAttribute()
 }
 
 func TestConnectionOptionsPingFederate_String(t *testing.T) {
@@ -4862,6 +5186,46 @@ func TestConnectionOptionsSalesforce_String(t *testing.T) {
 	}
 }
 
+func TestConnectionOptionsSAML_GetAgentIP(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsSAML{AgentIP: &zeroValue}
+	c.GetAgentIP()
+	c = &ConnectionOptionsSAML{}
+	c.GetAgentIP()
+	c = nil
+	c.GetAgentIP()
+}
+
+func TestConnectionOptionsSAML_GetAgentMode(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsSAML{AgentMode: &zeroValue}
+	c.GetAgentMode()
+	c = &ConnectionOptionsSAML{}
+	c.GetAgentMode()
+	c = nil
+	c.GetAgentMode()
+}
+
+func TestConnectionOptionsSAML_GetAgentVersion(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsSAML{AgentVersion: &zeroValue}
+	c.GetAgentVersion()
+	c = &ConnectionOptionsSAML{}
+	c.GetAgentVersion()
+	c = nil
+	c.GetAgentVersion()
+}
+
+func TestConnectionOptionsSAML_GetBindingMethod(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsSAML{BindingMethod: &zeroValue}
+	c.GetBindingMethod()
+	c = &ConnectionOptionsSAML{}
+	c.GetBindingMethod()
+	c = nil
+	c.GetBindingMethod()
+}
+
 func TestConnectionOptionsSAML_GetCert(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsSAML{Cert: &zeroValue}
@@ -4870,6 +5234,16 @@ func TestConnectionOptionsSAML_GetCert(tt *testing.T) {
 	c.GetCert()
 	c = nil
 	c.GetCert()
+}
+
+func TestConnectionOptionsSAML_GetCertRolloverNotification(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsSAML{CertRolloverNotification: &zeroValue}
+	c.GetCertRolloverNotification()
+	c = &ConnectionOptionsSAML{}
+	c.GetCertRolloverNotification()
+	c = nil
+	c.GetCertRolloverNotification()
 }
 
 func TestConnectionOptionsSAML_GetDebug(tt *testing.T) {
@@ -4937,6 +5311,26 @@ func TestConnectionOptionsSAML_GetExpires(tt *testing.T) {
 	c.GetExpires()
 	c = nil
 	c.GetExpires()
+}
+
+func TestConnectionOptionsSAML_GetExtGroups(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsSAML{ExtGroups: &zeroValue}
+	c.GetExtGroups()
+	c = &ConnectionOptionsSAML{}
+	c.GetExtGroups()
+	c = nil
+	c.GetExtGroups()
+}
+
+func TestConnectionOptionsSAML_GetExtProfile(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsSAML{ExtProfile: &zeroValue}
+	c.GetExtProfile()
+	c = &ConnectionOptionsSAML{}
+	c.GetExtProfile()
+	c = nil
+	c.GetExtProfile()
 }
 
 func TestConnectionOptionsSAML_GetIdpInitiated(tt *testing.T) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR is the v0 equivalent of #263, it adds all known properties to the `ad`, `adfs,` `pingfederate`, `saml`,  and `waad` connection options to prevent these options being removed when a update is performed

The diff here is slightly smaller as v1 introduced safe getters for `map[string]interface{}` and those are not included in this after being generated.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
