### PR TITLE
Change authErrorWrapper description to interface{} and assert strings

### DIFF
--- a/authentication/authentication_error.go
+++ b/authentication/authentication_error.go
@@ -54,8 +54,8 @@ func (a *Error) UnmarshalJSON(b []byte) error {
 	type authError Error
 	type authErrorWrapper struct {
 		*authError
-		Code        string `json:"code"`
-		Description string `json:"description"`
+		Code        string      `json:"code"`
+		Description interface{} `json:"description"`
 	}
 
 	alias := &authErrorWrapper{(*authError)(a), "", ""}
@@ -68,9 +68,8 @@ func (a *Error) UnmarshalJSON(b []byte) error {
 	if alias.Code != "" {
 		a.Err = alias.Code
 	}
-
 	if alias.Description != "" {
-		a.Message = alias.Description
+		a.Message, _ = alias.Description.(string)
 	}
 
 	return nil


### PR DESCRIPTION
### 🔧 Changes

Updates: `authentication.Error` `UnmarshalJSON()` 
Changes: `authErrorWrapper` struct field `Description` to an `interface{}` instead of `string` and test the type when filling during the unmarshal process. 

Consumers calling requests such as `Database.Signup()` would be returned back a JSON unmarshal error instead of the actual underlying error such as `invalid_password`, preventing passing important information back to the user, because the API returns a JSON object instead of a string and causes the UnmarshalJSON call to fail. This change allows for string descriptions to still be passed back, but doesn't fail in the case `description` is an object instead.

### 📚 References

Open bug report by someone encountering this issue:
https://github.com/auth0/go-auth0/issues/336

### 🔬 Testing

You can manually test that 400 invalid_password is returned using the code snippet provided below (copied from above bug report). Currently this returns a JSON unmarshal failure and no helpful information for the developer or user.

```go
 auth0, err := authentication.New(context.Background(), "<redacted>")
 resp, err := auth0.Database.Signup(context.Background(), database.SignupRequest{
	ClientID:   "<redacted>"
	Email:      "<redacted>",
	Password:   "password",
	Connection: "Username-Password-Authentication",
})
```

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

