### PR TITLE
Add Support for `FCMv1 Server Credentials` in `MultiFactorPush` Sub-Manager of `GuardianManager`

### DIFF
--- a/management/guardian.go
+++ b/management/guardian.go
@@ -94,10 +94,16 @@ type MultiFactorPushDirectAPNS struct {
 	Enabled  *bool   `json:"enabled,omitempty"`
 }
 
-// MultiFactorPushDirectFCM holds the Google FCM provider configuration.
+// MultiFactorPushDirectFCM holds the legacy Google FCM provider configuration.
 type MultiFactorPushDirectFCM struct {
 	// FCM Server Key
 	ServerKey *string `json:"server_key,omitempty"`
+}
+
+// MultiFactorPushDirectFCMv1 holds the Google FCM provider configuration.
+type MultiFactorPushDirectFCMv1 struct {
+	// FCM Server Credentials
+	ServerCredentials *string `json:"server_credentials,omitempty"`
 }
 
 // MultiFactorProviderTwilio is used for Twilio MultiFactor Authentication.
@@ -367,6 +373,13 @@ func (m *MultiFactorPush) UpdateDirectAPNS(ctx context.Context, sc *MultiFactorP
 // See: https://auth0.com/docs/api/management/v2#!/Guardian/patch_fcm
 func (m *MultiFactorPush) UpdateDirectFCM(ctx context.Context, sc *MultiFactorPushDirectFCM, opts ...RequestOption) error {
 	return m.management.Request(ctx, "PUT", m.management.URI("guardian", "factors", "push-notification", "providers", "fcm"), sc, opts...)
+}
+
+// UpdateDirectFCMv1 updates the Google FCM provider configuration for direct mode.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Guardian/patch_fcmv-1
+func (m *MultiFactorPush) UpdateDirectFCMv1(ctx context.Context, sc *MultiFactorPushDirectFCMv1, opts ...RequestOption) error {
+	return m.management.Request(ctx, "PUT", m.management.URI("guardian", "factors", "push-notification", "providers", "fcmv1"), sc, opts...)
 }
 
 // AmazonSNS returns the Amazon Web Services (AWS) Simple Notification Service

--- a/management/guardian.go
+++ b/management/guardian.go
@@ -370,14 +370,14 @@ func (m *MultiFactorPush) UpdateDirectAPNS(ctx context.Context, sc *MultiFactorP
 
 // UpdateDirectFCM updates the Google FCM provider configuration for direct mode.
 //
-// See: https://auth0.com/docs/api/management/v2#!/Guardian/patch_fcm
+// See: https://auth0.com/docs/api/management/v2#!/Guardian/put-fcm
 func (m *MultiFactorPush) UpdateDirectFCM(ctx context.Context, sc *MultiFactorPushDirectFCM, opts ...RequestOption) error {
 	return m.management.Request(ctx, "PUT", m.management.URI("guardian", "factors", "push-notification", "providers", "fcm"), sc, opts...)
 }
 
-// UpdateDirectFCMv1 updates the Google FCM provider configuration for direct mode.
+// UpdateDirectFCMv1 updates the Google FCM provider configuration for direct mode (v1).
 //
-// See: https://auth0.com/docs/api/management/v2#!/Guardian/patch_fcmv-1
+// See: https://auth0.com/docs/api/management/v2#!/Guardian/put-fcmv-1
 func (m *MultiFactorPush) UpdateDirectFCMv1(ctx context.Context, sc *MultiFactorPushDirectFCMv1, opts ...RequestOption) error {
 	return m.management.Request(ctx, "PUT", m.management.URI("guardian", "factors", "push-notification", "providers", "fcmv1"), sc, opts...)
 }

--- a/management/guardian_test.go
+++ b/management/guardian_test.go
@@ -306,6 +306,20 @@ func TestGuardian(t *testing.T) {
 				err = api.Guardian.MultiFactor.Push.UpdateDirectFCM(context.Background(), expectedDirectFCM)
 				assert.NoError(t, err)
 			})
+
+			t.Run("DirectFCMv1", func(t *testing.T) {
+				configureHTTPTestRecordings(t)
+
+				// This is a write only property
+
+				err := error(nil)
+
+				expectedDirectFCMv1 := &MultiFactorPushDirectFCMv1{
+					ServerCredentials: auth0.String("abc123"),
+				}
+				err = api.Guardian.MultiFactor.Push.UpdateDirectFCMv1(context.Background(), expectedDirectFCMv1)
+				assert.NoError(t, err)
+			})
 		})
 
 		t.Run("Email Enable", func(t *testing.T) {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -8830,6 +8830,19 @@ func (m *MultiFactorPushDirectFCM) String() string {
 	return Stringify(m)
 }
 
+// GetServerCredentials returns the ServerCredentials field if it's non-nil, zero value otherwise.
+func (m *MultiFactorPushDirectFCMv1) GetServerCredentials() string {
+	if m == nil || m.ServerCredentials == nil {
+		return ""
+	}
+	return *m.ServerCredentials
+}
+
+// String returns a string representation of MultiFactorPushDirectFCMv1.
+func (m *MultiFactorPushDirectFCMv1) String() string {
+	return Stringify(m)
+}
+
 // GetEnrollmentMessage returns the EnrollmentMessage field if it's non-nil, zero value otherwise.
 func (m *MultiFactorSMSTemplate) GetEnrollmentMessage() string {
 	if m == nil || m.EnrollmentMessage == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -11045,6 +11045,24 @@ func TestMultiFactorPushDirectFCM_String(t *testing.T) {
 	}
 }
 
+func TestMultiFactorPushDirectFCMv1_GetServerCredentials(tt *testing.T) {
+	var zeroValue string
+	m := &MultiFactorPushDirectFCMv1{ServerCredentials: &zeroValue}
+	m.GetServerCredentials()
+	m = &MultiFactorPushDirectFCMv1{}
+	m.GetServerCredentials()
+	m = nil
+	m.GetServerCredentials()
+}
+
+func TestMultiFactorPushDirectFCMv1_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &MultiFactorPushDirectFCMv1{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestMultiFactorSMSTemplate_GetEnrollmentMessage(tt *testing.T) {
 	var zeroValue string
 	m := &MultiFactorSMSTemplate{EnrollmentMessage: &zeroValue}

--- a/test/data/recordings/TestGuardian/MultiFactor/Push/DirectFCMv1.yaml
+++ b/test/data/recordings/TestGuardian/MultiFactor/Push/DirectFCMv1.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 802
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"server_credentials":"abc123"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.17.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/guardian/factors/push-notification/providers/fcmv1
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '{}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 711.429ms


### PR DESCRIPTION

<!--  
❗ For general support or usage questions, please use the [Auth0 Community forums](https://community.auth0.com/) or submit a support ticket.  

By opening this pull request, you agree to the terms of the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).  
-->  

### 🔧 Changes  

<!--  
Provide a clear description of what is changing and why it is important.  
Include details such as:  

- New, modified, deprecated, or removed types and methods  
- Usage summary for new features or API changes  
-->  

- Added support for the **FCM v1 endpoint**:  
  [Auth0 Guardian API – Update FCMv1 Credentials](https://auth0.com/docs/api/management/v2/guardian/put-fcmv-1)

### 📚 References  

<!--  
Include relevant links that support this change, such as:  

- GitHub issues or PRs addressed/fixed  
- Auth0 Community discussions  
- Stack Overflow answers  
- Related PRs/issues from other repositories  

If there are no relevant references, remove this section.  
-->  

- Resolves #511  
-   [Auth0 Guardian API – Update FCMv1 Credentials](https://auth0.com/docs/api/management/v2/guardian/put-fcmv-1)

### 🔬 Testing  

<!--  
Explain how reviewers can test this change. Be specific about:  

- Steps to reproduce/test functionality  
- Any manual testing required  
- Areas not covered by automated tests and reasons why  
-->  

- Ran initial tests to verify changes  
- Added Test Recordings  

### 📝 Checklist  

- [X] All new, modified, or fixed functionality is covered by tests  
- [X] Documentation has been updated for all new/changed functionality  

<!--  
❗ All checklist items are required. Pull requests with an incomplete checklist may be closed.  
-->  

_First-time contributor—happy to make any modifications as needed!_ 😊  

