### PR TITLE
Refactor `BrandingPhoneProvider`: Replace MarshalJSON with reset Method

### DIFF
--- a/management/branding.go
+++ b/management/branding.go
@@ -167,23 +167,11 @@ func (bpnt *BrandingPhoneNotificationTemplate) reset(method string) {
 	}
 }
 
-// MarshalJSON implements the json.Marshaler interface.
-//
-// It is required to handle the json field credentials, which can either
-// be a JSON object, or null.
-func (b *BrandingPhoneProvider) MarshalJSON() ([]byte, error) {
-	type BrandingPhoneProviderSubset struct {
-		Name          *string                             `json:"name,omitempty"`
-		Disabled      *bool                               `json:"disabled,omitempty"`
-		Configuration *BrandingPhoneProviderConfiguration `json:"configuration,omitempty"`
-		Credentials   *BrandingPhoneProviderCredential    `json:"credentials,omitempty"`
-	}
-	return json.Marshal(&BrandingPhoneProviderSubset{
-		Name:          b.Name,
-		Disabled:      b.Disabled,
-		Configuration: b.Configuration,
-		Credentials:   b.Credentials,
-	})
+// reset resets the BrandingPhoneProvider fields.
+func (b *BrandingPhoneProvider) reset() {
+	b.ID = nil
+	b.Channel = nil
+	b.Tenant = nil
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -329,6 +317,7 @@ func (m *BrandingManager) ReadPhoneProvider(ctx context.Context, id string, opts
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/create-phone-provider
 func (m *BrandingManager) CreatePhoneProvider(ctx context.Context, pp *BrandingPhoneProvider, opts ...RequestOption) (err error) {
+	pp.reset()
 	return m.management.Request(ctx, "POST", m.management.URI("branding", "phone", "providers"), pp, opts...)
 }
 
@@ -343,6 +332,7 @@ func (m *BrandingManager) DeletePhoneProvider(ctx context.Context, id string, op
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/update-phone-provider
 func (m *BrandingManager) UpdatePhoneProvider(ctx context.Context, id string, pp *BrandingPhoneProvider, opts ...RequestOption) (err error) {
+	pp.reset()
 	return m.management.Request(ctx, "PATCH", m.management.URI("branding", "phone", "providers", id), pp, opts...)
 }
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

- Replaced `MarshalJSON` method with a `reset` method for `BrandingPhoneProvider`
- Removed custom JSON marshaling logic, as it is no longer needed
- Added a `reset` function to clear specific fields (`ID`, `Channel`, `Tenant`)

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

N/A

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Verified that `reset` correctly clears the required fields
- Ensured no regressions in existing behavior related to `BrandingPhoneProvider`
- Ran unit tests to confirm expected behavior

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
