### PR TITLE
DXCDT-536: Add pkce and attribute_map settings to OIDC and Okta connections

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -337,6 +337,9 @@ type ConnectionOptionsOkta struct {
 	SetUserAttributes     *string                `json:"set_user_root_attributes,omitempty"`
 	NonPersistentAttrs    *[]string              `json:"non_persistent_attrs,omitempty"`
 	UpstreamParams        map[string]interface{} `json:"upstream_params,omitempty"`
+
+	ConnectionSettings *ConnectionOptionsOIDCConnectionSettings `json:"connection_settings,omitempty"`
+	AttributeMap       *ConnectionOptionsOIDCAttributeMap       `json:"attribute_map,omitempty"`
 }
 
 // Scopes returns the scopes for ConnectionOptionsOkta.
@@ -802,6 +805,35 @@ type ConnectionOptionsOIDC struct {
 	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`
 
 	UpstreamParams map[string]interface{} `json:"upstream_params,omitempty"`
+
+	ConnectionSettings *ConnectionOptionsOIDCConnectionSettings `json:"connection_settings,omitempty"`
+	AttributeMap       *ConnectionOptionsOIDCAttributeMap       `json:"attribute_map,omitempty"`
+}
+
+// ConnectionOptionsOIDCConnectionSettings contains PKCE configuration for the connection.
+//
+// PKCE possible values:
+//
+//	auto     - Uses the strongest algorithm available.
+//	S256     - Uses the SHA-256 algorithm. Auth0 does not currently support RS512 tokens.
+//	plain    - Uses plaintext as described in the PKCE specification.
+//	disabled - Disables support for PKCE.
+//
+// Setting the PKCE property to a value other than auto may prevent a connection from
+// working properly if the selected value is not supported by the identity provider.
+type ConnectionOptionsOIDCConnectionSettings struct {
+	PKCE *string `json:"pkce,omitempty"`
+}
+
+// ConnectionOptionsOIDCAttributeMap contains the mapping of claims received from the identity provider (IdP).
+type ConnectionOptionsOIDCAttributeMap struct {
+	// Scopes to send to the IdP's Userinfo endpoint.
+	UserInfoScope *string `json:"userinfo_scope,omitempty"`
+	// Method used to map incoming claims.
+	// Possible values: `use_map`, `bind_all`, `basic_profile`.
+	MappingMode *string `json:"mapping_mode,omitempty"`
+	// Object containing mapping details for incoming claims.
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
 }
 
 // Scopes returns the scopes for ConnectionOptionsOIDC.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -4138,6 +4138,14 @@ func (c *ConnectionOptionsOAuth2) String() string {
 	return Stringify(c)
 }
 
+// GetAttributeMap returns the AttributeMap field.
+func (c *ConnectionOptionsOIDC) GetAttributeMap() *ConnectionOptionsOIDCAttributeMap {
+	if c == nil {
+		return nil
+	}
+	return c.AttributeMap
+}
+
 // GetAuthorizationEndpoint returns the AuthorizationEndpoint field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsOIDC) GetAuthorizationEndpoint() string {
 	if c == nil || c.AuthorizationEndpoint == nil {
@@ -4160,6 +4168,14 @@ func (c *ConnectionOptionsOIDC) GetClientSecret() string {
 		return ""
 	}
 	return *c.ClientSecret
+}
+
+// GetConnectionSettings returns the ConnectionSettings field.
+func (c *ConnectionOptionsOIDC) GetConnectionSettings() *ConnectionOptionsOIDCConnectionSettings {
+	if c == nil {
+		return nil
+	}
+	return c.ConnectionSettings
 }
 
 // GetDiscoveryURL returns the DiscoveryURL field if it's non-nil, zero value otherwise.
@@ -4271,6 +4287,56 @@ func (c *ConnectionOptionsOIDC) String() string {
 	return Stringify(c)
 }
 
+// GetAttributes returns the Attributes map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsOIDCAttributeMap) GetAttributes() map[string]interface{} {
+	if c == nil || c.Attributes == nil {
+		return map[string]interface{}{}
+	}
+	return c.Attributes
+}
+
+// GetMappingMode returns the MappingMode field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDCAttributeMap) GetMappingMode() string {
+	if c == nil || c.MappingMode == nil {
+		return ""
+	}
+	return *c.MappingMode
+}
+
+// GetUserInfoScope returns the UserInfoScope field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDCAttributeMap) GetUserInfoScope() string {
+	if c == nil || c.UserInfoScope == nil {
+		return ""
+	}
+	return *c.UserInfoScope
+}
+
+// String returns a string representation of ConnectionOptionsOIDCAttributeMap.
+func (c *ConnectionOptionsOIDCAttributeMap) String() string {
+	return Stringify(c)
+}
+
+// GetPKCE returns the PKCE field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDCConnectionSettings) GetPKCE() string {
+	if c == nil || c.PKCE == nil {
+		return ""
+	}
+	return *c.PKCE
+}
+
+// String returns a string representation of ConnectionOptionsOIDCConnectionSettings.
+func (c *ConnectionOptionsOIDCConnectionSettings) String() string {
+	return Stringify(c)
+}
+
+// GetAttributeMap returns the AttributeMap field.
+func (c *ConnectionOptionsOkta) GetAttributeMap() *ConnectionOptionsOIDCAttributeMap {
+	if c == nil {
+		return nil
+	}
+	return c.AttributeMap
+}
+
 // GetAuthorizationEndpoint returns the AuthorizationEndpoint field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsOkta) GetAuthorizationEndpoint() string {
 	if c == nil || c.AuthorizationEndpoint == nil {
@@ -4293,6 +4359,14 @@ func (c *ConnectionOptionsOkta) GetClientSecret() string {
 		return ""
 	}
 	return *c.ClientSecret
+}
+
+// GetConnectionSettings returns the ConnectionSettings field.
+func (c *ConnectionOptionsOkta) GetConnectionSettings() *ConnectionOptionsOIDCConnectionSettings {
+	if c == nil {
+		return nil
+	}
+	return c.ConnectionSettings
 }
 
 // GetDomain returns the Domain field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -5141,6 +5141,13 @@ func TestConnectionOptionsOAuth2_String(t *testing.T) {
 	}
 }
 
+func TestConnectionOptionsOIDC_GetAttributeMap(tt *testing.T) {
+	c := &ConnectionOptionsOIDC{}
+	c.GetAttributeMap()
+	c = nil
+	c.GetAttributeMap()
+}
+
 func TestConnectionOptionsOIDC_GetAuthorizationEndpoint(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsOIDC{AuthorizationEndpoint: &zeroValue}
@@ -5169,6 +5176,13 @@ func TestConnectionOptionsOIDC_GetClientSecret(tt *testing.T) {
 	c.GetClientSecret()
 	c = nil
 	c.GetClientSecret()
+}
+
+func TestConnectionOptionsOIDC_GetConnectionSettings(tt *testing.T) {
+	c := &ConnectionOptionsOIDC{}
+	c.GetConnectionSettings()
+	c = nil
+	c.GetConnectionSettings()
 }
 
 func TestConnectionOptionsOIDC_GetDiscoveryURL(tt *testing.T) {
@@ -5309,6 +5323,69 @@ func TestConnectionOptionsOIDC_String(t *testing.T) {
 	}
 }
 
+func TestConnectionOptionsOIDCAttributeMap_GetAttributes(tt *testing.T) {
+	zeroValue := map[string]interface{}{}
+	c := &ConnectionOptionsOIDCAttributeMap{Attributes: zeroValue}
+	c.GetAttributes()
+	c = &ConnectionOptionsOIDCAttributeMap{}
+	c.GetAttributes()
+	c = nil
+	c.GetAttributes()
+}
+
+func TestConnectionOptionsOIDCAttributeMap_GetMappingMode(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsOIDCAttributeMap{MappingMode: &zeroValue}
+	c.GetMappingMode()
+	c = &ConnectionOptionsOIDCAttributeMap{}
+	c.GetMappingMode()
+	c = nil
+	c.GetMappingMode()
+}
+
+func TestConnectionOptionsOIDCAttributeMap_GetUserInfoScope(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsOIDCAttributeMap{UserInfoScope: &zeroValue}
+	c.GetUserInfoScope()
+	c = &ConnectionOptionsOIDCAttributeMap{}
+	c.GetUserInfoScope()
+	c = nil
+	c.GetUserInfoScope()
+}
+
+func TestConnectionOptionsOIDCAttributeMap_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsOIDCAttributeMap{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsOIDCConnectionSettings_GetPKCE(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsOIDCConnectionSettings{PKCE: &zeroValue}
+	c.GetPKCE()
+	c = &ConnectionOptionsOIDCConnectionSettings{}
+	c.GetPKCE()
+	c = nil
+	c.GetPKCE()
+}
+
+func TestConnectionOptionsOIDCConnectionSettings_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsOIDCConnectionSettings{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsOkta_GetAttributeMap(tt *testing.T) {
+	c := &ConnectionOptionsOkta{}
+	c.GetAttributeMap()
+	c = nil
+	c.GetAttributeMap()
+}
+
 func TestConnectionOptionsOkta_GetAuthorizationEndpoint(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsOkta{AuthorizationEndpoint: &zeroValue}
@@ -5337,6 +5414,13 @@ func TestConnectionOptionsOkta_GetClientSecret(tt *testing.T) {
 	c.GetClientSecret()
 	c = nil
 	c.GetClientSecret()
+}
+
+func TestConnectionOptionsOkta_GetConnectionSettings(tt *testing.T) {
+	c := &ConnectionOptionsOkta{}
+	c.GetConnectionSettings()
+	c = nil
+	c.GetConnectionSettings()
 }
 
 func TestConnectionOptionsOkta_GetDomain(tt *testing.T) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Add support for https://auth0.com/docs/authenticate/identity-providers/enterprise-identity-providers/configure-pkce-claim-mapping-for-oidc#map-claims-for-oidc-connections on OIDC and Okta connections.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
