### PR TITLE
Add missing scope tags to connection options

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -861,6 +861,8 @@ type ConnectionOptionsAD struct {
 
 	UpstreamParams map[string]interface{} `json:"upstream_params,omitempty"`
 
+	Thumbprints *[]string `json:"thumbprints,omitempty"`
+
 	Certs        *[]string `json:"certs,omitempty"`
 	AgentIP      *string   `json:"agentIP,omitempty"`
 	AgentVersion *string   `json:"agentVersion,omitempty"`

--- a/management/connection.go
+++ b/management/connection.go
@@ -986,8 +986,8 @@ type ConnectionOptionsPingFederate struct {
 	AgentIP                  *string                             `json:"agentIP,omitempty"`
 	AgentVersion             *string                             `json:"agentVersion,omitempty"`
 	AgentMode                *bool                               `json:"agentMode,omitempty"`
-	ExtGroups                *bool                               `json:"ext_groups,omitempty"`
-	ExtProfile               *bool                               `json:"ext_profile,omitempty"`
+	ExtGroups                *bool                               `json:"ext_groups,omitempty" scope:"ext_groups"`
+	ExtProfile               *bool                               `json:"ext_profile,omitempty" scope:"ext_profile"`
 }
 
 // ConnectionOptionsSAML is used to configure a SAML Connection.
@@ -1023,8 +1023,8 @@ type ConnectionOptionsSAML struct {
 	AgentIP                  *string `json:"agentIP,omitempty"`
 	AgentVersion             *string `json:"agentVersion,omitempty"`
 	AgentMode                *bool   `json:"agentMode,omitempty"`
-	ExtGroups                *bool   `json:"ext_groups,omitempty"`
-	ExtProfile               *bool   `json:"ext_profile,omitempty"`
+	ExtGroups                *bool   `json:"ext_groups,omitempty" scope:"ext_groups"`
+	ExtProfile               *bool   `json:"ext_profile,omitempty" scope:"ext_profile"`
 
 	SetUserAttributes  *string   `json:"set_user_root_attributes,omitempty"`
 	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2366,6 +2366,14 @@ func (c *ConnectionOptionsAD) GetTenantDomain() string {
 	return *c.TenantDomain
 }
 
+// GetThumbprints returns the Thumbprints field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetThumbprints() []string {
+	if c == nil || c.Thumbprints == nil {
+		return nil
+	}
+	return *c.Thumbprints
+}
+
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.
 func (c *ConnectionOptionsAD) GetUpstreamParams() map[string]interface{} {
 	if c == nil || c.UpstreamParams == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2911,6 +2911,16 @@ func TestConnectionOptionsAD_GetTenantDomain(tt *testing.T) {
 	c.GetTenantDomain()
 }
 
+func TestConnectionOptionsAD_GetThumbprints(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptionsAD{Thumbprints: &zeroValue}
+	c.GetThumbprints()
+	c = &ConnectionOptionsAD{}
+	c.GetThumbprints()
+	c = nil
+	c.GetThumbprints()
+}
+
 func TestConnectionOptionsAD_GetUpstreamParams(tt *testing.T) {
 	zeroValue := map[string]interface{}{}
 	c := &ConnectionOptionsAD{UpstreamParams: zeroValue}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Through https://github.com/auth0/go-auth0/pull/263/files we introduced the `ExtGroups` and `ExtProfile` properties on the `ConnectionOptionsPingFederate` and `ConnectionOptionsSAML`, however the scope tag was missed. This PR addresses that. 

To note also that unfortunately now we have inconsistent ways of describing the same attribute accepted by the API:

`ext_groups`
- `ConnectionOptionsPingFederate.ExtGroups`
- `ConnectionOptionsSAML.ExtGroups`
- `ConnectionOptionsAzureAD.Groups`
- `ConnectionOptionsGoogleApps.Groups`

`ext_profile`
- `ConnectionOptionsPingFederate.ExtProfile`
- `ConnectionOptionsSAML.ExtProfile`
- `ConnectionOptionsGoogleApps.ExtendedProfile`
- `ConnectionOptionsAzureAD.ExtendedProfile`

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
