### PR TITLE
fix(management): don't unmarshal empty array response from request

### DIFF
--- a/management/management_request.go
+++ b/management/management_request.go
@@ -107,7 +107,7 @@ func (m *Management) Request(ctx context.Context, method, uri string, payload in
 		return fmt.Errorf("failed to read the response body: %w", err)
 	}
 
-	if len(responseBody) > 0 && string(responseBody) != "{}" {
+	if len(responseBody) > 0 && string(responseBody) != "{}" && string(responseBody) != "[]" {
 		if err = json.Unmarshal(responseBody, &payload); err != nil {
 			return fmt.Errorf("failed to unmarshal response payload: %w", err)
 		}


### PR DESCRIPTION
This PR will make requests that return empty arrays `[]` behave the same as requests that return empty objects `{}`

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
fix: don't attempt to unmarshal empty array response in `management.Request`
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 🔬 Testing

Make a `List` request with parameters for an object that doesn't exist and the payload is a `List` struct e.g `func (m *ClientManager) List(ctx context.Context, opts ...RequestOption) (c *ClientList, err error) ` . Before this fix it could return `[]` and the unmarshal would err out, with this fix it will handle it the same as an empty object and it will not attempt to populate the payload. The payload will be unchanged

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
