### PR TITLE
Breaking Change: Migrate `custom_headers` from `map[string]string` to `*[]map[string]string` in `ConnectionOptionsOAuth2`

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -1144,7 +1144,7 @@ type ConnectionOptionsOAuth2 struct {
 	UpstreamParams map[string]interface{} `json:"upstream_params,omitempty"`
 
 	// CustomHeaders specifies custom headers.
-	CustomHeaders map[string]string `json:"custom_headers,omitempty"`
+	CustomHeaders *[]map[string]string `json:"custom_headers,omitempty"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for ConnectionOptionsOAuth2.

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -43,8 +43,10 @@ var connectionTestCases = []connectionTestCase{
 					"alias": "login_hint",
 				},
 			},
-			CustomHeaders: map[string]string{
-				"X-Auth0-Client": "my-client",
+			CustomHeaders: &[]map[string]string{
+				{
+					"X-Auth0-Client": "my-client",
+				},
 			},
 		},
 	},

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -4870,12 +4870,12 @@ func (c *ConnectionOptionsOAuth2) GetClientSecret() string {
 	return *c.ClientSecret
 }
 
-// GetCustomHeaders returns the CustomHeaders map if it's non-nil, an empty map otherwise.
-func (c *ConnectionOptionsOAuth2) GetCustomHeaders() map[string]string {
+// GetCustomHeaders returns the CustomHeaders field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOAuth2) GetCustomHeaders() []map[string]string {
 	if c == nil || c.CustomHeaders == nil {
-		return map[string]string{}
+		return []map[string]string{}
 	}
-	return c.CustomHeaders
+	return *c.CustomHeaders
 }
 
 // GetLogoURL returns the LogoURL field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -6017,8 +6017,8 @@ func TestConnectionOptionsOAuth2_GetClientSecret(tt *testing.T) {
 }
 
 func TestConnectionOptionsOAuth2_GetCustomHeaders(tt *testing.T) {
-	zeroValue := map[string]string{}
-	c := &ConnectionOptionsOAuth2{CustomHeaders: zeroValue}
+	var zeroValue []map[string]string
+	c := &ConnectionOptionsOAuth2{CustomHeaders: &zeroValue}
 	c.GetCustomHeaders()
 	c = &ConnectionOptionsOAuth2{}
 	c.GetCustomHeaders()

--- a/test/data/recordings/TestConnectionManager_Create/It_can_successfully_create_a_Wordpress_Connection.yaml
+++ b/test/data/recordings/TestConnectionManager_Create/It_can_successfully_create_a_Wordpress_Connection.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 286
+        content_length: 288
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-Wordpress-Connection-1741359636","strategy":"wordpress","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":{"X-Auth0-Client":"my-client"},"scope":["email","profile","openid"]}}
+            {"name":"Test-Wordpress-Connection-1743077299","strategy":"wordpress","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":[{"X-Auth0-Client":"my-client"}],"scope":["email","profile","openid"]}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
+                - Go-Auth0/1.18.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -28,15 +28,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 411
+        content_length: 413
         uncompressed: false
-        body: '{"id":"con_TERR7GxQ27Cu6WTk","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":{"X-Auth0-Client":"my-client"},"scope":["profile"],"profile":true},"strategy":"wordpress","name":"Test-Wordpress-Connection-1741359636","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1741359636"]}'
+        body: '{"id":"con_tAAh1V3duZJyON1m","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":[{"X-Auth0-Client":"my-client"}],"scope":["profile"],"profile":true},"strategy":"wordpress","name":"Test-Wordpress-Connection-1743077299","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1743077299"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 947.860042ms
+        duration: 1.287988708s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -54,8 +54,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_TERR7GxQ27Cu6WTk
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_tAAh1V3duZJyON1m
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -65,10 +65,10 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2025-03-07T15:00:38.032Z"}'
+        body: '{"deleted_at":"2025-03-27T12:08:20.989Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 410.596125ms
+        duration: 475.479334ms

--- a/test/data/recordings/TestConnectionManager_Read/It_can_successfully_read_a_Wordpress_Connection.yaml
+++ b/test/data/recordings/TestConnectionManager_Read/It_can_successfully_read_a_Wordpress_Connection.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 286
+        content_length: 288
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-Wordpress-Connection-1741359646","strategy":"wordpress","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":{"X-Auth0-Client":"my-client"},"scope":["email","profile","openid"]}}
+            {"name":"Test-Wordpress-Connection-1743077318","strategy":"wordpress","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":[{"X-Auth0-Client":"my-client"}],"scope":["email","profile","openid"]}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
+                - Go-Auth0/1.18.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -28,15 +28,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 411
+        content_length: 413
         uncompressed: false
-        body: '{"id":"con_eUJOzUal3WlBKjeS","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":{"X-Auth0-Client":"my-client"},"scope":["profile"],"profile":true},"strategy":"wordpress","name":"Test-Wordpress-Connection-1741359646","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1741359646"]}'
+        body: '{"id":"con_r2m1k7b6HBf72TSo","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":[{"X-Auth0-Client":"my-client"}],"scope":["profile"],"profile":true},"strategy":"wordpress","name":"Test-Wordpress-Connection-1743077318","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1743077318"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 885.620166ms
+        duration: 1.245704334s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -54,8 +54,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_eUJOzUal3WlBKjeS
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_r2m1k7b6HBf72TSo
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,13 +65,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_eUJOzUal3WlBKjeS","options":{"scope":["profile"],"profile":true,"custom_headers":{"X-Auth0-Client":"my-client"},"upstream_params":{"screen_name":{"alias":"login_hint"}},"strategy_version":2},"strategy":"wordpress","name":"Test-Wordpress-Connection-1741359646","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1741359646"]}'
+        body: '{"id":"con_r2m1k7b6HBf72TSo","options":{"scope":["profile"],"profile":true,"custom_headers":[{"X-Auth0-Client":"my-client"}],"upstream_params":{"screen_name":{"alias":"login_hint"}},"strategy_version":2},"strategy":"wordpress","name":"Test-Wordpress-Connection-1743077318","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1743077318"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.894834ms
+        duration: 483.403458ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -89,8 +89,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_eUJOzUal3WlBKjeS
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_r2m1k7b6HBf72TSo
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -100,13 +100,13 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2025-03-07T15:00:47.780Z"}'
+        body: '{"deleted_at":"2025-03-27T12:08:40.386Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 361.133958ms
+        duration: 445.066583ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -124,8 +124,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_eUJOzUal3WlBKjeS
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_r2m1k7b6HBf72TSo
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -141,4 +141,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 329.099208ms
+        duration: 696.23525ms

--- a/test/data/recordings/TestConnectionManager_ReadByName/It_can_successfully_find_a_Wordpress_Connection_by_its_name.yaml
+++ b/test/data/recordings/TestConnectionManager_ReadByName/It_can_successfully_find_a_Wordpress_Connection_by_its_name.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 286
+        content_length: 288
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-Wordpress-Connection-1741359646","strategy":"wordpress","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":{"X-Auth0-Client":"my-client"},"scope":["email","profile","openid"]}}
+            {"name":"Test-Wordpress-Connection-1743077318","strategy":"wordpress","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":[{"X-Auth0-Client":"my-client"}],"scope":["email","profile","openid"]}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
+                - Go-Auth0/1.18.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -28,15 +28,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 411
+        content_length: 413
         uncompressed: false
-        body: '{"id":"con_lZXfNWlpy7fCMeYO","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":{"X-Auth0-Client":"my-client"},"scope":["profile"],"profile":true},"strategy":"wordpress","name":"Test-Wordpress-Connection-1741359646","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1741359646"]}'
+        body: '{"id":"con_s2jJGWtYputLpnhH","options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":[{"X-Auth0-Client":"my-client"}],"scope":["profile"],"profile":true},"strategy":"wordpress","name":"Test-Wordpress-Connection-1743077318","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1743077318"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 403.832875ms
+        duration: 484.355625ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -54,8 +54,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections?include_totals=true&name=Test-Wordpress-Connection-1741359646&per_page=50
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections?include_totals=true&name=Test-Wordpress-Connection-1743077318&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,13 +65,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"total":1,"start":0,"limit":50,"connections":[{"id":"con_lZXfNWlpy7fCMeYO","options":{"scope":["profile"],"profile":true,"custom_headers":{"X-Auth0-Client":"my-client"},"upstream_params":{"screen_name":{"alias":"login_hint"}},"strategy_version":2},"strategy":"wordpress","name":"Test-Wordpress-Connection-1741359646","is_domain_connection":false,"realms":["Test-Wordpress-Connection-1741359646"],"enabled_clients":[]}]}'
+        body: '{"total":1,"start":0,"limit":50,"connections":[{"id":"con_s2jJGWtYputLpnhH","options":{"scope":["profile"],"profile":true,"custom_headers":[{"X-Auth0-Client":"my-client"}],"upstream_params":{"screen_name":{"alias":"login_hint"}},"strategy_version":2},"strategy":"wordpress","name":"Test-Wordpress-Connection-1743077318","is_domain_connection":false,"realms":["Test-Wordpress-Connection-1743077318"],"enabled_clients":[]}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.0715ms
+        duration: 429.095416ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -89,8 +89,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_lZXfNWlpy7fCMeYO
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_s2jJGWtYputLpnhH
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -100,13 +100,13 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2025-03-07T15:00:49.242Z"}'
+        body: '{"deleted_at":"2025-03-27T12:08:42.437Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 349.307792ms
+        duration: 410.093459ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -124,8 +124,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_lZXfNWlpy7fCMeYO
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_s2jJGWtYputLpnhH
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -141,4 +141,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 330.548334ms
+        duration: 432.249041ms

--- a/test/data/recordings/TestConnectionManager_Update/It_can_successfully_update_a_Wordpress_Connection.yaml
+++ b/test/data/recordings/TestConnectionManager_Update/It_can_successfully_update_a_Wordpress_Connection.yaml
@@ -13,13 +13,13 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-Wordpress-Connection-1741359670","strategy":"wordpress"}
+            {"name":"Test-Wordpress-Connection-1743077347","strategy":"wordpress"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
+                - Go-Auth0/1.18.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -30,33 +30,33 @@ interactions:
         trailer: {}
         content_length: 245
         uncompressed: false
-        body: '{"id":"con_pRqhueikoVpWweKV","options":{"profile":true,"scope":["profile"]},"strategy":"wordpress","name":"Test-Wordpress-Connection-1741359670","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1741359670"]}'
+        body: '{"id":"con_wwrBlZU4HO2QnZQB","options":{"profile":true,"scope":["profile"]},"strategy":"wordpress","name":"Test-Wordpress-Connection-1743077347","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1743077347"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 1.008415083s
+        duration: 1.103629458s
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 217
+        content_length: 219
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":{"X-Auth0-Client":"my-client"},"scope":["email","profile","openid"]}}
+            {"options":{"strategy_version":2,"authorizationURL":null,"tokenURL":null,"upstream_params":{"screen_name":{"alias":"login_hint"}},"custom_headers":[{"X-Auth0-Client":"my-client"}],"scope":["email","profile","openid"]}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_pRqhueikoVpWweKV
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_wwrBlZU4HO2QnZQB
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_pRqhueikoVpWweKV","options":{"scope":["profile"],"profile":true,"tokenURL":null,"custom_headers":{"X-Auth0-Client":"my-client"},"upstream_params":{"screen_name":{"alias":"login_hint"}},"authorizationURL":null,"strategy_version":2},"strategy":"wordpress","name":"Test-Wordpress-Connection-1741359670","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1741359670"]}'
+        body: '{"id":"con_wwrBlZU4HO2QnZQB","options":{"scope":["profile"],"profile":true,"tokenURL":null,"custom_headers":[{"X-Auth0-Client":"my-client"}],"upstream_params":{"screen_name":{"alias":"login_hint"}},"authorizationURL":null,"strategy_version":2},"strategy":"wordpress","name":"Test-Wordpress-Connection-1743077347","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1743077347"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 365.944208ms
+        duration: 485.549875ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -90,8 +90,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_pRqhueikoVpWweKV
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_wwrBlZU4HO2QnZQB
         method: GET
       response:
         proto: HTTP/2.0
@@ -101,13 +101,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_pRqhueikoVpWweKV","options":{"scope":["profile"],"profile":true,"custom_headers":{"X-Auth0-Client":"my-client"},"upstream_params":{"screen_name":{"alias":"login_hint"}},"strategy_version":2},"strategy":"wordpress","name":"Test-Wordpress-Connection-1741359670","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1741359670"]}'
+        body: '{"id":"con_wwrBlZU4HO2QnZQB","options":{"scope":["profile"],"profile":true,"custom_headers":[{"X-Auth0-Client":"my-client"}],"upstream_params":{"screen_name":{"alias":"login_hint"}},"strategy_version":2},"strategy":"wordpress","name":"Test-Wordpress-Connection-1743077347","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Wordpress-Connection-1743077347"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 357.515334ms
+        duration: 441.200959ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -125,8 +125,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.17.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_pRqhueikoVpWweKV
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_wwrBlZU4HO2QnZQB
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -136,10 +136,10 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2025-03-07T15:01:12.639Z"}'
+        body: '{"deleted_at":"2025-03-27T12:09:09.981Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 406.49425ms
+        duration: 442.989417ms


### PR DESCRIPTION

<!--  
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.  

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct:  
https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.  
-->  

### 🔧 Changes  

This PR introduces a **breaking change** by updating the `CustomHeaders` field in `ConnectionOptionsOAuth2`:  

- **Changed `CustomHeaders` from `map[string]string` to `*[]map[string]string`** to support multiple headers with the same key.  

This change improves API compatibility and ensures headers are handled consistently.  

### 📚 References  

<!-- Add relevant links supporting this change, such as: -->  
### 🔬 Testing  

- Updated tests to validate the new `CustomHeaders` structure.  

### 📝 Checklist  

- [x] All new/changed/fixed functionality is covered by tests (or N/A)  
- [x] Documentation has been updated for this breaking change (or N/A)  

<!--  
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.  
-->