### PR TITLE
ESD-32354: Add disable_self_service_change_password to AD connection options

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -940,27 +940,25 @@ func (c *ConnectionOptionsOAuth2) SetScopes(enable bool, scopes ...string) {
 
 // ConnectionOptionsAD is used to configure an AD Connection.
 type ConnectionOptionsAD struct {
-	TenantDomain  *string   `json:"tenant_domain,omitempty"`
-	DomainAliases *[]string `json:"domain_aliases,omitempty"`
-	LogoURL       *string   `json:"icon_url,omitempty"`
-	IPs           *[]string `json:"ips,omitempty"`
+	TenantDomain         *string                `json:"tenant_domain,omitempty"`
+	DomainAliases        *[]string              `json:"domain_aliases,omitempty"`
+	LogoURL              *string                `json:"icon_url,omitempty"`
+	IPs                  *[]string              `json:"ips,omitempty"`
+	CertAuth             *bool                  `json:"certAuth,omitempty"`
+	Kerberos             *bool                  `json:"kerberos,omitempty"`
+	DisableCache         *bool                  `json:"disable_cache,omitempty"`
+	BruteForceProtection *bool                  `json:"brute_force_protection,omitempty"`
+	SetUserAttributes    *string                `json:"set_user_root_attributes,omitempty"`
+	NonPersistentAttrs   *[]string              `json:"non_persistent_attrs,omitempty"`
+	UpstreamParams       map[string]interface{} `json:"upstream_params,omitempty"`
+	Thumbprints          *[]string              `json:"thumbprints,omitempty"`
+	Certs                *[]string              `json:"certs,omitempty"`
+	AgentIP              *string                `json:"agentIP,omitempty"`
+	AgentVersion         *string                `json:"agentVersion,omitempty"`
+	AgentMode            *bool                  `json:"agentMode,omitempty"`
 
-	CertAuth             *bool `json:"certAuth,omitempty"`
-	Kerberos             *bool `json:"kerberos,omitempty"`
-	DisableCache         *bool `json:"disable_cache,omitempty"`
-	BruteForceProtection *bool `json:"brute_force_protection,omitempty"`
-
-	SetUserAttributes  *string   `json:"set_user_root_attributes,omitempty"`
-	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`
-
-	UpstreamParams map[string]interface{} `json:"upstream_params,omitempty"`
-
-	Thumbprints *[]string `json:"thumbprints,omitempty"`
-
-	Certs        *[]string `json:"certs,omitempty"`
-	AgentIP      *string   `json:"agentIP,omitempty"`
-	AgentVersion *string   `json:"agentVersion,omitempty"`
-	AgentMode    *bool     `json:"agentMode,omitempty"`
+	// Set to true to stop the "Forgot Password" being displayed on login pages.
+	DisableSelfServiceChangePassword *bool `json:"disable_self_service_change_password,omitempty"`
 }
 
 // ConnectionOptionsAzureAD is used to configure an AzureAD Connection.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2379,6 +2379,14 @@ func (c *ConnectionOptionsAD) GetDisableCache() bool {
 	return *c.DisableCache
 }
 
+// GetDisableSelfServiceChangePassword returns the DisableSelfServiceChangePassword field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetDisableSelfServiceChangePassword() bool {
+	if c == nil || c.DisableSelfServiceChangePassword == nil {
+		return false
+	}
+	return *c.DisableSelfServiceChangePassword
+}
+
 // GetDomainAliases returns the DomainAliases field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsAD) GetDomainAliases() []string {
 	if c == nil || c.DomainAliases == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2917,6 +2917,16 @@ func TestConnectionOptionsAD_GetDisableCache(tt *testing.T) {
 	c.GetDisableCache()
 }
 
+func TestConnectionOptionsAD_GetDisableSelfServiceChangePassword(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsAD{DisableSelfServiceChangePassword: &zeroValue}
+	c.GetDisableSelfServiceChangePassword()
+	c = &ConnectionOptionsAD{}
+	c.GetDisableSelfServiceChangePassword()
+	c = nil
+	c.GetDisableSelfServiceChangePassword()
+}
+
 func TestConnectionOptionsAD_GetDomainAliases(tt *testing.T) {
 	var zeroValue []string
 	c := &ConnectionOptionsAD{DomainAliases: &zeroValue}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds support for `disable_self_service_change_password` on AD Connection Options.

### 📚 References

- https://github.com/auth0/terraform-provider-auth0/issues/870

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
