### PR TITLE
refactor: use a single client assertion audience

### DIFF
--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -340,7 +340,7 @@ func createClientAssertion(clientAssertionSigningAlg, clientAssertionSigningKey,
 		Subject(clientID).
 		JwtID(uuid.New().String()).
 		Issuer(clientID).
-		Audience([]string{domain}).
+		Claim("aud", domain).
 		Expiration(time.Now().Add(2 * time.Minute)).
 		Build()
 	if err != nil {


### PR DESCRIPTION
To align with FAPI 2.0 and future client assertion requirements this changes the JWT Client Authentication assertion to use a single audience string value. The value itself is the issuer identifier.