### PR TITLE
Export an Authentication Error to allow type assertions

### DIFF
--- a/authentication/authentication_error.go
+++ b/authentication/authentication_error.go
@@ -6,17 +6,19 @@ import (
 	"net/http"
 )
 
-type AuthenticationError struct {
+// Error represents errors return from the Authentication API, the `Err` property can
+// be used to check the error code returned from the API.
+type Error struct {
 	StatusCode int    `json:"statusCode"`
 	Err        string `json:"error"`
 	Message    string `json:"error_description"`
 }
 
 func newError(response *http.Response) error {
-	apiError := &AuthenticationError{}
+	apiError := &Error{}
 
 	if err := json.NewDecoder(response.Body).Decode(apiError); err != nil {
-		return &AuthenticationError{
+		return &Error{
 			StatusCode: response.StatusCode,
 			Err:        http.StatusText(response.StatusCode),
 			Message:    fmt.Errorf("failed to decode json error response payload: %w", err).Error(),
@@ -34,20 +36,20 @@ func newError(response *http.Response) error {
 }
 
 // Error formats the error into a string representation.
-func (a *AuthenticationError) Error() string {
+func (a *Error) Error() string {
 	return fmt.Sprintf("%d %s: %s", a.StatusCode, a.Err, a.Message)
 }
 
 // Status returns the status code of the error.
-func (a *AuthenticationError) Status() int {
+func (a *Error) Status() int {
 	return a.StatusCode
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 //
 // It is required to handle the differences between error responses between the APIs.
-func (a *AuthenticationError) UnmarshalJSON(b []byte) error {
-	type authError AuthenticationError
+func (a *Error) UnmarshalJSON(b []byte) error {
+	type authError Error
 	type authErrorWrapper struct {
 		*authError
 		Code        string `json:"code"`

--- a/authentication/authentication_error.go
+++ b/authentication/authentication_error.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-// Error represents errors return from the Authentication API, the `Err` property can
+// Error represents errors returned from the Authentication API. The `Err` property can
 // be used to check the error code returned from the API.
 type Error struct {
 	StatusCode int    `json:"statusCode"`

--- a/authentication/authentication_error.go
+++ b/authentication/authentication_error.go
@@ -6,17 +6,17 @@ import (
 	"net/http"
 )
 
-type authenticationError struct {
+type AuthenticationError struct {
 	StatusCode int    `json:"statusCode"`
 	Err        string `json:"error"`
 	Message    string `json:"error_description"`
 }
 
 func newError(response *http.Response) error {
-	apiError := &authenticationError{}
+	apiError := &AuthenticationError{}
 
 	if err := json.NewDecoder(response.Body).Decode(apiError); err != nil {
-		return &authenticationError{
+		return &AuthenticationError{
 			StatusCode: response.StatusCode,
 			Err:        http.StatusText(response.StatusCode),
 			Message:    fmt.Errorf("failed to decode json error response payload: %w", err).Error(),
@@ -34,20 +34,20 @@ func newError(response *http.Response) error {
 }
 
 // Error formats the error into a string representation.
-func (a *authenticationError) Error() string {
+func (a *AuthenticationError) Error() string {
 	return fmt.Sprintf("%d %s: %s", a.StatusCode, a.Err, a.Message)
 }
 
 // Status returns the status code of the error.
-func (a *authenticationError) Status() int {
+func (a *AuthenticationError) Status() int {
 	return a.StatusCode
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 //
 // It is required to handle the differences between error responses between the APIs.
-func (a *authenticationError) UnmarshalJSON(b []byte) error {
-	type authError authenticationError
+func (a *AuthenticationError) UnmarshalJSON(b []byte) error {
+	type authError AuthenticationError
 	type authErrorWrapper struct {
 		*authError
 		Code        string `json:"code"`

--- a/authentication/authentication_error_test.go
+++ b/authentication/authentication_error_test.go
@@ -13,7 +13,7 @@ func Test_newError(t *testing.T) {
 	var testCases = []struct {
 		name          string
 		givenResponse http.Response
-		expectedError authenticationError
+		expectedError AuthenticationError
 	}{
 		{
 			name: "it fails to decode if body is not json",
@@ -21,7 +21,7 @@ func Test_newError(t *testing.T) {
 				StatusCode: http.StatusForbidden,
 				Body:       io.NopCloser(strings.NewReader("Hello, I'm not JSON.")),
 			},
-			expectedError: authenticationError{
+			expectedError: AuthenticationError{
 				StatusCode: 403,
 				Err:        "Forbidden",
 				Message:    "failed to decode json error response payload: invalid character 'H' looking for beginning of value",
@@ -33,7 +33,7 @@ func Test_newError(t *testing.T) {
 				StatusCode: http.StatusBadRequest,
 				Body:       io.NopCloser(strings.NewReader(`{"statusCode":400,"error":"invalid_scope","error_description":"Scope must be an array or a string"}`)),
 			},
-			expectedError: authenticationError{
+			expectedError: AuthenticationError{
 				StatusCode: 400,
 				Err:        "invalid_scope",
 				Message:    "Scope must be an array or a string",
@@ -45,7 +45,7 @@ func Test_newError(t *testing.T) {
 				StatusCode: http.StatusInternalServerError,
 				Body:       io.NopCloser(strings.NewReader(`{"errorMessage":"wrongStruct"}`)),
 			},
-			expectedError: authenticationError{
+			expectedError: AuthenticationError{
 				StatusCode: 500,
 				Err:        "Internal Server Error",
 				Message:    "",
@@ -57,7 +57,7 @@ func Test_newError(t *testing.T) {
 				StatusCode: http.StatusBadRequest,
 				Body:       io.NopCloser(strings.NewReader(`{"name":"BadRequestError","code":"invalid_signup","description":"Invalid sign up","statusCode":400}`)),
 			},
-			expectedError: authenticationError{
+			expectedError: AuthenticationError{
 				StatusCode: 400,
 				Err:        "invalid_signup",
 				Message:    "Invalid sign up",

--- a/authentication/authentication_error_test.go
+++ b/authentication/authentication_error_test.go
@@ -13,7 +13,7 @@ func Test_newError(t *testing.T) {
 	var testCases = []struct {
 		name          string
 		givenResponse http.Response
-		expectedError AuthenticationError
+		expectedError Error
 	}{
 		{
 			name: "it fails to decode if body is not json",
@@ -21,7 +21,7 @@ func Test_newError(t *testing.T) {
 				StatusCode: http.StatusForbidden,
 				Body:       io.NopCloser(strings.NewReader("Hello, I'm not JSON.")),
 			},
-			expectedError: AuthenticationError{
+			expectedError: Error{
 				StatusCode: 403,
 				Err:        "Forbidden",
 				Message:    "failed to decode json error response payload: invalid character 'H' looking for beginning of value",
@@ -33,7 +33,7 @@ func Test_newError(t *testing.T) {
 				StatusCode: http.StatusBadRequest,
 				Body:       io.NopCloser(strings.NewReader(`{"statusCode":400,"error":"invalid_scope","error_description":"Scope must be an array or a string"}`)),
 			},
-			expectedError: AuthenticationError{
+			expectedError: Error{
 				StatusCode: 400,
 				Err:        "invalid_scope",
 				Message:    "Scope must be an array or a string",
@@ -45,7 +45,7 @@ func Test_newError(t *testing.T) {
 				StatusCode: http.StatusInternalServerError,
 				Body:       io.NopCloser(strings.NewReader(`{"errorMessage":"wrongStruct"}`)),
 			},
-			expectedError: AuthenticationError{
+			expectedError: Error{
 				StatusCode: 500,
 				Err:        "Internal Server Error",
 				Message:    "",
@@ -57,7 +57,7 @@ func Test_newError(t *testing.T) {
 				StatusCode: http.StatusBadRequest,
 				Body:       io.NopCloser(strings.NewReader(`{"name":"BadRequestError","code":"invalid_signup","description":"Invalid sign up","statusCode":400}`)),
 			},
-			expectedError: AuthenticationError{
+			expectedError: Error{
 				StatusCode: 400,
 				Err:        "invalid_signup",
 				Message:    "Invalid sign up",

--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -411,7 +411,7 @@ func TestRetries(t *testing.T) {
 		assert.NoError(t, err)
 
 		_, err = a.UserInfo(context.Background(), "123")
-		assert.Equal(t, http.StatusBadGateway, err.(*AuthenticationError).StatusCode)
+		assert.Equal(t, http.StatusBadGateway, err.(*Error).StatusCode)
 		assert.Equal(t, 1, i)
 	})
 

--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -411,7 +411,7 @@ func TestRetries(t *testing.T) {
 		assert.NoError(t, err)
 
 		_, err = a.UserInfo(context.Background(), "123")
-		assert.Equal(t, http.StatusBadGateway, err.(*authenticationError).StatusCode)
+		assert.Equal(t, http.StatusBadGateway, err.(*AuthenticationError).StatusCode)
 		assert.Equal(t, 1, i)
 	})
 

--- a/authentication/doc.go
+++ b/authentication/doc.go
@@ -51,4 +51,22 @@
 //		authentication.WithClientSecret(secret), // Optional depending on the grants used
 //		authentication.WithClockTolerance(10 * time.Second),
 //	)
+//
+// # Handling Errors
+//
+// This package exports an [authentication.Error] type that can be used to check errors
+// returned from the Authentication API and handle them as necessary, for example
+//
+//	tokens, err := auth.OAuth.LoginWithPassword(context.Background(), oauth.LoginWithPasswordRequest{
+//		Username: "test@example.com",
+//		Password: "hunter2",
+//	}, oauth.IDTokenValidationOptions{})
+//
+//	if err != nil {
+//		if aerr, ok := err.(*authentication.Error); ok {
+//			if aerr.Err == "mfa_required" {
+//				// Handle prompting for MFA usage
+//			}
+//		}
+//	}
 package authentication


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Exports the `Error` type so that it can be used in type assertions and document this in the godoc for the authentication package.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

Closes #315

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
