### PR TITLE
Add client credentials Private Key JWT auth for management API

### DIFF
--- a/authentication/oauth_test.go
+++ b/authentication/oauth_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/auth0/go-auth0/authentication/ciba"
+	"github.com/auth0/go-auth0/internal/client"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -286,7 +287,7 @@ func TestLoginWithClientCredentials(t *testing.T) {
 		skipE2E(t)
 		configureHTTPTestRecordings(t, authAPI)
 
-		auth, err := createClientAssertion("RS256", jwtPrivateKey, clientID, "https://"+domain+"/")
+		auth, err := client.CreateClientAssertion("RS256", jwtPrivateKey, clientID, "https://"+domain+"/")
 		require.NoError(t, err)
 
 		tokenSet, err := authAPI.OAuth.LoginWithClientCredentials(context.Background(), oauth.LoginWithClientCredentialsRequest{

--- a/authentication/passwordless_test.go
+++ b/authentication/passwordless_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/auth0/go-auth0/internal/client"
+
 	"github.com/auth0/go-auth0/authentication/oauth"
 	"github.com/auth0/go-auth0/authentication/passwordless"
 )
@@ -179,7 +181,7 @@ func TestPasswordlessWithClientAssertion(t *testing.T) {
 		require.NoError(t, err)
 		configureHTTPTestRecordings(t, api)
 
-		auth, err := createClientAssertion("RS256", jwtPrivateKey, clientID, "https://"+domain+"/")
+		auth, err := client.CreateClientAssertion("RS256", jwtPrivateKey, clientID, "https://"+domain+"/")
 		require.NoError(t, err)
 
 		r, err := api.Passwordless.SendSMS(context.Background(), passwordless.SendSMSRequest{

--- a/internal/client/jwt_token_source.go
+++ b/internal/client/jwt_token_source.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"context"
+	"net/url"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+type privateKeyJwtTokenSource struct {
+	ctx                       context.Context
+	uri                       string
+	clientID                  string
+	clientAssertionSigningAlg string
+	clientAssertionSigningKey string
+	audience                  string
+}
+
+func newPrivateKeyJwtTokenSource(
+	ctx context.Context,
+	uri,
+	clientAssertionSigningAlg,
+	clientAssertionSigningKey,
+	clientID,
+	audience string,
+) oauth2.TokenSource {
+	source := &privateKeyJwtTokenSource{
+		ctx:                       ctx,
+		uri:                       uri,
+		clientAssertionSigningAlg: clientAssertionSigningAlg,
+		clientAssertionSigningKey: clientAssertionSigningKey,
+		clientID:                  clientID,
+		audience:                  audience,
+	}
+
+	return oauth2.ReuseTokenSource(nil, source)
+}
+
+func (p privateKeyJwtTokenSource) Token() (*oauth2.Token, error) {
+	alg, err := determineAlg(p.clientAssertionSigningAlg)
+	if err != nil {
+		return nil, err
+	}
+
+	baseURL, err := url.Parse(p.uri)
+	if err != nil {
+		return nil, err
+	}
+
+	assertion, err := CreateClientAssertion(alg, p.clientAssertionSigningKey, p.clientID, baseURL.JoinPath("/").String())
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &clientcredentials.Config{
+		TokenURL:  p.uri + "/oauth/token",
+		AuthStyle: oauth2.AuthStyleInParams,
+		EndpointParams: url.Values{
+			"audience":              []string{p.audience},
+			"client_assertion_type": []string{"urn:ietf:params:oauth:client-assertion-type:jwt-bearer"},
+			"client_assertion":      []string{assertion},
+		},
+	}
+
+	return cfg.Token(p.ctx)
+}

--- a/management/management_option.go
+++ b/management/management_option.go
@@ -48,6 +48,22 @@ func WithClientCredentialsAndAudience(ctx context.Context, clientID, clientSecre
 	}
 }
 
+// WithClientCredentialsPrivateKeyJwt configures management to authenticate using the client
+// credentials with Private Key JWT authentication flow.
+func WithClientCredentialsPrivateKeyJwt(ctx context.Context, clientAssertionSigningAlg, clientAssertionSigningKey, clientID string) Option {
+	return func(m *Management) {
+		m.tokenSource = client.OAuth2ClientCredentialsPrivateKeyJwt(ctx, m.url.String(), clientAssertionSigningAlg, clientAssertionSigningKey, clientID)
+	}
+}
+
+// WithClientCredentialsPrivateKeyJwtAndAudience configures management to authenticate using the client
+// credentials with Private Key JWT authentication flow and custom audience.
+func WithClientCredentialsPrivateKeyJwtAndAudience(ctx context.Context, clientAssertionSigningAlg, clientAssertionSigningKey, clientID, audience string) Option {
+	return func(m *Management) {
+		m.tokenSource = client.OAuth2ClientCredentialsPrivateKeyJwtAndAudience(ctx, m.url.String(), clientAssertionSigningAlg, clientAssertionSigningKey, clientID, audience)
+	}
+}
+
 // WithStaticToken configures management to authenticate using a static
 // authentication token.
 func WithStaticToken(token string) Option {


### PR DESCRIPTION
### 🔧 Changes

Add client credentials Private Key JWT auth for management API.

The `x/oauth2` package allows for adding extra `EndpointParams` to client credentials config which allows for Private Key JWT to be used without implementation in the library. If we use `AuthStyleInParams`, but do not add client ID or Secret, they will not get added to the request params. 

There is an [open issue](https://github.com/golang/go/issues/57186) for implementing this in the library, but there seems to be no traction anymore for a long time. Therefore I wanted to suggest this solution. 

If ok, I can start adding tests for it. 

### 📚 References

* Issue: https://github.com/auth0/go-auth0/issues/494
* Related issue in `x/oauth2` package: https://github.com/golang/go/issues/57186

### 🔬 Testing

* Generate key pair with:
  * `openssl genrsa -out private.pem 2048`
  * `openssl rsa -in private.pem -pubout > public.pub` 
* Add new application in Auth0
* Setup Private Key JWT auth for the application and add the public key

Run following `main.go` program:

```
package main

import (
	"context"
	"log"
	"os"

	"github.com/auth0/go-auth0/management"
)

func main() {
	signingAlg := "RS256"
	auth0Domain := "auth0Domain"
	clientID := "clientId"

	key, err := os.ReadFile("private.pem")
	if err != nil {
		panic(err)
	}

	auth0API, err := management.New(
		auth0Domain,
		management.WithClientCredentialsPrivateKeyJwt(context.TODO(), signingAlg, string(key), clientID),
	)
	if err != nil {
		panic(err)
	}

	test, err := auth0API.Client.List(context.TODO(), management.Page(0), management.PerPage(10))
	if err != nil {
		panic(err)
	}

	log.Println("Auth0 clients: %+v", test)
}

```

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)
