### PR TITLE
 Refactor `Mappings` in `SAML2ClientAddon` from `map[string]string` to `map[string]interface{}` for enhanced flexibility

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -520,8 +520,9 @@ type SalesforceSandboxAPIClientAddon struct {
 type SAML2ClientAddon struct {
 	// The mappings between the Auth0 user profile and the output attributes on the SAML Assertion.
 	// Each "name" represents the property name on the Auth0 user profile.
+	// Each "value" can be a string or an array of strings if multiple values are expected.
 	// Each "value" is the name (including namespace) for the resulting SAML attribute in the assertion.
-	Mappings *map[string]string `json:"mappings,omitempty"`
+	Mappings *map[string]interface{} `json:"mappings,omitempty"`
 	// The audience of the SAML Assertion.
 	Audience *string `json:"audience,omitempty"`
 	// The recipient of the SAML Assertion.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -10558,9 +10558,9 @@ func (s *SAML2ClientAddon) GetMapIdentities() bool {
 }
 
 // GetMappings returns the Mappings field if it's non-nil, zero value otherwise.
-func (s *SAML2ClientAddon) GetMappings() map[string]string {
+func (s *SAML2ClientAddon) GetMappings() map[string]interface{} {
 	if s == nil || s.Mappings == nil {
-		return map[string]string{}
+		return map[string]interface{}{}
 	}
 	return *s.Mappings
 }

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -13254,7 +13254,7 @@ func TestSAML2ClientAddon_GetMapIdentities(tt *testing.T) {
 }
 
 func TestSAML2ClientAddon_GetMappings(tt *testing.T) {
-	var zeroValue map[string]string
+	var zeroValue map[string]interface{}
 	s := &SAML2ClientAddon{Mappings: &zeroValue}
 	s.GetMappings()
 	s = &SAML2ClientAddon{}


### PR DESCRIPTION

### 🔧 Changes  

- Updated `Mappings` field in `SAML2ClientAddon` from `map[string]string` to `map[string]interface{}`.  
- Allows for greater flexibility by supporting both string and array values in SAML assertions.  

### 📚 References  

N/A  

### 🔬 Testing  

- Verified that existing SAML mappings work as expected.  
- Manually tested to confirm that both string and array values are correctly processed in assertions.  

### 📝 Checklist  

- [x] All new/changed/fixed functionality is covered by tests (or N/A)  
- [x] I have added documentation for all new/changed functionality (or N/A)  