### PR TITLE
Remove omitempty from From and MessagingServiceSID on SMS Connection

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -658,7 +658,7 @@ type ConnectionGatewayAuthentication struct {
 // ConnectionOptionsSMS is used to configure an SMS Connection.
 type ConnectionOptionsSMS struct {
 	Name     *string `json:"name,omitempty"`
-	From     *string `json:"from,omitempty"`
+	From     *string `json:"from"`
 	Syntax   *string `json:"syntax,omitempty"`
 	Template *string `json:"template,omitempty"`
 
@@ -668,7 +668,7 @@ type ConnectionOptionsSMS struct {
 
 	TwilioSID           *string `json:"twilio_sid,omitempty"`
 	TwilioToken         *string `json:"twilio_token,omitempty"`
-	MessagingServiceSID *string `json:"messaging_service_sid,omitempty"`
+	MessagingServiceSID *string `json:"messaging_service_sid"`
 
 	Provider              *string                          `json:"provider,omitempty"`
 	GatewayURL            *string                          `json:"gateway_url,omitempty"`


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This fixes https://github.com/auth0/terraform-provider-auth0/issues/805, where we need to send either the `from` or `messaging_service_sid` as null in order to toggle them on or off. 

Note the payload when checking the network tab within the UI:

```
{
	"options": {
		"from": "+155",
		"messaging_service_sid": null,
	}
}
```

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
