### PR TITLE
Add support for setting `captcha_widget_theme` in `BrandingTheme` Struct in `BrandingThemeManager`

### DIFF
--- a/management/branding_theme.go
+++ b/management/branding_theme.go
@@ -35,6 +35,7 @@ type BrandingThemeColors struct {
 	BaseFocusColor          *string `json:"base_focus_color,omitempty"`
 	BaseHoverColor          *string `json:"base_hover_color,omitempty"`
 	BodyText                string  `json:"body_text"`
+	CaptchaWidgetTheme      string  `json:"captcha_widget_theme"`
 	Error                   string  `json:"error"`
 	Header                  string  `json:"header"`
 	Icons                   string  `json:"icons"`

--- a/management/branding_theme_test.go
+++ b/management/branding_theme_test.go
@@ -40,6 +40,7 @@ func TestBrandingThemeManager_Create(t *testing.T) {
 		Colors: BrandingThemeColors{
 			BodyText:                "#00FF00",
 			Error:                   "#00FF00",
+			CaptchaWidgetTheme:      "auto",
 			Header:                  "#00FF00",
 			Icons:                   "#00FF00",
 			InputBackground:         "#00FF00",
@@ -139,6 +140,7 @@ func TestBrandingThemeManager_Update(t *testing.T) {
 		Colors: BrandingThemeColors{
 			BodyText:                "#00FF00",
 			Error:                   "#00FF00",
+			CaptchaWidgetTheme:      "auto",
 			Header:                  "#00FF00",
 			Icons:                   "#00FF00",
 			InputBackground:         "#00FF00",
@@ -238,6 +240,7 @@ func givenABrandingTheme(t *testing.T) *BrandingTheme {
 		Colors: BrandingThemeColors{
 			BodyText:                "#00FF00",
 			Error:                   "#00FF00",
+			CaptchaWidgetTheme:      "auto",
 			Header:                  "#00FF00",
 			Icons:                   "#00FF00",
 			InputBackground:         "#00FF00",


### PR DESCRIPTION

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- Added support for setting `captcha_widget_theme` in `BrandingTheme`.
- Introduced a new field in the `BrandingTheme` struct:
  ```go
  CaptchaWidgetTheme string `json:"captcha_widget_theme"`
  ```
- This field has been added under `BrandingThemeColors` in `BrandingThemeManager`.
- Allows customization of the Captcha widget theme for branding.

### 📚 References

- [Auth0 Branding API Documentation](https://auth0.com/docs/api/management/v2#!/Branding/patch_branding)]

### 🔬 Testing

- Ensure the `captcha_widget_theme` field is correctly serialized/deserialized in the `BrandingTheme` struct.
- Validate that updating the branding theme successfully applies the Captcha widget theme customization.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
