### PR TITLE
Fix typo on adfs previousthumbrints json tag

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -941,7 +941,7 @@ type ConnectionOptionsADFS struct {
 
 	EntityID                 *string   `json:"entityID,omitempty"`
 	CertRolloverNotification *string   `json:"cert_rollover_notification,omitempty"`
-	PreviousThumbprints      *[]string `json:"prev_thumprints,omitempty"`
+	PreviousThumbprints      *[]string `json:"prev_thumbprints,omitempty"`
 }
 
 // ConnectionOptionsPingFederate is used to configure a Ping Federate Connection.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Fixes a typo on the json tag for `PreviousThumbprints` on the `ConnectionOptionsADFS` struct

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
