### PR TITLE
Changing UserMetadata and AppMetadata on User struct to use json.Rawmessage

### DIFF
--- a/auth0.go
+++ b/auth0.go
@@ -1,6 +1,7 @@
 package auth0
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -77,4 +78,9 @@ func TimeValue(t *time.Time) time.Time {
 		return *t
 	}
 	return time.Time{}
+}
+
+// JSONRawMessage returns a pointer to the json.RawMessage passed in.
+func JSONRawMessage(json json.RawMessage) *json.RawMessage {
+	return &json
 }

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -4,6 +4,7 @@
 package management
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -9718,9 +9719,9 @@ func (t *Ticket) String() string {
 }
 
 // GetAppMetadata returns the AppMetadata field if it's non-nil, zero value otherwise.
-func (u *User) GetAppMetadata() map[string]interface{} {
+func (u *User) GetAppMetadata() json.RawMessage {
 	if u == nil || u.AppMetadata == nil {
-		return map[string]interface{}{}
+		return json.RawMessage{}
 	}
 	return *u.AppMetadata
 }
@@ -9926,9 +9927,9 @@ func (u *User) GetURL() string {
 }
 
 // GetUserMetadata returns the UserMetadata field if it's non-nil, zero value otherwise.
-func (u *User) GetUserMetadata() map[string]interface{} {
+func (u *User) GetUserMetadata() json.RawMessage {
 	if u == nil || u.UserMetadata == nil {
-		return map[string]interface{}{}
+		return json.RawMessage{}
 	}
 	return *u.UserMetadata
 }

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -12226,7 +12226,7 @@ func TestTicket_String(t *testing.T) {
 }
 
 func TestUser_GetAppMetadata(tt *testing.T) {
-	var zeroValue map[string]interface{}
+	var zeroValue json.RawMessage
 	u := &User{AppMetadata: &zeroValue}
 	u.GetAppMetadata()
 	u = &User{}
@@ -12486,7 +12486,7 @@ func TestUser_GetURL(tt *testing.T) {
 }
 
 func TestUser_GetUserMetadata(tt *testing.T) {
-	var zeroValue map[string]interface{}
+	var zeroValue json.RawMessage
 	u := &User{UserMetadata: &zeroValue}
 	u.GetUserMetadata()
 	u = &User{}

--- a/management/user.go
+++ b/management/user.go
@@ -70,7 +70,7 @@ type User struct {
 
 	// UserMetadata holds data that the user has read/write access to.
 	// For example color_preference, blog_url, etc.
-	UserMetadata *map[string]interface{} `json:"user_metadata,omitempty"`
+	UserMetadata *json.RawMessage `json:"user_metadata,omitempty"`
 
 	// Identities is a list of user identities for when accounts are linked.
 	Identities []*UserIdentity `json:"identities,omitempty"`
@@ -96,7 +96,7 @@ type User struct {
 	// For example roles, permissions, vip, etc.
 	// NOTE: Roles added to AppMetadata are not integrated with Auth0 Role-Based Access Control (RBAC).
 	// For RBAC, see the functions User.Roles, User.AssignRoles, and User.RemoveRoles.
-	AppMetadata *map[string]interface{} `json:"app_metadata,omitempty"`
+	AppMetadata *json.RawMessage `json:"app_metadata,omitempty"`
 
 	// The user's picture url.
 	Picture *string `json:"picture,omitempty"`


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
Considering the endpoints to create and update an user in Auth0 require `app_metadata` and `user_metadata` to be JSON objects I propose switching those variables from `*map[string]interface{}` to `json.RawMessage`. 

This will allow ease of use within applications for marshalling and unmarshaling the values into structs without the overhead for dealing with type assertions or need for 3rd party libraries with deeply nested values.
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

Create user API docs: https://auth0.com/docs/api/management/v2/users/post-users
Update user API docs: https://auth0.com/docs/api/management/v2/users/patch-users-by-id
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
