### PR TITLE
Add support for `GetUserLogs` method to fetch user log events in `UserManager`

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -810,3 +810,20 @@ func (m *UserManager) DeleteUserSessions(ctx context.Context, userID string, opt
 	err = m.management.Request(ctx, "DELETE", m.management.URI("users", userID, "sessions"), nil, opts...)
 	return
 }
+
+// GetUserLogs retrieves logs for a user.
+//
+// It allows pagination using the provided options. For more information on pagination, refer to:
+// https://pkg.go.dev/github.com/auth0/go-auth0/management#hdr-Page_Based_Pagination
+//
+// For more information on all possible event types, their respective acronyms and descriptions, see Log Event Type Codes.
+//
+// For more information on the list of fields that can be used in sort, see Searchable Fields.
+//
+// Auth0 limits the number of logs you can return by search criteria to 100 logs per request. Furthermore, you may only paginate through up to 1,000 search results. If you exceed this threshold, please redefine your search.
+//
+// See: https://auth0.com/docs/api/management/v2/users/get-logs-by-user
+func (m *UserManager) GetUserLogs(ctx context.Context, userID string, opts ...RequestOption) (r []*Log, err error) {
+	err = m.management.Request(ctx, "GET", m.management.URI("users", userID, "logs"), &r, opts...)
+	return
+}

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -316,6 +316,15 @@ func TestUserManager_DeleteUserSessions(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestUserManager_GetUserLogs(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	user := givenAUser(t)
+	logs, err := api.User.GetUserLogs(context.Background(), user.GetID())
+	assert.NoError(t, err)
+	assert.Len(t, logs, 0)
+}
+
 func TestUser_MarshalJSON(t *testing.T) {
 	for user, expected := range map[*User]string{
 		{}:                                 `{}`,

--- a/test/data/recordings/TestUserManager_GetUserLogs.yaml
+++ b/test/data/recordings/TestUserManager_GetUserLogs.yaml
@@ -1,0 +1,109 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 480
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"connection":"Username-Password-Authentication","email":"chuck899@example.com","given_name":"Chuck","family_name":"Sanchez","username":"test-user412","nickname":"Chucky","password":"Passwords hide their chuck","user_metadata":{"favourite_attack":"roundhouse_kick"},"verify_email":false,"app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]},"picture":"https://example-picture-url.jpg","blocked":false,"email_verified":true}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/users
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 661
+        uncompressed: false
+        body: '{"blocked":false,"created_at":"2025-03-24T04:03:54.935Z","email":"chuck899@example.com","email_verified":true,"family_name":"Sanchez","given_name":"Chuck","identities":[{"connection":"Username-Password-Authentication","user_id":"67e0d9aaa2a92ff53f98a3fc","provider":"auth0","isSocial":false}],"name":"chuck899@example.com","nickname":"Chucky","picture":"https://example-picture-url.jpg","updated_at":"2025-03-24T04:03:54.936Z","user_id":"auth0|67e0d9aaa2a92ff53f98a3fc","user_metadata":{"favourite_attack":"roundhouse_kick"},"username":"test-user412","app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 3.825640208s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C67e0d9aaa2a92ff53f98a3fc/logs
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '[]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 563.942708ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C67e0d9aaa2a92ff53f98a3fc
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 623.239125ms


### PR DESCRIPTION

<!--  
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.  

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.  
-->  

### 🔧 Changes  

<!--  
Describe both what is changing and why this is important. Include:  

- Types and methods added, deleted, deprecated, or changed  
- A summary of usage if this is a new feature or a change to a public API  
-->  

- Added `GetUserLogs` method in `UserManager` to fetch user log events.  

### 📚 References  
- [Auth0 Management API - Get User Logs](https://auth0.com/docs/api/management/v2/users/get-logs-by-user)
<!--  
Add relevant links supporting this change, such as:  

- GitHub issue/PR number addressed or fixed  
- Auth0 Community post  
- StackOverflow answer  
- Related pull requests/issues from other repositories  

If there are no references, simply delete this section.  
-->  

### 🔬 Testing  

<!--  
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.  
-->  

- Added test cases to validate the behavior of `GetUserLogs`.  
- Manually tested by calling the method with different user IDs and verifying log events returned match expectations.  

### 📝 Checklist  

- [x] All new/changed/fixed functionality is covered by tests (or N/A)  
- [x] I have added documentation for all new/changed functionality (or N/A)  

<!--  
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.  
-->