### PR TITLE
[SDK-4558] Add passkey metadata in authentication method and connections

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -347,7 +347,7 @@ type PasskeyAuthenticationMethod struct {
 
 // PasskeyOptions contains Passkey configuration for the connection.
 type PasskeyOptions struct {
-	// Controls the UI used to challenge the user for their passkey. Should be one of "both", "autofill", or "button"
+	// Controls the UI used to challenge the user for their passkey. Should be one of "both", "autofill", or "button".
 	ChallengeUI *string `json:"challenge_ui,omitempty"`
 	// Enables or disables progressive enrollment of passkeys for the connection.
 	ProgressiveEnrollmentEnabled *bool `json:"progressive_enrollment_enabled,omitempty"`

--- a/management/connection.go
+++ b/management/connection.go
@@ -319,6 +319,40 @@ type ConnectionOptions struct {
 
 	// Set to true to stop the "Forgot Password" being displayed on login pages
 	DisableSelfServiceChangePassword *bool `json:"disable_self_service_change_password,omitempty"`
+
+	// Options for enabling authentication methods.
+	AuthenticationMethods *AuthenticationMethods `json:"authentication_methods,omitempty"`
+
+	// Options for the passkey authentication method.
+	PasskeyOptions *PasskeyOptions `json:"passkey_options,omitempty"`
+}
+
+// AuthenticationMethods represents the options for enabling authentication methods for the connection.
+type AuthenticationMethods struct {
+	Password *PasswordAuthenticationMethod `json:"password,omitempty"`
+	Passkey  *PasskeyAuthenticationMethod  `json:"passkey,omitempty"`
+}
+
+// PasswordAuthenticationMethod represents password authentication enablement for the connection.
+type PasswordAuthenticationMethod struct {
+	// Determines whether passwords are enabled.
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// PasskeyAuthenticationMethod represents passkey authentication enablement for the connection.
+type PasskeyAuthenticationMethod struct {
+	// Determines whether passkeys are enabled.
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// PasskeyOptions contains Passkey configuration for the connection.
+type PasskeyOptions struct {
+	// Controls the UI used to challenge the user for their passkey. Should be one of "both", "autofill", or "button"
+	ChallengeUI *string `json:"challenge_ui,omitempty"`
+	// Enables or disables progressive enrollment of passkeys for the connection.
+	ProgressiveEnrollmentEnabled *bool `json:"progressive_enrollment_enabled,omitempty"`
+	// Enables or disables enrollment prompt for local passkey when user authenticates using a cross-device passkey for the connection.
+	LocalEnrollmentEnabled *bool `json:"local_enrollment_enabled,omitempty"`
 }
 
 // ConnectionOptionsOkta is used to configure an Okta Workforce Connection.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -511,6 +511,22 @@ func (a *AuthenticationMethod) GetCreatedAt() time.Time {
 	return *a.CreatedAt
 }
 
+// GetCredentialBackedUp returns the CredentialBackedUp field if it's non-nil, zero value otherwise.
+func (a *AuthenticationMethod) GetCredentialBackedUp() bool {
+	if a == nil || a.CredentialBackedUp == nil {
+		return false
+	}
+	return *a.CredentialBackedUp
+}
+
+// GetCredentialDeviceType returns the CredentialDeviceType field if it's non-nil, zero value otherwise.
+func (a *AuthenticationMethod) GetCredentialDeviceType() string {
+	if a == nil || a.CredentialDeviceType == nil {
+		return ""
+	}
+	return *a.CredentialDeviceType
+}
+
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
 func (a *AuthenticationMethod) GetEmail() string {
 	if a == nil || a.Email == nil {
@@ -533,6 +549,14 @@ func (a *AuthenticationMethod) GetID() string {
 		return ""
 	}
 	return *a.ID
+}
+
+// GetIdentityUserID returns the IdentityUserID field if it's non-nil, zero value otherwise.
+func (a *AuthenticationMethod) GetIdentityUserID() string {
+	if a == nil || a.IdentityUserID == nil {
+		return ""
+	}
+	return *a.IdentityUserID
 }
 
 // GetKeyID returns the KeyID field if it's non-nil, zero value otherwise.
@@ -615,6 +639,14 @@ func (a *AuthenticationMethod) GetType() string {
 	return *a.Type
 }
 
+// GetUserAgent returns the UserAgent field if it's non-nil, zero value otherwise.
+func (a *AuthenticationMethod) GetUserAgent() string {
+	if a == nil || a.UserAgent == nil {
+		return ""
+	}
+	return *a.UserAgent
+}
+
 // String returns a string representation of AuthenticationMethod.
 func (a *AuthenticationMethod) String() string {
 	return Stringify(a)
@@ -643,6 +675,27 @@ func (a *AuthenticationMethodReference) GetType() string {
 
 // String returns a string representation of AuthenticationMethodReference.
 func (a *AuthenticationMethodReference) String() string {
+	return Stringify(a)
+}
+
+// GetPasskey returns the Passkey field.
+func (a *AuthenticationMethods) GetPasskey() *PasskeyAuthenticationMethod {
+	if a == nil {
+		return nil
+	}
+	return a.Passkey
+}
+
+// GetPassword returns the Password field.
+func (a *AuthenticationMethods) GetPassword() *PasswordAuthenticationMethod {
+	if a == nil {
+		return nil
+	}
+	return a.Password
+}
+
+// String returns a string representation of AuthenticationMethods.
+func (a *AuthenticationMethods) String() string {
 	return Stringify(a)
 }
 
@@ -2089,6 +2142,14 @@ func (c *ConnectionList) String() string {
 	return Stringify(c)
 }
 
+// GetAuthenticationMethods returns the AuthenticationMethods field.
+func (c *ConnectionOptions) GetAuthenticationMethods() *AuthenticationMethods {
+	if c == nil {
+		return nil
+	}
+	return c.AuthenticationMethods
+}
+
 // GetBruteForceProtection returns the BruteForceProtection field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptions) GetBruteForceProtection() bool {
 	if c == nil || c.BruteForceProtection == nil {
@@ -2167,6 +2228,14 @@ func (c *ConnectionOptions) GetNonPersistentAttrs() []string {
 		return nil
 	}
 	return *c.NonPersistentAttrs
+}
+
+// GetPasskeyOptions returns the PasskeyOptions field.
+func (c *ConnectionOptions) GetPasskeyOptions() *PasskeyOptions {
+	if c == nil {
+		return nil
+	}
+	return c.PasskeyOptions
 }
 
 // GetPasswordComplexityOptions returns the PasswordComplexityOptions map if it's non-nil, an empty map otherwise.
@@ -7901,6 +7970,61 @@ func (o *OrganizationMemberRole) String() string {
 // String returns a string representation of OrganizationMemberRoleList.
 func (o *OrganizationMemberRoleList) String() string {
 	return Stringify(o)
+}
+
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (p *PasskeyAuthenticationMethod) GetEnabled() bool {
+	if p == nil || p.Enabled == nil {
+		return false
+	}
+	return *p.Enabled
+}
+
+// String returns a string representation of PasskeyAuthenticationMethod.
+func (p *PasskeyAuthenticationMethod) String() string {
+	return Stringify(p)
+}
+
+// GetChallengeUI returns the ChallengeUI field if it's non-nil, zero value otherwise.
+func (p *PasskeyOptions) GetChallengeUI() string {
+	if p == nil || p.ChallengeUI == nil {
+		return ""
+	}
+	return *p.ChallengeUI
+}
+
+// GetLocalEnrollmentEnabled returns the LocalEnrollmentEnabled field if it's non-nil, zero value otherwise.
+func (p *PasskeyOptions) GetLocalEnrollmentEnabled() bool {
+	if p == nil || p.LocalEnrollmentEnabled == nil {
+		return false
+	}
+	return *p.LocalEnrollmentEnabled
+}
+
+// GetProgressiveEnrollmentEnabled returns the ProgressiveEnrollmentEnabled field if it's non-nil, zero value otherwise.
+func (p *PasskeyOptions) GetProgressiveEnrollmentEnabled() bool {
+	if p == nil || p.ProgressiveEnrollmentEnabled == nil {
+		return false
+	}
+	return *p.ProgressiveEnrollmentEnabled
+}
+
+// String returns a string representation of PasskeyOptions.
+func (p *PasskeyOptions) String() string {
+	return Stringify(p)
+}
+
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (p *PasswordAuthenticationMethod) GetEnabled() bool {
+	if p == nil || p.Enabled == nil {
+		return false
+	}
+	return *p.Enabled
+}
+
+// String returns a string representation of PasswordAuthenticationMethod.
+func (p *PasswordAuthenticationMethod) String() string {
+	return Stringify(p)
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -655,6 +655,26 @@ func TestAuthenticationMethod_GetCreatedAt(tt *testing.T) {
 	a.GetCreatedAt()
 }
 
+func TestAuthenticationMethod_GetCredentialBackedUp(tt *testing.T) {
+	var zeroValue bool
+	a := &AuthenticationMethod{CredentialBackedUp: &zeroValue}
+	a.GetCredentialBackedUp()
+	a = &AuthenticationMethod{}
+	a.GetCredentialBackedUp()
+	a = nil
+	a.GetCredentialBackedUp()
+}
+
+func TestAuthenticationMethod_GetCredentialDeviceType(tt *testing.T) {
+	var zeroValue string
+	a := &AuthenticationMethod{CredentialDeviceType: &zeroValue}
+	a.GetCredentialDeviceType()
+	a = &AuthenticationMethod{}
+	a.GetCredentialDeviceType()
+	a = nil
+	a.GetCredentialDeviceType()
+}
+
 func TestAuthenticationMethod_GetEmail(tt *testing.T) {
 	var zeroValue string
 	a := &AuthenticationMethod{Email: &zeroValue}
@@ -683,6 +703,16 @@ func TestAuthenticationMethod_GetID(tt *testing.T) {
 	a.GetID()
 	a = nil
 	a.GetID()
+}
+
+func TestAuthenticationMethod_GetIdentityUserID(tt *testing.T) {
+	var zeroValue string
+	a := &AuthenticationMethod{IdentityUserID: &zeroValue}
+	a.GetIdentityUserID()
+	a = &AuthenticationMethod{}
+	a.GetIdentityUserID()
+	a = nil
+	a.GetIdentityUserID()
 }
 
 func TestAuthenticationMethod_GetKeyID(tt *testing.T) {
@@ -785,6 +815,16 @@ func TestAuthenticationMethod_GetType(tt *testing.T) {
 	a.GetType()
 }
 
+func TestAuthenticationMethod_GetUserAgent(tt *testing.T) {
+	var zeroValue string
+	a := &AuthenticationMethod{UserAgent: &zeroValue}
+	a.GetUserAgent()
+	a = &AuthenticationMethod{}
+	a.GetUserAgent()
+	a = nil
+	a.GetUserAgent()
+}
+
 func TestAuthenticationMethod_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &AuthenticationMethod{}
@@ -824,6 +864,28 @@ func TestAuthenticationMethodReference_GetType(tt *testing.T) {
 func TestAuthenticationMethodReference_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &AuthenticationMethodReference{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestAuthenticationMethods_GetPasskey(tt *testing.T) {
+	a := &AuthenticationMethods{}
+	a.GetPasskey()
+	a = nil
+	a.GetPasskey()
+}
+
+func TestAuthenticationMethods_GetPassword(tt *testing.T) {
+	a := &AuthenticationMethods{}
+	a.GetPassword()
+	a = nil
+	a.GetPassword()
+}
+
+func TestAuthenticationMethods_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &AuthenticationMethods{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
@@ -2563,6 +2625,13 @@ func TestConnectionList_String(t *testing.T) {
 	}
 }
 
+func TestConnectionOptions_GetAuthenticationMethods(tt *testing.T) {
+	c := &ConnectionOptions{}
+	c.GetAuthenticationMethods()
+	c = nil
+	c.GetAuthenticationMethods()
+}
+
 func TestConnectionOptions_GetBruteForceProtection(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptions{BruteForceProtection: &zeroValue}
@@ -2661,6 +2730,13 @@ func TestConnectionOptions_GetNonPersistentAttrs(tt *testing.T) {
 	c.GetNonPersistentAttrs()
 	c = nil
 	c.GetNonPersistentAttrs()
+}
+
+func TestConnectionOptions_GetPasskeyOptions(tt *testing.T) {
+	c := &ConnectionOptions{}
+	c.GetPasskeyOptions()
+	c = nil
+	c.GetPasskeyOptions()
 }
 
 func TestConnectionOptions_GetPasswordComplexityOptions(tt *testing.T) {
@@ -9932,6 +10008,80 @@ func TestOrganizationMemberRole_String(t *testing.T) {
 func TestOrganizationMemberRoleList_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &OrganizationMemberRoleList{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestPasskeyAuthenticationMethod_GetEnabled(tt *testing.T) {
+	var zeroValue bool
+	p := &PasskeyAuthenticationMethod{Enabled: &zeroValue}
+	p.GetEnabled()
+	p = &PasskeyAuthenticationMethod{}
+	p.GetEnabled()
+	p = nil
+	p.GetEnabled()
+}
+
+func TestPasskeyAuthenticationMethod_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &PasskeyAuthenticationMethod{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestPasskeyOptions_GetChallengeUI(tt *testing.T) {
+	var zeroValue string
+	p := &PasskeyOptions{ChallengeUI: &zeroValue}
+	p.GetChallengeUI()
+	p = &PasskeyOptions{}
+	p.GetChallengeUI()
+	p = nil
+	p.GetChallengeUI()
+}
+
+func TestPasskeyOptions_GetLocalEnrollmentEnabled(tt *testing.T) {
+	var zeroValue bool
+	p := &PasskeyOptions{LocalEnrollmentEnabled: &zeroValue}
+	p.GetLocalEnrollmentEnabled()
+	p = &PasskeyOptions{}
+	p.GetLocalEnrollmentEnabled()
+	p = nil
+	p.GetLocalEnrollmentEnabled()
+}
+
+func TestPasskeyOptions_GetProgressiveEnrollmentEnabled(tt *testing.T) {
+	var zeroValue bool
+	p := &PasskeyOptions{ProgressiveEnrollmentEnabled: &zeroValue}
+	p.GetProgressiveEnrollmentEnabled()
+	p = &PasskeyOptions{}
+	p.GetProgressiveEnrollmentEnabled()
+	p = nil
+	p.GetProgressiveEnrollmentEnabled()
+}
+
+func TestPasskeyOptions_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &PasskeyOptions{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestPasswordAuthenticationMethod_GetEnabled(tt *testing.T) {
+	var zeroValue bool
+	p := &PasswordAuthenticationMethod{Enabled: &zeroValue}
+	p.GetEnabled()
+	p = &PasswordAuthenticationMethod{}
+	p.GetEnabled()
+	p = nil
+	p.GetEnabled()
+}
+
+func TestPasswordAuthenticationMethod_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &PasswordAuthenticationMethod{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/management/user.go
+++ b/management/user.go
@@ -313,7 +313,7 @@ type AuthenticationMethod struct {
 	// The ID of the authentication method (auto generated).
 	ID *string `json:"id,omitempty"`
 
-	// The type of the authentication method. Should be one of "phone", "email", "totp" or "webauthn-roaming".
+	// The type of the authentication method. Should be one of "phone", "email", "totp", "webauthn-roaming", or "passkey".
 	Type *string `json:"type,omitempty"`
 
 	// The authentication method status.
@@ -356,6 +356,20 @@ type AuthenticationMethod struct {
 	RelyingPartyIdentifier *string `json:"relying_party_identifier,omitempty"`
 
 	AuthenticationMethods *[]AuthenticationMethodReference `json:"authentication_methods,omitempty"`
+
+	// Applies to passkeys only. The kind of device the credential is stored on as defined by backup eligibility.
+	// "single_device" credentials cannot be backed up and synced to another device,
+	// "multi_device" credentials can be backed up if enabled by the end-user.
+	CredentialDeviceType *string `json:"credential_device_type,omitempty"`
+
+	// Applies to passkeys only. Whether the credential was backed up.
+	CredentialBackedUp *bool `json:"credential_backed_up,omitempty"`
+
+	// Applies to passkeys only. The ID of the user identity linked with the authentication method.
+	IdentityUserID *string `json:"identity_user_id,omitempty"`
+
+	// Applies to passkeys only. The user-agent of the browser used to create the passkey.
+	UserAgent *string `json:"user_agent,omitempty"`
 }
 
 // AuthenticationMethodReference used within the AuthenticationMethod.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds passkey metadata to Connection and AuthenticationMethod structs 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
