### PR TITLE
Updated SetScope implementation in Options for Facebook and Apple Connection

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -771,12 +771,27 @@ type ConnectionOptionsFacebook struct {
 
 // Scopes returns the scopes for ConnectionOptionsFacebook.
 func (c *ConnectionOptionsFacebook) Scopes() []string {
-	return tag.Scopes(c)
+	return strings.Fields(c.GetScope())
 }
 
 // SetScopes sets the scopes for ConnectionOptionsFacebook.
 func (c *ConnectionOptionsFacebook) SetScopes(enable bool, scopes ...string) {
-	tag.SetScopes(c, enable, scopes...)
+	scopeMap := make(map[string]bool)
+	for _, scope := range c.Scopes() {
+		scopeMap[scope] = true
+	}
+	for _, scope := range scopes {
+		scopeMap[scope] = enable
+	}
+	scopeSlice := make([]string, 0, len(scopeMap))
+	for scope, enabled := range scopeMap {
+		if enabled {
+			scopeSlice = append(scopeSlice, scope)
+		}
+	}
+	sort.Strings(scopeSlice)
+	scope := strings.Join(scopeSlice, " ")
+	c.Scope = &scope
 }
 
 // ConnectionOptionsApple is used to configure an Apple Connection.
@@ -799,12 +814,27 @@ type ConnectionOptionsApple struct {
 
 // Scopes returns the scopes for ConnectionOptionsApple.
 func (c *ConnectionOptionsApple) Scopes() []string {
-	return tag.Scopes(c)
+	return strings.Fields(c.GetScope())
 }
 
 // SetScopes sets the scopes for ConnectionOptionsApple.
 func (c *ConnectionOptionsApple) SetScopes(enable bool, scopes ...string) {
-	tag.SetScopes(c, enable, scopes...)
+	scopeMap := make(map[string]bool)
+	for _, scope := range c.Scopes() {
+		scopeMap[scope] = true
+	}
+	for _, scope := range scopes {
+		scopeMap[scope] = enable
+	}
+	scopeSlice := make([]string, 0, len(scopeMap))
+	for scope, enabled := range scopeMap {
+		if enabled {
+			scopeSlice = append(scopeSlice, scope)
+		}
+	}
+	sort.Strings(scopeSlice)
+	scope := strings.Join(scopeSlice, " ")
+	c.Scope = &scope
 }
 
 // ConnectionOptionsLinkedin is used to configure a Linkedin Connection.


### PR DESCRIPTION
The SetScope implementation for Facebook and Apple connections treated the scope field as  `[]interface{}` whereas they are `*string`.
Oauth2, Okta and OIDC are other connections where scopes field in the Options block is of type `*string`
The rest of the connections have a different way of handling scopes. 


<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Updated the implementation of SetScope for Facebook and Apple connection

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

Addressed a customer ESD

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
