### PR TITLE
Add missing Scopes and SetScopes for PingFederate and SAML Connections

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -77,6 +77,31 @@ const (
 	ConnectionStrategyLine = "line"
 )
 
+var (
+	// Enforcing the ConnectionOptionsScoper interface.
+	_ ConnectionOptionsScoper = &ConnectionOptionsOkta{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsGoogleOAuth2{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsFacebook{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsApple{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsLinkedin{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsGitHub{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsWindowsLive{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsSalesforce{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsOIDC{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsOAuth2{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsAzureAD{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsPingFederate{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsSAML{}
+	_ ConnectionOptionsScoper = &ConnectionOptionsGoogleApps{}
+)
+
+// ConnectionOptionsScoper is used to enforce being able to read and
+// set scopes through the scope tag on connection options properties.
+type ConnectionOptionsScoper interface {
+	Scopes() []string
+	SetScopes(enable bool, scopes ...string)
+}
+
 // Connection is the relationship between Auth0 and a source of users.
 //
 // See: https://auth0.com/docs/authenticate/identity-providers
@@ -995,6 +1020,16 @@ type ConnectionOptionsPingFederate struct {
 	ExtProfile               *bool                               `json:"ext_profile,omitempty" scope:"ext_profile"`
 }
 
+// Scopes returns the scopes for ConnectionOptionsPingFederate.
+func (c *ConnectionOptionsPingFederate) Scopes() []string {
+	return tag.Scopes(c)
+}
+
+// SetScopes sets the scopes for ConnectionOptionsPingFederate.
+func (c *ConnectionOptionsPingFederate) SetScopes(enable bool, scopes ...string) {
+	tag.SetScopes(c, enable, scopes...)
+}
+
 // ConnectionOptionsSAML is used to configure a SAML Connection.
 type ConnectionOptionsSAML struct {
 	Cert               *string                             `json:"cert,omitempty"`
@@ -1061,6 +1096,16 @@ type ConnectionOptionsSAMLSigningKey struct {
 type ConnectionOptionsSAMLDecryptionKey struct {
 	Key  *string `json:"key,omitempty"`
 	Cert *string `json:"cert,omitempty"`
+}
+
+// Scopes returns the scopes for ConnectionOptionsSAML.
+func (c *ConnectionOptionsSAML) Scopes() []string {
+	return tag.Scopes(c)
+}
+
+// SetScopes sets the scopes for ConnectionOptionsSAML.
+func (c *ConnectionOptionsSAML) SetScopes(enable bool, scopes ...string) {
+	tag.SetScopes(c, enable, scopes...)
 }
 
 // ConnectionOptionsGoogleApps is used to configure a GoogleApps Connection.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Add missing Scopes and SetScopes for PingFederate and SAML Connections and as well introducing a new ConnectionOptionsScoper to enforce the interface. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
