### PR TITLE
Add Support for `attributes` and `precedence` to ConnectionOptions & `phone_number` to SignupRequest Struct

### DIFF
--- a/authentication/database/database.go
+++ b/authentication/database/database.go
@@ -18,6 +18,8 @@ type SignupRequest struct {
 	Connection string `json:"connection,omitempty"`
 	// The user's username. Only valid if the connection requires a username.
 	Username string `json:"username,omitempty"`
+	// The user's phone number.
+	PhoneNumber string `json:"phone_number,omitempty"`
 	// The user's given name(s).
 	GivenName string `json:"given_name,omitempty"`
 	// The user's family name(s).
@@ -43,6 +45,8 @@ type SignupResponse struct {
 	EmailVerified bool `json:"email_verified,omitempty"`
 	// The user's ID.
 	ID string `json:"_id,omitempty"`
+	// The user's phone number.
+	PhoneNumber string `json:"phone_number,omitempty"`
 	// The user's username. Only valid if the connection requires a username.
 	Username string `json:"username,omitempty"`
 	// The user's given name(s).

--- a/authentication/database_test.go
+++ b/authentication/database_test.go
@@ -11,14 +11,20 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/auth0/go-auth0"
+
 	"github.com/auth0/go-auth0/authentication/database"
 	"github.com/auth0/go-auth0/management"
 )
 
-func TestDatabaseSignUp(t *testing.T) {
+// TestDatabaseSignUp_RequiresUsername tests the Database.Signup method with a connection that requires a username.
+func TestDatabaseSignUp_RequiresUsername(t *testing.T) {
+	connectionOptions := &management.ConnectionOptions{
+		RequiresUsername: auth0.Bool(true),
+	}
+
 	configureHTTPTestRecordings(t, authAPI)
 
-	details := givenSignUpDetails(t)
+	details := givenSignUpDetails(t, connectionOptions)
 
 	userData := database.SignupRequest{
 		Connection: details.connection,
@@ -29,10 +35,272 @@ func TestDatabaseSignUp(t *testing.T) {
 
 	createdUser, err := authAPI.Database.Signup(context.Background(), userData)
 	require.NoError(t, err)
+
 	assert.NotEmpty(t, createdUser.ID)
 	assert.Equal(t, userData.Username, createdUser.Username)
 }
 
+// TestDatabaseSignUp_WithEmailIdentifier tests the Database.Signup method with a connection that requires an email.
+func TestDatabaseSignUp_WithEmailIdentifier(t *testing.T) {
+	connectionOptions := &management.ConnectionOptions{
+		Attributes: &management.ConnectionOptionsAttributes{
+			Email: &management.ConnectionOptionsEmailAttribute{
+				Identifier: &management.ConnectionOptionsAttributeIdentifier{
+					Active: auth0.Bool(true),
+				},
+				ProfileRequired: auth0.Bool(true),
+				Signup: &management.ConnectionOptionsAttributeSignup{
+					Status: auth0.String("required"),
+					Verification: &management.ConnectionOptionsAttributeVerification{
+						Active: auth0.Bool(false),
+					},
+				},
+			},
+		},
+	}
+
+	configureHTTPTestRecordings(t, authAPI)
+
+	details := givenSignUpDetails(t, connectionOptions)
+
+	userData := database.SignupRequest{
+		Connection: details.connection,
+		Password:   details.password,
+		Email:      details.email,
+	}
+
+	createdUser, err := authAPI.Database.Signup(context.Background(), userData)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, createdUser.ID)
+	assert.Equal(t, userData.Email, createdUser.Email)
+}
+
+// TestDatabaseSignUp_WithUsernameIdentifier tests the Database.Signup method with a connection that requires a username.
+func TestDatabaseSignUp_WithUsernameIdentifier(t *testing.T) {
+	connectionOptions := &management.ConnectionOptions{
+		Attributes: &management.ConnectionOptionsAttributes{
+			Username: &management.ConnectionOptionsUsernameAttribute{
+				Identifier: &management.ConnectionOptionsAttributeIdentifier{
+					Active: auth0.Bool(true),
+				},
+				ProfileRequired: auth0.Bool(true),
+				Signup: &management.ConnectionOptionsAttributeSignup{
+					Status: auth0.String("required"),
+				},
+			},
+		},
+	}
+
+	configureHTTPTestRecordings(t, authAPI)
+
+	details := givenSignUpDetails(t, connectionOptions)
+
+	userData := database.SignupRequest{
+		Connection: details.connection,
+		Password:   details.password,
+		Username:   details.username,
+	}
+
+	createdUser, err := authAPI.Database.Signup(context.Background(), userData)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, createdUser.ID)
+	assert.Equal(t, userData.Username, createdUser.Username)
+}
+
+// TestDatabaseSignUp_WithUsernameAndEmailIdentifiers tests the Database.Signup method with a connection that requires both a username and email.
+func TestDatabaseSignUp_WithUsernameAndEmailIdentifiers(t *testing.T) {
+	connectionOptions := &management.ConnectionOptions{
+		Attributes: &management.ConnectionOptionsAttributes{
+			Username: &management.ConnectionOptionsUsernameAttribute{
+				Identifier: &management.ConnectionOptionsAttributeIdentifier{
+					Active: auth0.Bool(true),
+				},
+				ProfileRequired: auth0.Bool(true),
+				Signup: &management.ConnectionOptionsAttributeSignup{
+					Status: auth0.String("required"),
+				},
+			},
+			Email: &management.ConnectionOptionsEmailAttribute{
+				Identifier: &management.ConnectionOptionsAttributeIdentifier{
+					Active: auth0.Bool(true),
+				},
+				ProfileRequired: auth0.Bool(true),
+				Signup: &management.ConnectionOptionsAttributeSignup{
+					Status: auth0.String("required"),
+					Verification: &management.ConnectionOptionsAttributeVerification{
+						Active: auth0.Bool(false),
+					},
+				},
+			},
+		},
+	}
+
+	configureHTTPTestRecordings(t, authAPI)
+
+	details := givenSignUpDetails(t, connectionOptions)
+
+	userData := database.SignupRequest{
+		Connection: details.connection,
+		Username:   details.username,
+		Password:   details.password,
+		Email:      details.email,
+	}
+
+	createdUser, err := authAPI.Database.Signup(context.Background(), userData)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, createdUser.ID)
+	assert.Equal(t, userData.Username, createdUser.Username)
+	assert.Equal(t, userData.Email, createdUser.Email)
+}
+
+// TestDatabaseSignUp_WithPhoneNumberIdentifier tests the Database.Signup method with a connection that requires a phone number.
+func TestDatabaseSignUp_WithPhoneNumberIdentifier(t *testing.T) {
+	connectionOptions := &management.ConnectionOptions{
+		Attributes: &management.ConnectionOptionsAttributes{
+			PhoneNumber: &management.ConnectionOptionsPhoneNumberAttribute{
+				Identifier: &management.ConnectionOptionsAttributeIdentifier{
+					Active: auth0.Bool(true),
+				},
+				ProfileRequired: auth0.Bool(true),
+				Signup: &management.ConnectionOptionsAttributeSignup{
+					Status: auth0.String("required"),
+					Verification: &management.ConnectionOptionsAttributeVerification{
+						Active: auth0.Bool(false),
+					},
+				},
+			},
+		},
+	}
+
+	configureHTTPTestRecordings(t, authAPI)
+
+	details := givenSignUpDetails(t, connectionOptions)
+
+	userData := database.SignupRequest{
+		Connection:  details.connection,
+		Password:    details.password,
+		PhoneNumber: details.phoneNumber,
+	}
+
+	createdUser, err := authAPI.Database.Signup(context.Background(), userData)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, createdUser.ID)
+	assert.Equal(t, userData.PhoneNumber, createdUser.PhoneNumber)
+}
+
+// TestDatabaseSignUp_WithUsernameAndPhoneNumberIdentifiers tests the Database.Signup method with a connection that requires both a username and phone number.
+func TestDatabaseSignUp_WithUsernameAndPhoneNumberIdentifiers(t *testing.T) {
+	connectionOptions := &management.ConnectionOptions{
+		Attributes: &management.ConnectionOptionsAttributes{
+			Username: &management.ConnectionOptionsUsernameAttribute{
+				Identifier: &management.ConnectionOptionsAttributeIdentifier{
+					Active: auth0.Bool(true),
+				},
+				ProfileRequired: auth0.Bool(true),
+				Signup: &management.ConnectionOptionsAttributeSignup{
+					Status: auth0.String("required"),
+				},
+			},
+			PhoneNumber: &management.ConnectionOptionsPhoneNumberAttribute{
+				Identifier: &management.ConnectionOptionsAttributeIdentifier{
+					Active: auth0.Bool(true),
+				},
+				ProfileRequired: auth0.Bool(true),
+				Signup: &management.ConnectionOptionsAttributeSignup{
+					Status: auth0.String("required"),
+					Verification: &management.ConnectionOptionsAttributeVerification{
+						Active: auth0.Bool(false),
+					},
+				},
+			},
+		},
+	}
+
+	configureHTTPTestRecordings(t, authAPI)
+
+	details := givenSignUpDetails(t, connectionOptions)
+
+	userData := database.SignupRequest{
+		Connection:  details.connection,
+		Username:    details.username,
+		Password:    details.password,
+		PhoneNumber: details.phoneNumber,
+	}
+
+	createdUser, err := authAPI.Database.Signup(context.Background(), userData)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, createdUser.ID)
+	assert.Equal(t, userData.Username, createdUser.Username)
+	assert.Equal(t, userData.PhoneNumber, createdUser.PhoneNumber)
+}
+
+// TestDatabaseSignUp_WithUsernameEmailAndPhoneNumberIdentifiers tests the Database.Signup method with a connection that requires a username, email, and phone number.
+func TestDatabaseSignUp_WithUsernameEmailAndPhoneNumberIdentifiers(t *testing.T) {
+	connectionOptions := &management.ConnectionOptions{
+		Attributes: &management.ConnectionOptionsAttributes{
+			Username: &management.ConnectionOptionsUsernameAttribute{
+				Identifier: &management.ConnectionOptionsAttributeIdentifier{
+					Active: auth0.Bool(true),
+				},
+				ProfileRequired: auth0.Bool(true),
+				Signup: &management.ConnectionOptionsAttributeSignup{
+					Status: auth0.String("required"),
+				},
+			},
+			Email: &management.ConnectionOptionsEmailAttribute{
+				Identifier: &management.ConnectionOptionsAttributeIdentifier{
+					Active: auth0.Bool(true),
+				},
+				ProfileRequired: auth0.Bool(true),
+				Signup: &management.ConnectionOptionsAttributeSignup{
+					Status: auth0.String("required"),
+					Verification: &management.ConnectionOptionsAttributeVerification{
+						Active: auth0.Bool(false),
+					},
+				},
+			},
+			PhoneNumber: &management.ConnectionOptionsPhoneNumberAttribute{
+				Identifier: &management.ConnectionOptionsAttributeIdentifier{
+					Active: auth0.Bool(true),
+				},
+				ProfileRequired: auth0.Bool(true),
+				Signup: &management.ConnectionOptionsAttributeSignup{
+					Status: auth0.String("required"),
+					Verification: &management.ConnectionOptionsAttributeVerification{
+						Active: auth0.Bool(false),
+					},
+				},
+			},
+		},
+	}
+
+	configureHTTPTestRecordings(t, authAPI)
+
+	details := givenSignUpDetails(t, connectionOptions)
+
+	userData := database.SignupRequest{
+		Connection:  details.connection,
+		Username:    details.username,
+		Password:    details.password,
+		Email:       details.email,
+		PhoneNumber: details.phoneNumber,
+	}
+
+	createdUser, err := authAPI.Database.Signup(context.Background(), userData)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, createdUser.ID)
+	assert.Equal(t, userData.Username, createdUser.Username)
+	assert.Equal(t, userData.Email, createdUser.Email)
+	assert.Equal(t, userData.PhoneNumber, createdUser.PhoneNumber)
+}
+
+// TestDatabaseChangePassword tests the Database.ChangePassword method.
 func TestDatabaseChangePassword(t *testing.T) {
 	configureHTTPTestRecordings(t, authAPI)
 
@@ -46,43 +314,43 @@ func TestDatabaseChangePassword(t *testing.T) {
 }
 
 type userDetails struct {
-	username   string
-	password   string
-	email      string
-	connection string
+	username    string
+	password    string
+	email       string
+	connection  string
+	phoneNumber string
 }
 
-func givenSignUpDetails(t *testing.T) *userDetails {
+func givenSignUpDetails(t *testing.T, options *management.ConnectionOptions) *userDetails {
 	t.Helper()
 	// If we're running from recordings then we want to return the default
 	if usingRecordingResponses(t) {
 		return &userDetails{
-			username:   "mytestaccount",
-			password:   "mypassword",
-			email:      "mytestaccount@example.com",
-			connection: "Username-Password-Authentication",
+			username:    "mytestaccount",
+			password:    "mypassword",
+			email:       "mytestaccount@example.com",
+			phoneNumber: "+12345678900",
+			connection:  "Username-Password-Authentication",
 		}
 	}
-
-	conn := givenAConnection(t)
+	conn := givenAConnection(t, options)
 
 	return &userDetails{
-		username:   fmt.Sprintf("chuck%d", rand.Intn(999)),
-		password:   "Passwords hide their chuck",
-		email:      fmt.Sprintf("chuck%d@example.com", rand.Intn(999)),
-		connection: conn.GetName(),
+		username:    fmt.Sprintf("chuck%d", rand.Intn(999)),
+		password:    "Passwords hide their chuck",
+		email:       fmt.Sprintf("chuck%d@example.com", rand.Intn(999)),
+		phoneNumber: fmt.Sprintf("+1234567890%d", rand.Intn(9)),
+		connection:  conn.GetName(),
 	}
 }
 
-func givenAConnection(t *testing.T) management.Connection {
+func givenAConnection(t *testing.T, options *management.ConnectionOptions) *management.Connection {
 	conn := &management.Connection{
 		Name:           auth0.Stringf("Test-Connection-%d", time.Now().Unix()),
 		Strategy:       auth0.String("auth0"),
 		EnabledClients: &[]string{clientID, mgmtClientID},
-		Options: &management.ConnectionOptions{
-			RequiresUsername: auth0.Bool(true),
-		},
 	}
+	conn.Options = &options
 
 	err := mgmtAPI.Connection.Create(context.Background(), conn)
 	require.NoError(t, err)
@@ -92,5 +360,5 @@ func givenAConnection(t *testing.T) management.Connection {
 		require.NoError(t, err)
 	})
 
-	return *conn
+	return conn
 }

--- a/management/connection.go
+++ b/management/connection.go
@@ -464,6 +464,22 @@ type ConnectionOptionsAttributeSignup struct {
 	Verification *ConnectionOptionsAttributeVerification `json:"verification,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaler interface.
+func (c *ConnectionOptionsUsernameAttribute) MarshalJSON() ([]byte, error) {
+	type connectionOptionsUsernameAttribute ConnectionOptionsUsernameAttribute
+	alias := &struct {
+		*connectionOptionsUsernameAttribute
+	}{
+		connectionOptionsUsernameAttribute: (*connectionOptionsUsernameAttribute)(c),
+	}
+
+	if alias.Signup != nil {
+		alias.Signup.Verification = nil
+	}
+
+	return json.Marshal(alias)
+}
+
 // ConnectionOptionsAttributeVerification defines verification settings for an attribute.
 type ConnectionOptionsAttributeVerification struct {
 	Active *bool `json:"active"`

--- a/management/connection.go
+++ b/management/connection.go
@@ -424,7 +424,7 @@ type ConnectionOptions struct {
 
 	// Order of attributes for precedence in identification.
 	// Valid values: "email", "phone_number", "username"
-	// The order to lookup a user identity.
+	// If Precedence is set, it must contain all three values ("email", "phone_number", "username") specifying the order to look up a user identity.
 	Precedence *[]string `json:"precedence,omitempty"`
 
 	// Attributes configures identifiers and other options for user attributes.

--- a/management/connection.go
+++ b/management/connection.go
@@ -421,6 +421,87 @@ type ConnectionOptions struct {
 
 	// Options for the passkey authentication method.
 	PasskeyOptions *PasskeyOptions `json:"passkey_options,omitempty"`
+
+	// Order of attributes for precedence in identification.
+	// Valid values: "email", "phone_number", "username"
+	// The order to lookup a user identity.
+	Precedence *[]string `json:"precedence,omitempty"`
+
+	// Attributes configures identifiers and other options for user attributes.
+	//
+	// The `attributes` field is a map that holds configuration for various identifiers.
+	//
+	// Each identifier (e.g., "phone_number", "email", "username") can include the following keys:
+	//   1. `active`: Specifies if the identifier is active. Example: {"active": bool}.
+	//   2. `profile_required`: Specifies if the identifier is required in the user's profile. Example: {"profile_required": bool}.
+	//   3. `signup`: Configures the identifier for signup. `verification` is not supported for the username identifier. Example: {"status": "required" | "optional" | "inactive", "verification": {"active": bool}}.
+	//
+	// Notes:
+	//   - At least one identifier must be active in `attributes`.
+	//   - Combining `requires_username` and `attributes` in the same configuration is not allowed.
+	//   - Combining `attributes` and `validation` in the same configuration is not allowed.
+	//   - If any identifier is required in the profile, it must be active during signup.
+	Attributes *ConnectionOptionsAttributes `json:"attributes,omitempty"`
+}
+
+// ConnectionOptionsAttributes defines the structure for attribute configurations.
+type ConnectionOptionsAttributes struct {
+	Email       *ConnectionOptionsEmailAttribute       `json:"email,omitempty"`
+	Username    *ConnectionOptionsUsernameAttribute    `json:"username,omitempty"`
+	PhoneNumber *ConnectionOptionsPhoneNumberAttribute `json:"phone_number,omitempty"`
+}
+
+// ConnectionOptionsAttributeIdentifier defines whether an attribute is active as an identifier.
+type ConnectionOptionsAttributeIdentifier struct {
+	Active *bool `json:"active"`
+}
+
+// ConnectionOptionsAttributeSignup defines signup settings for an attribute.
+type ConnectionOptionsAttributeSignup struct {
+	Status *string `json:"status"`
+
+	// Verification settings for an attribute. Only applicable to email and phone_number attributes.
+	Verification *ConnectionOptionsAttributeVerification `json:"verification,omitempty"`
+}
+
+// ConnectionOptionsAttributeVerification defines verification settings for an attribute.
+type ConnectionOptionsAttributeVerification struct {
+	Active *bool `json:"active"`
+}
+
+// ConnectionOptionsAttributeValidation defines validation settings for an attribute.
+type ConnectionOptionsAttributeValidation struct {
+	MinLength    *int                                    `json:"min_length,omitempty"`
+	MaxLength    *int                                    `json:"max_length,omitempty"`
+	AllowedTypes *ConnectionOptionsAttributeAllowedTypes `json:"allowed_types,omitempty"`
+}
+
+// ConnectionOptionsAttributeAllowedTypes defines allowed types for an attribute.
+type ConnectionOptionsAttributeAllowedTypes struct {
+	Email       *bool `json:"email"`
+	PhoneNumber *bool `json:"phone_number"`
+}
+
+// ConnectionOptionsEmailAttribute defines configuration settings for email attributes.
+type ConnectionOptionsEmailAttribute struct {
+	Identifier      *ConnectionOptionsAttributeIdentifier `json:"identifier,omitempty"`
+	ProfileRequired *bool                                 `json:"profile_required"`
+	Signup          *ConnectionOptionsAttributeSignup     `json:"signup,omitempty"`
+}
+
+// ConnectionOptionsUsernameAttribute defines configuration settings for username attributes.
+type ConnectionOptionsUsernameAttribute struct {
+	Identifier      *ConnectionOptionsAttributeIdentifier `json:"identifier,omitempty"`
+	ProfileRequired *bool                                 `json:"profile_required"`
+	Signup          *ConnectionOptionsAttributeSignup     `json:"signup,omitempty"`
+	Validation      *ConnectionOptionsAttributeValidation `json:"validation,omitempty"`
+}
+
+// ConnectionOptionsPhoneNumberAttribute defines configuration settings for phone number attributes.
+type ConnectionOptionsPhoneNumberAttribute struct {
+	Identifier      *ConnectionOptionsAttributeIdentifier `json:"identifier,omitempty"`
+	ProfileRequired *bool                                 `json:"profile_required"`
+	Signup          *ConnectionOptionsAttributeSignup     `json:"signup,omitempty"`
 }
 
 // AuthenticationMethods represents the options for enabling authentication methods for the connection.

--- a/management/connection.go
+++ b/management/connection.go
@@ -437,6 +437,7 @@ type ConnectionOptions struct {
 	//   3. `signup`: Configures the identifier for signup. `verification` is not supported for the username identifier. Example: {"status": "required" | "optional" | "inactive", "verification": {"active": bool}}.
 	//
 	// Notes:
+	//   - For ConnectionOptionsPhoneNumberAttribute identifiers, the configuration is only available when the "identifier first" Prompt is enabled.
 	//   - At least one identifier must be active in `attributes`.
 	//   - Combining `requires_username` and `attributes` in the same configuration is not allowed.
 	//   - Combining `attributes` and `validation` in the same configuration is not allowed.
@@ -514,6 +515,7 @@ type ConnectionOptionsUsernameAttribute struct {
 }
 
 // ConnectionOptionsPhoneNumberAttribute defines configuration settings for phone number attributes.
+// This attribute is available only when the Prompt 'identifier first' setting is enabled.
 type ConnectionOptionsPhoneNumberAttribute struct {
 	Identifier      *ConnectionOptionsAttributeIdentifier `json:"identifier,omitempty"`
 	ProfileRequired *bool                                 `json:"profile_required"`

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -484,6 +484,7 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 			Strategy: auth0.String("auth0"),
 		},
 		options: &ConnectionOptions{
+			Precedence:       &[]string{"username", "email", "phone_number"},
 			RequiresUsername: auth0.Bool(true),
 		},
 	},
@@ -494,6 +495,7 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 			Strategy: auth0.String("auth0"),
 		},
 		options: &ConnectionOptions{
+			Precedence: &[]string{"username", "email", "phone_number"},
 			Attributes: &ConnectionOptionsAttributes{
 				PhoneNumber: &ConnectionOptionsPhoneNumberAttribute{
 					Identifier: &ConnectionOptionsAttributeIdentifier{
@@ -514,6 +516,7 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 			Strategy: auth0.String("auth0"),
 		},
 		options: &ConnectionOptions{
+			Precedence: &[]string{"username", "email", "phone_number"},
 			Attributes: &ConnectionOptionsAttributes{
 				Email: &ConnectionOptionsEmailAttribute{
 					Identifier: &ConnectionOptionsAttributeIdentifier{
@@ -534,6 +537,7 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 			Strategy: auth0.String("auth0"),
 		},
 		options: &ConnectionOptions{
+			Precedence: &[]string{"username", "email", "phone_number"},
 			Attributes: &ConnectionOptionsAttributes{
 				Username: &ConnectionOptionsUsernameAttribute{
 					Identifier: &ConnectionOptionsAttributeIdentifier{
@@ -554,6 +558,7 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 			Strategy: auth0.String("auth0"),
 		},
 		options: &ConnectionOptions{
+			Precedence:       &[]string{"username", "email", "phone_number"},
 			RequiresUsername: auth0.Bool(true),
 			Attributes: &ConnectionOptionsAttributes{
 				Email: &ConnectionOptionsEmailAttribute{
@@ -575,6 +580,7 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 			Strategy: auth0.String("auth0"),
 		},
 		options: &ConnectionOptions{
+			Precedence: &[]string{"username", "email", "phone_number"},
 			Attributes: &ConnectionOptionsAttributes{
 				PhoneNumber: &ConnectionOptionsPhoneNumberAttribute{
 					Identifier: &ConnectionOptionsAttributeIdentifier{
@@ -613,6 +619,7 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 			Strategy: auth0.String("auth0"),
 		},
 		options: &ConnectionOptions{
+			Precedence: &[]string{"username", "email", "phone_number"},
 			Attributes: &ConnectionOptionsAttributes{
 				Email: &ConnectionOptionsEmailAttribute{
 					Identifier: &ConnectionOptionsAttributeIdentifier{
@@ -648,6 +655,7 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 			Strategy: auth0.String("auth0"),
 		},
 		options: &ConnectionOptions{
+			Precedence: &[]string{"username", "email", "phone_number"},
 			Attributes: &ConnectionOptionsAttributes{
 				PhoneNumber: &ConnectionOptionsPhoneNumberAttribute{
 					Identifier: &ConnectionOptionsAttributeIdentifier{

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -503,8 +503,11 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 					},
 					ProfileRequired: auth0.Bool(true),
 					Signup: &ConnectionOptionsAttributeSignup{
-						Status:       auth0.String("required"),
-						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+						Status: auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{
+							Active: auth0.Bool(false),
+						},
+					},
 				},
 			},
 		},
@@ -524,8 +527,11 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 					},
 					ProfileRequired: auth0.Bool(true),
 					Signup: &ConnectionOptionsAttributeSignup{
-						Status:       auth0.String("required"),
-						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+						Status: auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{
+							Active: auth0.Bool(false),
+						},
+					},
 				},
 			},
 		},
@@ -567,8 +573,11 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 					},
 					ProfileRequired: auth0.Bool(true),
 					Signup: &ConnectionOptionsAttributeSignup{
-						Status:       auth0.String("required"),
-						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+						Status: auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{
+							Active: auth0.Bool(false),
+						},
+					},
 				},
 			},
 		},
@@ -588,8 +597,11 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 					},
 					ProfileRequired: auth0.Bool(true),
 					Signup: &ConnectionOptionsAttributeSignup{
-						Status:       auth0.String("required"),
-						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+						Status: auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{
+							Active: auth0.Bool(false),
+						},
+					},
 				},
 				Email: &ConnectionOptionsEmailAttribute{
 					Identifier: &ConnectionOptionsAttributeIdentifier{
@@ -597,8 +609,11 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 					},
 					ProfileRequired: auth0.Bool(true),
 					Signup: &ConnectionOptionsAttributeSignup{
-						Status:       auth0.String("required"),
-						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+						Status: auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{
+							Active: auth0.Bool(false),
+						},
+					},
 				},
 				Username: &ConnectionOptionsUsernameAttribute{
 					Identifier: &ConnectionOptionsAttributeIdentifier{
@@ -627,8 +642,11 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 					},
 					ProfileRequired: auth0.Bool(true),
 					Signup: &ConnectionOptionsAttributeSignup{
-						Status:       auth0.String("required"),
-						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+						Status: auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{
+							Active: auth0.Bool(false),
+						},
+					},
 				},
 				Username: &ConnectionOptionsUsernameAttribute{
 					Identifier: &ConnectionOptionsAttributeIdentifier{
@@ -663,8 +681,11 @@ var Auth0ConnectionTestCase = []connectionTestCase{
 					},
 					ProfileRequired: auth0.Bool(true),
 					Signup: &ConnectionOptionsAttributeSignup{
-						Status:       auth0.String("inactive"),
-						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+						Status: auth0.String("inactive"),
+						Verification: &ConnectionOptionsAttributeVerification{
+							Active: auth0.Bool(false),
+						},
+					},
 				},
 			},
 		},
@@ -1061,6 +1082,37 @@ func TestConnectionManager_DeleteSCIMToken(t *testing.T) {
 	t.Cleanup(func() {
 		cleanupSCIMConfig(t, expectedConnection.GetID())
 	})
+}
+func TestConnectionOptionsUsernameAttribute_MarshalJSON(t *testing.T) {
+	for attribute, expected := range map[*ConnectionOptionsUsernameAttribute]string{
+		{
+			Identifier: &ConnectionOptionsAttributeIdentifier{
+				Active: auth0.Bool(true),
+			},
+			ProfileRequired: auth0.Bool(true),
+			Signup: &ConnectionOptionsAttributeSignup{
+				Status:       auth0.String("required"),
+				Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)},
+			},
+		}: `{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"}}`,
+		{
+			ProfileRequired: auth0.Bool(true),
+			Signup: &ConnectionOptionsAttributeSignup{
+				Status: auth0.String("required"),
+			},
+		}: `{"profile_required":true,"signup":{"status":"required"}}`,
+
+		{
+			Identifier: &ConnectionOptionsAttributeIdentifier{
+				Active: auth0.Bool(true),
+			},
+			ProfileRequired: auth0.Bool(true),
+		}: `{"identifier":{"active":true},"profile_required":true}`,
+	} {
+		payload, err := json.Marshal(attribute)
+		assert.NoError(t, err)
+		assert.JSONEq(t, expected, string(payload))
+	}
 }
 
 func TestOAuth2Connection_MarshalJSON(t *testing.T) {

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -476,6 +476,231 @@ func TestConnectionManager_Create(t *testing.T) {
 	}
 }
 
+var Auth0ConnectionTestCase = []connectionTestCase{
+	{
+		name: "Auth0 Connection With RequireUsername",
+		connection: Connection{
+			Name:     auth0.Stringf("Test-Auth0-Connection-RequireUsername-%d", time.Now().Unix()),
+			Strategy: auth0.String("auth0"),
+		},
+		options: &ConnectionOptions{
+			RequiresUsername: auth0.Bool(true),
+		},
+	},
+	{
+		name: "Auth0 Connection with PhoneNumber as Identifier",
+		connection: Connection{
+			Name:     auth0.Stringf("Test-Auth0-Connection-Phone-%d", time.Now().Unix()),
+			Strategy: auth0.String("auth0"),
+		},
+		options: &ConnectionOptions{
+			Attributes: &ConnectionOptionsAttributes{
+				PhoneNumber: &ConnectionOptionsPhoneNumberAttribute{
+					Identifier: &ConnectionOptionsAttributeIdentifier{
+						Active: auth0.Bool(true),
+					},
+					ProfileRequired: auth0.Bool(true),
+					Signup: &ConnectionOptionsAttributeSignup{
+						Status:       auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+				},
+			},
+		},
+	},
+	{
+		name: "Auth0 Connection with Email as Identifier",
+		connection: Connection{
+			Name:     auth0.Stringf("Test-Auth0-Connection-Email-%d", time.Now().Unix()),
+			Strategy: auth0.String("auth0"),
+		},
+		options: &ConnectionOptions{
+			Attributes: &ConnectionOptionsAttributes{
+				Email: &ConnectionOptionsEmailAttribute{
+					Identifier: &ConnectionOptionsAttributeIdentifier{
+						Active: auth0.Bool(true),
+					},
+					ProfileRequired: auth0.Bool(true),
+					Signup: &ConnectionOptionsAttributeSignup{
+						Status:       auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+				},
+			},
+		},
+	},
+	{
+		name: "Auth0 Connection with Username as Identifier",
+		connection: Connection{
+			Name:     auth0.Stringf("Test-Auth0-Connection-Username-%d", time.Now().Unix()),
+			Strategy: auth0.String("auth0"),
+		},
+		options: &ConnectionOptions{
+			Attributes: &ConnectionOptionsAttributes{
+				Username: &ConnectionOptionsUsernameAttribute{
+					Identifier: &ConnectionOptionsAttributeIdentifier{
+						Active: auth0.Bool(true),
+					},
+					ProfileRequired: auth0.Bool(true),
+					Signup: &ConnectionOptionsAttributeSignup{
+						Status: auth0.String("required"),
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "Auth0 Connection Cannot set both requires_username and attributes together",
+		connection: Connection{
+			Name:     auth0.Stringf("Test-Auth0-Connection-Invalid-%d", time.Now().Unix()),
+			Strategy: auth0.String("auth0"),
+		},
+		options: &ConnectionOptions{
+			RequiresUsername: auth0.Bool(true),
+			Attributes: &ConnectionOptionsAttributes{
+				Email: &ConnectionOptionsEmailAttribute{
+					Identifier: &ConnectionOptionsAttributeIdentifier{
+						Active: auth0.Bool(true),
+					},
+					ProfileRequired: auth0.Bool(true),
+					Signup: &ConnectionOptionsAttributeSignup{
+						Status:       auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+				},
+			},
+		},
+	},
+	{
+		name: "Auth0 Connection With No attribute is active",
+		connection: Connection{
+			Name:     auth0.Stringf("Test-Auth0-Connection-No-Active-Attributes-%d", time.Now().Unix()),
+			Strategy: auth0.String("auth0"),
+		},
+		options: &ConnectionOptions{
+			Attributes: &ConnectionOptionsAttributes{
+				PhoneNumber: &ConnectionOptionsPhoneNumberAttribute{
+					Identifier: &ConnectionOptionsAttributeIdentifier{
+						Active: auth0.Bool(false),
+					},
+					ProfileRequired: auth0.Bool(true),
+					Signup: &ConnectionOptionsAttributeSignup{
+						Status:       auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+				},
+				Email: &ConnectionOptionsEmailAttribute{
+					Identifier: &ConnectionOptionsAttributeIdentifier{
+						Active: auth0.Bool(false),
+					},
+					ProfileRequired: auth0.Bool(true),
+					Signup: &ConnectionOptionsAttributeSignup{
+						Status:       auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+				},
+				Username: &ConnectionOptionsUsernameAttribute{
+					Identifier: &ConnectionOptionsAttributeIdentifier{
+						Active: auth0.Bool(false),
+					},
+					ProfileRequired: auth0.Bool(true),
+					Signup: &ConnectionOptionsAttributeSignup{
+						Status: auth0.String("required"),
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "Auth0 Connection Cannot set both validation and attributes together",
+		connection: Connection{
+			Name:     auth0.Stringf("Test-Auth0-Connection-Attributes-And-Validation-%d", time.Now().Unix()),
+			Strategy: auth0.String("auth0"),
+		},
+		options: &ConnectionOptions{
+			Attributes: &ConnectionOptionsAttributes{
+				Email: &ConnectionOptionsEmailAttribute{
+					Identifier: &ConnectionOptionsAttributeIdentifier{
+						Active: auth0.Bool(true),
+					},
+					ProfileRequired: auth0.Bool(true),
+					Signup: &ConnectionOptionsAttributeSignup{
+						Status:       auth0.String("required"),
+						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+				},
+				Username: &ConnectionOptionsUsernameAttribute{
+					Identifier: &ConnectionOptionsAttributeIdentifier{
+						Active: auth0.Bool(true),
+					},
+					ProfileRequired: auth0.Bool(true),
+					Signup: &ConnectionOptionsAttributeSignup{
+						Status: auth0.String("required"),
+					},
+				},
+			},
+			Validation: map[string]interface{}{
+				"username": map[string]interface{}{
+					"min": 1,
+					"max": 5,
+				},
+			},
+		},
+	},
+	{
+		name: "Auth0 Connection Attribute required in profile but inactive on signup",
+		connection: Connection{
+			Name:     auth0.Stringf("Test-Auth0-Connection-Attribute-Inactive-On-Signup-%d", time.Now().Unix()),
+			Strategy: auth0.String("auth0"),
+		},
+		options: &ConnectionOptions{
+			Attributes: &ConnectionOptionsAttributes{
+				PhoneNumber: &ConnectionOptionsPhoneNumberAttribute{
+					Identifier: &ConnectionOptionsAttributeIdentifier{
+						Active: auth0.Bool(true),
+					},
+					ProfileRequired: auth0.Bool(true),
+					Signup: &ConnectionOptionsAttributeSignup{
+						Status:       auth0.String("inactive"),
+						Verification: &ConnectionOptionsAttributeVerification{Active: auth0.Bool(false)}},
+				},
+			},
+		},
+	},
+}
+
+func TestConnectionManager_CreateDBConnectionWithDifferentOptions(t *testing.T) {
+	for _, testCase := range Auth0ConnectionTestCase {
+		t.Run("It handles "+testCase.name, func(t *testing.T) {
+			configureHTTPTestRecordings(t)
+
+			expectedConnection := testCase.connection
+			expectedConnection.Options = testCase.options
+
+			err := api.Connection.Create(context.Background(), &expectedConnection)
+
+			switch testCase.name {
+			case "Auth0 Connection Cannot set both requires_username and attributes together":
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "Cannot set both options.attributes and options.requires_username")
+			case "Auth0 Connection With No attribute is active":
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "attributes must contain one active identifier")
+			case "Auth0 Connection Cannot set both validation and attributes together":
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "Cannot set both options.attributes and options.validation")
+			case "Auth0 Connection Attribute required in profile but inactive on signup":
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "attribute phone_number must also be required on signup")
+			default:
+				assert.NoError(t, err)
+				assert.NotEmpty(t, expectedConnection.Name)
+				assert.NotEmpty(t, expectedConnection.Strategy)
+			}
+
+			if err == nil {
+				t.Cleanup(func() {
+					cleanupConnection(t, expectedConnection.GetID())
+				})
+			}
+		})
+	}
+}
+
 func TestConnectionManager_Read(t *testing.T) {
 	for _, testCase := range connectionTestCases {
 		t.Run("It can successfully read a "+testCase.name, func(t *testing.T) {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2169,6 +2169,14 @@ func (c *ConnectionList) String() string {
 	return Stringify(c)
 }
 
+// GetAttributes returns the Attributes field.
+func (c *ConnectionOptions) GetAttributes() *ConnectionOptionsAttributes {
+	if c == nil {
+		return nil
+	}
+	return c.Attributes
+}
+
 // GetAuthenticationMethods returns the AuthenticationMethods field.
 func (c *ConnectionOptions) GetAuthenticationMethods() *AuthenticationMethods {
 	if c == nil {
@@ -2303,6 +2311,14 @@ func (c *ConnectionOptions) GetPasswordPolicy() string {
 		return ""
 	}
 	return *c.PasswordPolicy
+}
+
+// GetPrecedence returns the Precedence field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptions) GetPrecedence() []string {
+	if c == nil || c.Precedence == nil {
+		return nil
+	}
+	return *c.Precedence
 }
 
 // GetRequiresUsername returns the RequiresUsername field if it's non-nil, zero value otherwise.
@@ -2701,6 +2717,132 @@ func (c *ConnectionOptionsApple) String() string {
 	return Stringify(c)
 }
 
+// GetEmail returns the Email field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAttributeAllowedTypes) GetEmail() bool {
+	if c == nil || c.Email == nil {
+		return false
+	}
+	return *c.Email
+}
+
+// GetPhoneNumber returns the PhoneNumber field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAttributeAllowedTypes) GetPhoneNumber() bool {
+	if c == nil || c.PhoneNumber == nil {
+		return false
+	}
+	return *c.PhoneNumber
+}
+
+// String returns a string representation of ConnectionOptionsAttributeAllowedTypes.
+func (c *ConnectionOptionsAttributeAllowedTypes) String() string {
+	return Stringify(c)
+}
+
+// GetActive returns the Active field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAttributeIdentifier) GetActive() bool {
+	if c == nil || c.Active == nil {
+		return false
+	}
+	return *c.Active
+}
+
+// String returns a string representation of ConnectionOptionsAttributeIdentifier.
+func (c *ConnectionOptionsAttributeIdentifier) String() string {
+	return Stringify(c)
+}
+
+// GetEmail returns the Email field.
+func (c *ConnectionOptionsAttributes) GetEmail() *ConnectionOptionsEmailAttribute {
+	if c == nil {
+		return nil
+	}
+	return c.Email
+}
+
+// GetPhoneNumber returns the PhoneNumber field.
+func (c *ConnectionOptionsAttributes) GetPhoneNumber() *ConnectionOptionsPhoneNumberAttribute {
+	if c == nil {
+		return nil
+	}
+	return c.PhoneNumber
+}
+
+// GetUsername returns the Username field.
+func (c *ConnectionOptionsAttributes) GetUsername() *ConnectionOptionsUsernameAttribute {
+	if c == nil {
+		return nil
+	}
+	return c.Username
+}
+
+// String returns a string representation of ConnectionOptionsAttributes.
+func (c *ConnectionOptionsAttributes) String() string {
+	return Stringify(c)
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAttributeSignup) GetStatus() string {
+	if c == nil || c.Status == nil {
+		return ""
+	}
+	return *c.Status
+}
+
+// GetVerification returns the Verification field.
+func (c *ConnectionOptionsAttributeSignup) GetVerification() *ConnectionOptionsAttributeVerification {
+	if c == nil {
+		return nil
+	}
+	return c.Verification
+}
+
+// String returns a string representation of ConnectionOptionsAttributeSignup.
+func (c *ConnectionOptionsAttributeSignup) String() string {
+	return Stringify(c)
+}
+
+// GetAllowedTypes returns the AllowedTypes field.
+func (c *ConnectionOptionsAttributeValidation) GetAllowedTypes() *ConnectionOptionsAttributeAllowedTypes {
+	if c == nil {
+		return nil
+	}
+	return c.AllowedTypes
+}
+
+// GetMaxLength returns the MaxLength field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAttributeValidation) GetMaxLength() int {
+	if c == nil || c.MaxLength == nil {
+		return 0
+	}
+	return *c.MaxLength
+}
+
+// GetMinLength returns the MinLength field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAttributeValidation) GetMinLength() int {
+	if c == nil || c.MinLength == nil {
+		return 0
+	}
+	return *c.MinLength
+}
+
+// String returns a string representation of ConnectionOptionsAttributeValidation.
+func (c *ConnectionOptionsAttributeValidation) String() string {
+	return Stringify(c)
+}
+
+// GetActive returns the Active field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAttributeVerification) GetActive() bool {
+	if c == nil || c.Active == nil {
+		return false
+	}
+	return *c.Active
+}
+
+// String returns a string representation of ConnectionOptionsAttributeVerification.
+func (c *ConnectionOptionsAttributeVerification) String() string {
+	return Stringify(c)
+}
+
 // GetAdmin returns the Admin field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsAzureAD) GetAdmin() bool {
 	if c == nil || c.Admin == nil {
@@ -3020,6 +3162,35 @@ func (c *ConnectionOptionsEmail) GetUpstreamParams() map[string]interface{} {
 
 // String returns a string representation of ConnectionOptionsEmail.
 func (c *ConnectionOptionsEmail) String() string {
+	return Stringify(c)
+}
+
+// GetIdentifier returns the Identifier field.
+func (c *ConnectionOptionsEmailAttribute) GetIdentifier() *ConnectionOptionsAttributeIdentifier {
+	if c == nil {
+		return nil
+	}
+	return c.Identifier
+}
+
+// GetProfileRequired returns the ProfileRequired field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsEmailAttribute) GetProfileRequired() bool {
+	if c == nil || c.ProfileRequired == nil {
+		return false
+	}
+	return *c.ProfileRequired
+}
+
+// GetSignup returns the Signup field.
+func (c *ConnectionOptionsEmailAttribute) GetSignup() *ConnectionOptionsAttributeSignup {
+	if c == nil {
+		return nil
+	}
+	return c.Signup
+}
+
+// String returns a string representation of ConnectionOptionsEmailAttribute.
+func (c *ConnectionOptionsEmailAttribute) String() string {
 	return Stringify(c)
 }
 
@@ -4627,6 +4798,35 @@ func (c *ConnectionOptionsOTP) String() string {
 	return Stringify(c)
 }
 
+// GetIdentifier returns the Identifier field.
+func (c *ConnectionOptionsPhoneNumberAttribute) GetIdentifier() *ConnectionOptionsAttributeIdentifier {
+	if c == nil {
+		return nil
+	}
+	return c.Identifier
+}
+
+// GetProfileRequired returns the ProfileRequired field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsPhoneNumberAttribute) GetProfileRequired() bool {
+	if c == nil || c.ProfileRequired == nil {
+		return false
+	}
+	return *c.ProfileRequired
+}
+
+// GetSignup returns the Signup field.
+func (c *ConnectionOptionsPhoneNumberAttribute) GetSignup() *ConnectionOptionsAttributeSignup {
+	if c == nil {
+		return nil
+	}
+	return c.Signup
+}
+
+// String returns a string representation of ConnectionOptionsPhoneNumberAttribute.
+func (c *ConnectionOptionsPhoneNumberAttribute) String() string {
+	return Stringify(c)
+}
+
 // GetAgentIP returns the AgentIP field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsPingFederate) GetAgentIP() string {
 	if c == nil || c.AgentIP == nil {
@@ -5483,6 +5683,43 @@ func (c *ConnectionOptionsSMS) GetUpstreamParams() map[string]interface{} {
 
 // String returns a string representation of ConnectionOptionsSMS.
 func (c *ConnectionOptionsSMS) String() string {
+	return Stringify(c)
+}
+
+// GetIdentifier returns the Identifier field.
+func (c *ConnectionOptionsUsernameAttribute) GetIdentifier() *ConnectionOptionsAttributeIdentifier {
+	if c == nil {
+		return nil
+	}
+	return c.Identifier
+}
+
+// GetProfileRequired returns the ProfileRequired field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsUsernameAttribute) GetProfileRequired() bool {
+	if c == nil || c.ProfileRequired == nil {
+		return false
+	}
+	return *c.ProfileRequired
+}
+
+// GetSignup returns the Signup field.
+func (c *ConnectionOptionsUsernameAttribute) GetSignup() *ConnectionOptionsAttributeSignup {
+	if c == nil {
+		return nil
+	}
+	return c.Signup
+}
+
+// GetValidation returns the Validation field.
+func (c *ConnectionOptionsUsernameAttribute) GetValidation() *ConnectionOptionsAttributeValidation {
+	if c == nil {
+		return nil
+	}
+	return c.Validation
+}
+
+// String returns a string representation of ConnectionOptionsUsernameAttribute.
+func (c *ConnectionOptionsUsernameAttribute) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2654,6 +2654,13 @@ func TestConnectionList_String(t *testing.T) {
 	}
 }
 
+func TestConnectionOptions_GetAttributes(tt *testing.T) {
+	c := &ConnectionOptions{}
+	c.GetAttributes()
+	c = nil
+	c.GetAttributes()
+}
+
 func TestConnectionOptions_GetAuthenticationMethods(tt *testing.T) {
 	c := &ConnectionOptions{}
 	c.GetAuthenticationMethods()
@@ -2816,6 +2823,16 @@ func TestConnectionOptions_GetPasswordPolicy(tt *testing.T) {
 	c.GetPasswordPolicy()
 	c = nil
 	c.GetPasswordPolicy()
+}
+
+func TestConnectionOptions_GetPrecedence(tt *testing.T) {
+	var zeroValue []string
+	c := &ConnectionOptions{Precedence: &zeroValue}
+	c.GetPrecedence()
+	c = &ConnectionOptions{}
+	c.GetPrecedence()
+	c = nil
+	c.GetPrecedence()
 }
 
 func TestConnectionOptions_GetRequiresUsername(tt *testing.T) {
@@ -3320,6 +3337,159 @@ func TestConnectionOptionsApple_String(t *testing.T) {
 	}
 }
 
+func TestConnectionOptionsAttributeAllowedTypes_GetEmail(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsAttributeAllowedTypes{Email: &zeroValue}
+	c.GetEmail()
+	c = &ConnectionOptionsAttributeAllowedTypes{}
+	c.GetEmail()
+	c = nil
+	c.GetEmail()
+}
+
+func TestConnectionOptionsAttributeAllowedTypes_GetPhoneNumber(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsAttributeAllowedTypes{PhoneNumber: &zeroValue}
+	c.GetPhoneNumber()
+	c = &ConnectionOptionsAttributeAllowedTypes{}
+	c.GetPhoneNumber()
+	c = nil
+	c.GetPhoneNumber()
+}
+
+func TestConnectionOptionsAttributeAllowedTypes_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsAttributeAllowedTypes{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsAttributeIdentifier_GetActive(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsAttributeIdentifier{Active: &zeroValue}
+	c.GetActive()
+	c = &ConnectionOptionsAttributeIdentifier{}
+	c.GetActive()
+	c = nil
+	c.GetActive()
+}
+
+func TestConnectionOptionsAttributeIdentifier_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsAttributeIdentifier{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsAttributes_GetEmail(tt *testing.T) {
+	c := &ConnectionOptionsAttributes{}
+	c.GetEmail()
+	c = nil
+	c.GetEmail()
+}
+
+func TestConnectionOptionsAttributes_GetPhoneNumber(tt *testing.T) {
+	c := &ConnectionOptionsAttributes{}
+	c.GetPhoneNumber()
+	c = nil
+	c.GetPhoneNumber()
+}
+
+func TestConnectionOptionsAttributes_GetUsername(tt *testing.T) {
+	c := &ConnectionOptionsAttributes{}
+	c.GetUsername()
+	c = nil
+	c.GetUsername()
+}
+
+func TestConnectionOptionsAttributes_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsAttributes{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsAttributeSignup_GetStatus(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsAttributeSignup{Status: &zeroValue}
+	c.GetStatus()
+	c = &ConnectionOptionsAttributeSignup{}
+	c.GetStatus()
+	c = nil
+	c.GetStatus()
+}
+
+func TestConnectionOptionsAttributeSignup_GetVerification(tt *testing.T) {
+	c := &ConnectionOptionsAttributeSignup{}
+	c.GetVerification()
+	c = nil
+	c.GetVerification()
+}
+
+func TestConnectionOptionsAttributeSignup_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsAttributeSignup{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsAttributeValidation_GetAllowedTypes(tt *testing.T) {
+	c := &ConnectionOptionsAttributeValidation{}
+	c.GetAllowedTypes()
+	c = nil
+	c.GetAllowedTypes()
+}
+
+func TestConnectionOptionsAttributeValidation_GetMaxLength(tt *testing.T) {
+	var zeroValue int
+	c := &ConnectionOptionsAttributeValidation{MaxLength: &zeroValue}
+	c.GetMaxLength()
+	c = &ConnectionOptionsAttributeValidation{}
+	c.GetMaxLength()
+	c = nil
+	c.GetMaxLength()
+}
+
+func TestConnectionOptionsAttributeValidation_GetMinLength(tt *testing.T) {
+	var zeroValue int
+	c := &ConnectionOptionsAttributeValidation{MinLength: &zeroValue}
+	c.GetMinLength()
+	c = &ConnectionOptionsAttributeValidation{}
+	c.GetMinLength()
+	c = nil
+	c.GetMinLength()
+}
+
+func TestConnectionOptionsAttributeValidation_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsAttributeValidation{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsAttributeVerification_GetActive(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsAttributeVerification{Active: &zeroValue}
+	c.GetActive()
+	c = &ConnectionOptionsAttributeVerification{}
+	c.GetActive()
+	c = nil
+	c.GetActive()
+}
+
+func TestConnectionOptionsAttributeVerification_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsAttributeVerification{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestConnectionOptionsAzureAD_GetAdmin(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptionsAzureAD{Admin: &zeroValue}
@@ -3715,6 +3885,38 @@ func TestConnectionOptionsEmail_GetUpstreamParams(tt *testing.T) {
 func TestConnectionOptionsEmail_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ConnectionOptionsEmail{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsEmailAttribute_GetIdentifier(tt *testing.T) {
+	c := &ConnectionOptionsEmailAttribute{}
+	c.GetIdentifier()
+	c = nil
+	c.GetIdentifier()
+}
+
+func TestConnectionOptionsEmailAttribute_GetProfileRequired(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsEmailAttribute{ProfileRequired: &zeroValue}
+	c.GetProfileRequired()
+	c = &ConnectionOptionsEmailAttribute{}
+	c.GetProfileRequired()
+	c = nil
+	c.GetProfileRequired()
+}
+
+func TestConnectionOptionsEmailAttribute_GetSignup(tt *testing.T) {
+	c := &ConnectionOptionsEmailAttribute{}
+	c.GetSignup()
+	c = nil
+	c.GetSignup()
+}
+
+func TestConnectionOptionsEmailAttribute_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsEmailAttribute{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
@@ -5734,6 +5936,38 @@ func TestConnectionOptionsOTP_String(t *testing.T) {
 	}
 }
 
+func TestConnectionOptionsPhoneNumberAttribute_GetIdentifier(tt *testing.T) {
+	c := &ConnectionOptionsPhoneNumberAttribute{}
+	c.GetIdentifier()
+	c = nil
+	c.GetIdentifier()
+}
+
+func TestConnectionOptionsPhoneNumberAttribute_GetProfileRequired(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsPhoneNumberAttribute{ProfileRequired: &zeroValue}
+	c.GetProfileRequired()
+	c = &ConnectionOptionsPhoneNumberAttribute{}
+	c.GetProfileRequired()
+	c = nil
+	c.GetProfileRequired()
+}
+
+func TestConnectionOptionsPhoneNumberAttribute_GetSignup(tt *testing.T) {
+	c := &ConnectionOptionsPhoneNumberAttribute{}
+	c.GetSignup()
+	c = nil
+	c.GetSignup()
+}
+
+func TestConnectionOptionsPhoneNumberAttribute_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsPhoneNumberAttribute{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestConnectionOptionsPingFederate_GetAgentIP(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsPingFederate{AgentIP: &zeroValue}
@@ -6791,6 +7025,45 @@ func TestConnectionOptionsSMS_GetUpstreamParams(tt *testing.T) {
 func TestConnectionOptionsSMS_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ConnectionOptionsSMS{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsUsernameAttribute_GetIdentifier(tt *testing.T) {
+	c := &ConnectionOptionsUsernameAttribute{}
+	c.GetIdentifier()
+	c = nil
+	c.GetIdentifier()
+}
+
+func TestConnectionOptionsUsernameAttribute_GetProfileRequired(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsUsernameAttribute{ProfileRequired: &zeroValue}
+	c.GetProfileRequired()
+	c = &ConnectionOptionsUsernameAttribute{}
+	c.GetProfileRequired()
+	c = nil
+	c.GetProfileRequired()
+}
+
+func TestConnectionOptionsUsernameAttribute_GetSignup(tt *testing.T) {
+	c := &ConnectionOptionsUsernameAttribute{}
+	c.GetSignup()
+	c = nil
+	c.GetSignup()
+}
+
+func TestConnectionOptionsUsernameAttribute_GetValidation(tt *testing.T) {
+	c := &ConnectionOptionsUsernameAttribute{}
+	c.GetValidation()
+	c = nil
+	c.GetValidation()
+}
+
+func TestConnectionOptionsUsernameAttribute_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsUsernameAttribute{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_Attribute_required_in_profile_but_inactive_on_signup.yaml
+++ b/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_Attribute_required_in_profile_but_inactive_on_signup.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 252
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Auth0-Connection-Attribute-Inactive-On-Signup-1720679132","strategy":"auth0","options":{"attributes":{"phone_number":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"inactive","verification":{"active":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 134
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"attribute phone_number must also be required on signup","errorCode":"invalid_body"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 349.747667ms

--- a/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_Cannot_set_both_requires_username_and_attributes_together.yaml
+++ b/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_Cannot_set_both_requires_username_and_attributes_together.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 249
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Auth0-Connection-Invalid-1720679132","strategy":"auth0","options":{"requires_username":true,"attributes":{"email":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 144
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"Cannot set both options.attributes and options.requires_username","errorCode":"invalid_body"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 376.519916ms

--- a/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_Cannot_set_both_validation_and_attributes_together.yaml
+++ b/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_Cannot_set_both_validation_and_attributes_together.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 383
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Auth0-Connection-Attributes-And-Validation-1720679132","strategy":"auth0","options":{"validation":{"username":{"max":5,"min":1}},"attributes":{"email":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required","verification":{"active":true}}},"username":{"identifier":{"active":true},"profile_required":false,"signup":{"status":"required"}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 137
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"Cannot set both options.attributes and options.validation","errorCode":"invalid_body"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 516.528375ms

--- a/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_With_No_attribute_is_active.yaml
+++ b/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_With_No_attribute_is_active.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 473
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Auth0-Connection-No-Active-Attributes-1720679132","strategy":"auth0","options":{"attributes":{"email":{"identifier":{"active":false},"profile_required":false,"signup":{"status":"required","verification":{"active":false}}},"phone_number":{"identifier":{"active":false},"profile_required":false,"signup":{"status":"required","verification":{"active":false}}},"username":{"identifier":{"active":false},"profile_required":false,"signup":{"status":"required"}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 125
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"attributes must contain one active identifier","errorCode":"invalid_body"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 357.934708ms

--- a/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_With_RequireUsername.yaml
+++ b/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_With_RequireUsername.yaml
@@ -1,0 +1,74 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 116
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Auth0-Connection-RequireUsername-1720679132","strategy":"auth0","options":{"requires_username":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 577
+        uncompressed: false
+        body: '{"id":"con_m9a3URYUtiwf0BGT","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","requires_username":true,"strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Test-Auth0-Connection-RequireUsername-1720679132","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Auth0-Connection-RequireUsername-1720679132"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 966.438125ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_m9a3URYUtiwf0BGT
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2024-07-11T06:25:33.377Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 367.648416ms

--- a/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_with_Email_as_Identifier.yaml
+++ b/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_with_Email_as_Identifier.yaml
@@ -1,0 +1,74 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 222
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Auth0-Connection-Email-1720679132","strategy":"auth0","options":{"attributes":{"email":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 673
+        uncompressed: false
+        body: '{"id":"con_79cNlTmqfsIeaCep","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","attributes":{"email":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}}},"strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Test-Auth0-Connection-Email-1720679132","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Auth0-Connection-Email-1720679132"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 419.663875ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_79cNlTmqfsIeaCep
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2024-07-11T06:25:35.112Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 505.959625ms

--- a/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_with_PhoneNumber_as_Identifier.yaml
+++ b/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_with_PhoneNumber_as_Identifier.yaml
@@ -1,0 +1,74 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 229
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Auth0-Connection-Phone-1720679132","strategy":"auth0","options":{"attributes":{"phone_number":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 680
+        uncompressed: false
+        body: '{"id":"con_o3oE5KvCvPLkZh4d","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","attributes":{"phone_number":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}}},"strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Test-Auth0-Connection-Phone-1720679132","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Auth0-Connection-Phone-1720679132"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 400.634334ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_o3oE5KvCvPLkZh4d
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2024-07-11T06:25:34.174Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 400.471542ms

--- a/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_with_Username_as_Identifier.yaml
+++ b/test/data/recordings/TestConnectionManager_CreateDBConnectionWithDifferentOptions/It_handles_Auth0_Connection_with_Username_as_Identifier.yaml
@@ -1,0 +1,74 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 196
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Auth0-Connection-Username-1720679132","strategy":"auth0","options":{"attributes":{"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 749
+        uncompressed: false
+        body: '{"id":"con_j4m7pWHVBIcSXNEJ","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","attributes":{"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":1,"max_length":15,"allowed_types":{"email":false,"phone_number":false}}}},"strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Test-Auth0-Connection-Username-1720679132","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Auth0-Connection-Username-1720679132"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 426.863959ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_j4m7pWHVBIcSXNEJ
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2024-07-11T06:25:35.951Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 414.330208ms

--- a/test/data/recordings/authentication/TestDatabaseSignUp_RequiresUsername.yaml
+++ b/test/data/recordings/authentication/TestDatabaseSignUp_RequiresUsername.yaml
@@ -1,0 +1,36 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 184
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"client_id":"test-client_id","connection":"Username-Password-Authentication","email":"mytestaccount@example.com","password":"mypassword","username":"mytestaccount"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://go-auth0-dev.eu.auth0.com/dbconnections/signup
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 110
+        uncompressed: false
+        body: '{"_id":"668fbaa9d0c86eb15afa21f1","email":"mytestaccount@example.com","username":"mytestaccount","email_verified":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 517.365625ms

--- a/test/data/recordings/authentication/TestDatabaseSignUp_WithEmailIdentifier.yaml
+++ b/test/data/recordings/authentication/TestDatabaseSignUp_WithEmailIdentifier.yaml
@@ -1,0 +1,36 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 162
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"client_id":"test-client_id","connection":"Username-Password-Authentication","email":"mytestaccount@example.com","password":"mypassword"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://go-auth0-dev.eu.auth0.com/dbconnections/signup
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 88
+        uncompressed: false
+        body: '{"_id":"668fbaab724b1bf53b436691","email":"mytestaccount@example.com","email_verified":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 498.375417ms

--- a/test/data/recordings/authentication/TestDatabaseSignUp_WithPhoneNumberIdentifier.yaml
+++ b/test/data/recordings/authentication/TestDatabaseSignUp_WithPhoneNumberIdentifier.yaml
@@ -1,0 +1,36 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 161
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"client_id":"test-client_id","connection":"Username-Password-Authentication","password":"mypassword","phone_number":"+12345678900"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://go-auth0-dev.eu.auth0.com/dbconnections/signup
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 87
+        uncompressed: false
+        body: '{"_id":"668fbaafd0c86eb15afa21f5","phone_number":"+12345678900","phone_verified":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 489.083292ms

--- a/test/data/recordings/authentication/TestDatabaseSignUp_WithUsernameAndEmailIdentifiers.yaml
+++ b/test/data/recordings/authentication/TestDatabaseSignUp_WithUsernameAndEmailIdentifiers.yaml
@@ -1,0 +1,36 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 184
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"client_id":"test-client_id","connection":"Username-Password-Authentication","email":"mytestaccount@example.com","password":"mypassword","username":"mytestaccount"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://go-auth0-dev.eu.auth0.com/dbconnections/signup
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 110
+        uncompressed: false
+        body: '{"_id":"668fbaaeca9ad18c8c5c4bef","email":"mytestaccount@example.com","username":"mytestaccount","email_verified":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 503.201083ms

--- a/test/data/recordings/authentication/TestDatabaseSignUp_WithUsernameAndPhoneNumberIdentifiers.yaml
+++ b/test/data/recordings/authentication/TestDatabaseSignUp_WithUsernameAndPhoneNumberIdentifiers.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 184
+        content_length: 183
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: '{"client_id":"test-client_id","email":"mytestaccount@example.com","password":"mypassword","connection":"Username-Password-Authentication","username":"mytestaccount"}'
+        body: '{"client_id":"test-client_id","connection":"Username-Password-Authentication","password":"mypassword","phone_number":"+12345678900","username":"mytestaccount"}'
         form: {}
         headers:
             Content-Type:
@@ -25,12 +25,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
+        content_length: 109
         uncompressed: false
-        body: '{"_id":"6486fc52049355c8fda30e21","email_verified":false,"email":"mytestaccount@example.com","username":"mytestaccount","app_metadata":{},"user_metadata":{}}'
+        body: '{"_id":"668fbab0ca9ad18c8c5c4bf2","username":"mytestaccount","phone_number":"+12345678900","phone_verified":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 365.410542ms
+        duration: 468.674292ms

--- a/test/data/recordings/authentication/TestDatabaseSignUp_WithUsernameEmailAndPhoneNumberIdentifiers.yaml
+++ b/test/data/recordings/authentication/TestDatabaseSignUp_WithUsernameEmailAndPhoneNumberIdentifiers.yaml
@@ -1,0 +1,36 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 214
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"client_id":"test-client_id","connection":"Username-Password-Authentication","email":"mytestaccount@example.com","password":"mypassword","phone_number":"+12345678900","username":"mytestaccount"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://go-auth0-dev.eu.auth0.com/dbconnections/signup
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 163
+        uncompressed: false
+        body: '{"_id":"668fbab1ca9ad18c8c5c4bf4","email":"mytestaccount@example.com","username":"mytestaccount","email_verified":false,"phone_number":"+12345678900","phone_verified":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 448.52975ms

--- a/test/data/recordings/authentication/TestDatabaseSignUp_WithUsernameIdentifier.yaml
+++ b/test/data/recordings/authentication/TestDatabaseSignUp_WithUsernameIdentifier.yaml
@@ -1,0 +1,36 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 152
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"client_id":"test-client_id","connection":"Username-Password-Authentication","password":"mypassword","username":"mytestaccount"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://go-auth0-dev.eu.auth0.com/dbconnections/signup
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 55
+        uncompressed: false
+        body: '{"_id":"668fbaac724b1bf53b436693","username":"mytestaccount"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 743.526708ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
- Added support for `attributes` and `precedence` fields to `ConnectionOptions` struct in the management package.
- Added `phone_number` field to `SignupRequest` struct in the authentication package to allow user signup with phone number.
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References
- [Auth0 Management API: Create Connections](https://auth0.com/docs/api/management/v2/connections/post-connections)
- [Auth0 Authentication API: Signup](https://auth0.com/docs/api/authentication#signup)

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
The following test cases have been added to ensure the new functionality works as expected:

#### Authentication Package

- **TestDatabaseSignUp_RequiresUsername**
  - Tests the `Database.Signup` method with a connection that requires a username.
- **TestDatabaseSignUp_WithEmailIdentifier**
  - Tests the `Database.Signup` method with a connection that requires an email.
- **TestDatabaseSignUp_WithUsernameIdentifier**
  - Tests the `Database.Signup` method with a connection that requires a username.
- **TestDatabaseSignUp_WithUsernameAndEmailIdentifiers**
  - Tests the `Database.Signup` method with a connection that requires both a username and email.
- **TestDatabaseSignUp_WithPhoneNumberIdentifier**
  - Tests the `Database.Signup` method with a connection that requires a phone number.
- **TestDatabaseSignUp_WithUsernameAndPhoneNumberIdentifiers**
  - Tests the `Database.Signup` method with a connection that requires both a username and phone number.
- **TestDatabaseSignUp_WithUsernameEmailAndPhoneNumberIdentifiers**
  - Tests the `Database.Signup` method with a connection that requires a username, email, and phone number.

#### Management Package

- **Auth0ConnectionTestCase**
  - Added a set of test cases to test various combinations of `ConnectionOptions`:
    - Auth0 Connection With RequireUsername
    - Auth0 Connection with PhoneNumber as Identifier
    - Auth0 Connection with Email as Identifier
    - Auth0 Connection with Username as Identifier
    - Auth0 Connection Cannot set both requires_username and attributes together
    - Auth0 Connection With No attribute is active
    - Auth0 Connection Cannot set both validation and attributes together
    - Auth0 Connection Attribute required in profile but inactive on signup


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
