### PR TITLE
Revert "Bump codecov/codecov-action from 3.1.5 to 4.2.0"

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
           AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
 
       - name: Update codecov report
-        uses: codecov/codecov-action@7afa10ed9b269c561c2336fd862446844e0cbf71 # pin@4.2.0
+        uses: codecov/codecov-action@4fe8c5f003fae66aa5ebb77cfd3e7bfbbda0b6b0 # pin@3.1.5
         with:
           files: ./coverage.out
           fail_ci_if_error: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         run: make test
 
       - name: Update codecov report
-        uses: codecov/codecov-action@7afa10ed9b269c561c2336fd862446844e0cbf71 # pin@4.2.0
+        uses: codecov/codecov-action@4fe8c5f003fae66aa5ebb77cfd3e7bfbbda0b6b0 # pin@3.1.5
         with:
           files: ./coverage.out
           fail_ci_if_error: false


### PR DESCRIPTION
Reverts auth0/go-auth0#376 due to breaking changes introduced in v4 requiring a token. 