### PR TITLE
Add Support for `ListRendering` method and associated tests for `PromptManager`

### DIFF
--- a/management/custom_domain_test.go
+++ b/management/custom_domain_test.go
@@ -15,7 +15,7 @@ func TestCustomDomainManager_Create(t *testing.T) {
 	configureHTTPTestRecordings(t)
 
 	expected := &CustomDomain{
-		Domain:    auth0.Stringf("%d.auth.uat.auth0.com", time.Now().UTC().Unix()),
+		Domain:    auth0.Stringf("%d.tempdomain.com", time.Now().UTC().Unix()),
 		Type:      auth0.String("auth0_managed_certs"),
 		TLSPolicy: auth0.String("recommended"),
 	}
@@ -96,7 +96,7 @@ func givenACustomDomain(t *testing.T) *CustomDomain {
 	t.Helper()
 
 	customDomain := &CustomDomain{
-		Domain:    auth0.Stringf("%d.auth.uat.auth0.com", time.Now().UTC().Unix()),
+		Domain:    auth0.Stringf("%d.tempdomain.com", time.Now().UTC().Unix()),
 		Type:      auth0.String("auth0_managed_certs"),
 		TLSPolicy: auth0.String("recommended"),
 	}

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -9878,6 +9878,11 @@ func (p *PromptRendering) String() string {
 	return Stringify(p)
 }
 
+// String returns a string representation of PromptRenderingList.
+func (p *PromptRenderingList) String() string {
+	return Stringify(p)
+}
+
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
 func (r *RefreshToken) GetClientID() string {
 	if r == nil || r.ClientID == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -12383,6 +12383,14 @@ func TestPromptRendering_String(t *testing.T) {
 	}
 }
 
+func TestPromptRenderingList_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &PromptRenderingList{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestRefreshToken_GetClientID(tt *testing.T) {
 	var zeroValue string
 	r := &RefreshToken{ClientID: &zeroValue}

--- a/management/prompt.go
+++ b/management/prompt.go
@@ -456,6 +456,12 @@ type PromptRendering struct {
 	HeadTags                []interface{}  `json:"head_tags,omitempty"`
 }
 
+// PromptRenderingList is a list of prompt rendering settings.
+type PromptRenderingList struct {
+	List
+	PromptRenderings []*PromptRendering `json:"configs"`
+}
+
 // MarshalJSON implements a custom [json.Marshaler].
 func (c *PromptRendering) MarshalJSON() ([]byte, error) {
 	type RenderingSubSet struct {
@@ -652,4 +658,12 @@ func (c *PromptRendering) cleanForPatch() *PromptRendering {
 func (m *PromptManager) UpdateRendering(ctx context.Context, prompt PromptType, screen ScreenName, c *PromptRendering, opts ...RequestOption) error {
 	c = c.cleanForPatch()
 	return m.management.Request(ctx, "PATCH", m.management.URI("prompts", string(prompt), "screen", string(screen), "rendering"), c, opts...)
+}
+
+// ListRendering lists the settings for all the ACUL.
+//
+// See: https://auth0.com/docs/api/management/v2/prompts/get-all-rendering
+func (m *PromptManager) ListRendering(ctx context.Context, opts ...RequestOption) (c *PromptRenderingList, err error) {
+	err = m.management.Request(ctx, "GET", m.management.URI("prompts", "rendering"), &c, applyListDefaults(opts))
+	return
 }

--- a/management/prompt.go
+++ b/management/prompt.go
@@ -119,6 +119,9 @@ const (
 
 	// PromptCaptcha represents the captcha prompt.
 	PromptCaptcha PromptType = "captcha"
+
+	// PromptBruteForceProtection represents the brute-force-protection prompt.
+	PromptBruteForceProtection PromptType = "brute-force-protection"
 )
 
 var allowedPromptsWithPartials = []PromptType{
@@ -340,6 +343,9 @@ const (
 	// ScreenMFABeginEnrollOptions represents the mfa-begin-enroll-options screen.
 	ScreenMFABeginEnrollOptions ScreenName = "mfa-begin-enroll-options"
 
+	// ScreenMFARecoveryCodeChallengeNewCode represents the mfa-recovery-code-challenge-new-code screen.
+	ScreenMFARecoveryCodeChallengeNewCode ScreenName = "mfa-recovery-code-challenge-new-code"
+
 	// ScreenStatus represents the status screen.
 	ScreenStatus ScreenName = "status"
 
@@ -381,6 +387,15 @@ const (
 
 	// ScreenInterstitialCaptcha represents the interstitial-captcha screen.
 	ScreenInterstitialCaptcha ScreenName = "interstitial-captcha"
+
+	// ScreenBruteForceProtectionUnblock represents the brute-force-protection-unblock screen.
+	ScreenBruteForceProtectionUnblock ScreenName = "brute-force-protection-unblock"
+
+	// ScreenBruteForceProtectionUnblockFailure represents the brute-force-protection-unblock-failure.
+	ScreenBruteForceProtectionUnblockFailure ScreenName = "brute-force-protection-unblock-failure"
+
+	// ScreenBruteForceProtectionUnblockSuccess represents the brute-force-protection-unblock-success.
+	ScreenBruteForceProtectionUnblockSuccess ScreenName = "brute-force-protection-unblock-success"
 )
 
 const (

--- a/management/prompt_test.go
+++ b/management/prompt_test.go
@@ -143,6 +143,28 @@ func TestPromptManager_ReadRendering(t *testing.T) {
 	assert.Equal(t, ScreenSignup, *actual.GetScreen())
 }
 
+func TestPromptManager_ListRendering(t *testing.T) {
+	configureHTTPTestRecordings(t)
+	_ = givenACustomDomain(t)
+	_ = givenAUniversalLoginTemplate(t)
+	expected := givenAPromptRendering(t, RenderingModeAdvanced)
+
+	actual, err := api.Prompt.ListRendering(context.Background())
+	assert.NoError(t, err)
+	found := false
+	for _, r := range actual.PromptRenderings {
+		if r.RenderingMode != nil && expected.RenderingMode != nil &&
+			*r.GetRenderingMode() == *expected.GetRenderingMode() &&
+			assert.Equal(t, expected.GetContextConfiguration(), r.GetContextConfiguration()) &&
+			assert.Equal(t, expected.GetDefaultHeadTagsDisabled(), r.GetDefaultHeadTagsDisabled()) &&
+			assert.Equal(t, expected.HeadTags, r.HeadTags) {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected PromptRendering not found in actual.PromptRendering")
+}
+
 // Able to update the renderingMode to advanced and the setting configs when parsing the advanced renderingMode in payload.
 func TestPromptManager_UpdateRenderingWithAdvancedMode(t *testing.T) {
 	configureHTTPTestRecordings(t)

--- a/management/prompt_test.go
+++ b/management/prompt_test.go
@@ -163,6 +163,7 @@ func TestPromptManager_ListRendering(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "expected PromptRendering not found in actual.PromptRendering")
+	assert.Greater(t, len(actual.PromptRenderings), 0)
 }
 
 // Able to update the renderingMode to advanced and the setting configs when parsing the advanced renderingMode in payload.

--- a/test/data/recordings/TestBrandingManager_UniversalLogin.yaml
+++ b/test/data/recordings/TestBrandingManager_UniversalLogin.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1674668556.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1674668556.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 300
         uncompressed: false
-        body: '{"custom_domain_id":"cd_DHYNDw1TXPiTDg9V","domain":"1674668556.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-dhyndw1txpitdg9v.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_DHYNDw1TXPiTDg9V","domain":"1674668556.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-dhyndw1txpitdg9v.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestCustomDomainManager_Create.yaml
+++ b/test/data/recordings/TestCustomDomainManager_Create.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1674668736.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1674668736.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 300
         uncompressed: false
-        body: '{"custom_domain_id":"cd_Qgv4RYP5j8Eovjl5","domain":"1674668736.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-qgv4ryp5j8eovjl5.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_Qgv4RYP5j8Eovjl5","domain":"1674668736.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-qgv4ryp5j8eovjl5.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestCustomDomainManager_Delete.yaml
+++ b/test/data/recordings/TestCustomDomainManager_Delete.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1674668763.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1674668763.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 300
         uncompressed: false
-        body: '{"custom_domain_id":"cd_FEt6ft8M0RkBUDsp","domain":"1674668763.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-fet6ft8m0rkbudsp.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_FEt6ft8M0RkBUDsp","domain":"1674668763.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-fet6ft8m0rkbudsp.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestCustomDomainManager_List.yaml
+++ b/test/data/recordings/TestCustomDomainManager_List.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1674668771.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1674668771.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 300
         uncompressed: false
-        body: '{"custom_domain_id":"cd_xFmdOfl4i2CwG9Rk","domain":"1674668771.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-xfmdofl4i2cwg9rk.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_xFmdOfl4i2CwG9Rk","domain":"1674668771.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-xfmdofl4i2cwg9rk.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
@@ -66,7 +66,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"custom_domain_id":"cd_xFmdOfl4i2CwG9Rk","domain":"1674668771.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-xfmdofl4i2cwg9rk.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}]'
+        body: '[{"custom_domain_id":"cd_xFmdOfl4i2CwG9Rk","domain":"1674668771.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-xfmdofl4i2cwg9rk.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}]'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestCustomDomainManager_Read.yaml
+++ b/test/data/recordings/TestCustomDomainManager_Read.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1674668745.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1674668745.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 300
         uncompressed: false
-        body: '{"custom_domain_id":"cd_4SMEJ852bkNWQ5nH","domain":"1674668745.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-4smej852bknwq5nh.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_4SMEJ852bkNWQ5nH","domain":"1674668745.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-4smej852bknwq5nh.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
@@ -66,7 +66,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"custom_domain_id":"cd_4SMEJ852bkNWQ5nH","domain":"1674668745.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-4smej852bknwq5nh.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_4SMEJ852bkNWQ5nH","domain":"1674668745.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-4smej852bknwq5nh.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestCustomDomainManager_Update.yaml
+++ b/test/data/recordings/TestCustomDomainManager_Update.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1674668754.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1674668754.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 300
         uncompressed: false
-        body: '{"custom_domain_id":"cd_7UHmBHGRRwUWpajT","domain":"1674668754.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-7uhmbhgrrwuwpajt.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_7UHmBHGRRwUWpajT","domain":"1674668754.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-7uhmbhgrrwuwpajt.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
@@ -66,7 +66,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"custom_domain_id":"cd_7UHmBHGRRwUWpajT","domain":"1674668754.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-7uhmbhgrrwuwpajt.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_7UHmBHGRRwUWpajT","domain":"1674668754.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-7uhmbhgrrwuwpajt.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
@@ -102,7 +102,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"custom_domain_id":"cd_7UHmBHGRRwUWpajT","domain":"1674668754.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-7uhmbhgrrwuwpajt.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_7UHmBHGRRwUWpajT","domain":"1674668754.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-7uhmbhgrrwuwpajt.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestCustomDomainManager_Verify.yaml
+++ b/test/data/recordings/TestCustomDomainManager_Verify.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1674668780.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1674668780.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 300
         uncompressed: false
-        body: '{"custom_domain_id":"cd_IXrkgIcEAN0hJbuV","domain":"1674668780.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-ixrkgicean0hjbuv.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_IXrkgIcEAN0hJbuV","domain":"1674668780.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-ixrkgicean0hjbuv.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
@@ -66,7 +66,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"custom_domain_id":"cd_IXrkgIcEAN0hJbuV","domain":"1674668780.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-ixrkgicean0hjbuv.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_IXrkgIcEAN0hJbuV","domain":"1674668780.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-ixrkgicean0hjbuv.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestPromptManager_CreatePartials.yaml
+++ b/test/data/recordings/TestPromptManager_CreatePartials.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1709139540.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1709139540.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 324
         uncompressed: false
-        body: '{"custom_domain_id":"cd_nVqh1HtMcMIQ2i3Q","domain":"1709139540.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-nvqh1htmcmiq2i3q.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_nVqh1HtMcMIQ2i3Q","domain":"1709139540.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-nvqh1htmcmiq2i3q.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestPromptManager_DeletePartials.yaml
+++ b/test/data/recordings/TestPromptManager_DeletePartials.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1709139641.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1709139641.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 324
         uncompressed: false
-        body: '{"custom_domain_id":"cd_EWydSAqJJuQLmlWT","domain":"1709139641.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-ewydsaqjjuqlmlwt.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_EWydSAqJJuQLmlWT","domain":"1709139641.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-ewydsaqjjuqlmlwt.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestPromptManager_GetPartials.yaml
+++ b/test/data/recordings/TestPromptManager_GetPartials.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1724659065.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1724659065.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 373
         uncompressed: false
-        body: '{"custom_domain_id":"cd_h3Zz4noJ4gzl10ND","domain":"1724659065.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-h3zz4noj4gzl10nd.edge.tenants.sus.auth0.com","domain":"1724659065.auth.uat.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_h3Zz4noJ4gzl10ND","domain":"1724659065.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-h3zz4noj4gzl10nd.edge.tenants.sus.auth0.com","domain":"1724659065.tempdomain.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestPromptManager_ListRendering.yaml
+++ b/test/data/recordings/TestPromptManager_ListRendering.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 81
+        content_length: 98
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1724659065.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1747220381.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.9.0
+                - Go-Auth0/1.20.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains
         method: POST
       response:
@@ -28,15 +28,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 304
+        content_length: 339
         uncompressed: false
-        body: '{"custom_domain_id":"cd_itzPuKdJ8NdyfDpI","domain":"1724659065.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-itzpukdj8ndyfdpi.edge.tenants.us.auth0.com","domain":"kunal.dawar"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_i4mVcdyPwpPCzUD3","domain":"1747220381.tempdomain.com","primary":false,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-i4mvcdypwppczud3.edge.tenants.us.auth0.com","domain":"1747220381.tempdomain.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 1.658834625s
+        duration: 981.391125ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,7 +55,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.9.0
+                - Go-Auth0/1.20.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
         method: PUT
       response:
@@ -72,28 +72,28 @@ interactions:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 2.838140417s
+        duration: 637.245667ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 355
+        content_length: 408
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"login-passwordless-email-code":{"form-content-end":"\u003cdiv\u003eForm Content Start\u003c/div\u003e","form-content-start":"\u003cdiv\u003eForm Content Start\u003c/div\u003e"},"login-passwordless-sms-otp":{"form-content-end":"\u003cdiv\u003eForm Content Start\u003c/div\u003e","form-content-start":"\u003cdiv\u003eForm Content Start\u003c/div\u003e"}}
+            {"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.9.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/login-passwordless/partials
-        method: PUT
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -102,13 +102,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"login-passwordless-email-code":{"form-content-end":"<div>Form Content Start</div>","form-content-start":"<div>Form Content Start</div>"},"login-passwordless-sms-otp":{"form-content-end":"<div>Form Content Start</div>","form-content-start":"<div>Form Content Start</div>"}}'
+        body: '{"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 411.334083ms
+        duration: 455.612792ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -126,8 +126,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.9.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/login-passwordless/partials
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/rendering?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -137,49 +137,48 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"login-passwordless-email-code":{"form-content-end":"<div>Form Content Start</div>","form-content-start":"<div>Form Content Start</div>"},"login-passwordless-sms-otp":{"form-content-end":"<div>Form Content Start</div>","form-content-start":"<div>Form Content Start</div>"}}'
+        body: '{"configs":[{"prompt":"signup","screen":"signup","rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"tag":"script","content":"","attributes":{"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js","async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="]}}],"filters":null}],"start":0,"limit":50,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.680375ms
+        duration: 370.402167ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 3
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            {}
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.9.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/login-passwordless/partials
-        method: PUT
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 2
+        content_length: 0
         uncompressed: false
-        body: '{}'
+        body: ""
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 382.801458ms
+        status: 204 No Content
+        code: 204
+        duration: 444.462459ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -197,8 +196,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.9.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_i4mVcdyPwpPCzUD3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -214,39 +213,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 503.549041ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: go-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.9.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_itzPuKdJ8NdyfDpI
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 1.395291834s
+        duration: 391.238541ms

--- a/test/data/recordings/TestPromptManager_ReadPartials.yaml
+++ b/test/data/recordings/TestPromptManager_ReadPartials.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1709139498.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1709139498.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 324
         uncompressed: false
-        body: '{"custom_domain_id":"cd_GP9AMRKgSj467Hq8","domain":"1709139498.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-gp9amrkgsj467hq8.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_GP9AMRKgSj467Hq8","domain":"1709139498.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-gp9amrkgsj467hq8.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestPromptManager_ReadRendering.yaml
+++ b/test/data/recordings/TestPromptManager_ReadRendering.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1730881029.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1730881029.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 328
         uncompressed: false
-        body: '{"custom_domain_id":"cd_7SgKHnrmHQNuTXEs","domain":"1730881029.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-7sgkhnrmhqnutxes.edge.tenants.us.auth0.com","domain":"1730881029.auth.uat.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_7SgKHnrmHQNuTXEs","domain":"1730881029.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-7sgkhnrmhqnutxes.edge.tenants.us.auth0.com","domain":"1730881029.tempdomain.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestPromptManager_UpdatePartials.yaml
+++ b/test/data/recordings/TestPromptManager_UpdatePartials.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1709139551.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1709139551.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 324
         uncompressed: false
-        body: '{"custom_domain_id":"cd_fagxlqwlaFt5sYRe","domain":"1709139551.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-fagxlqwlaft5syre.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_fagxlqwlaFt5sYRe","domain":"1709139551.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"go-auth0-dev.eu.auth0.com-cd-fagxlqwlaft5syre.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestPromptManager_UpdateRendering.yaml
+++ b/test/data/recordings/TestPromptManager_UpdateRendering.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1734698728.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1734698728.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 342
         uncompressed: false
-        body: '{"custom_domain_id":"cd_hW5C18CQPXRsKpDz","domain":"1733383424.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-hw5c18cqpxrskpdz.edge.tenants.us.auth0.com","domain":"1733383424.auth.uat.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_hW5C18CQPXRsKpDz","domain":"1733383424.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-hw5c18cqpxrskpdz.edge.tenants.us.auth0.com","domain":"1733383424.tempdomain.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestPromptManager_UpdateRenderingWithAdvancedMode.yaml
+++ b/test/data/recordings/TestPromptManager_UpdateRenderingWithAdvancedMode.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-          {"domain":"1734698728.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+          {"domain":"1734698728.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: { }
         headers:
           Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: { }
         content_length: 342
         uncompressed: false
-        body: '{"custom_domain_id":"cd_hW5C18CQPXRsKpDz","domain":"1733383424.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-hw5c18cqpxrskpdz.edge.tenants.us.auth0.com","domain":"1733383424.auth.uat.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_hW5C18CQPXRsKpDz","domain":"1733383424.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-hw5c18cqpxrskpdz.edge.tenants.us.auth0.com","domain":"1733383424.tempdomain.com"}]},"tls_policy":"recommended"}'
         headers:
           Content-Type:
             - application/json; charset=utf-8

--- a/test/data/recordings/TestPromptManager_UpdateRenderingWithStandardMode.yaml
+++ b/test/data/recordings/TestPromptManager_UpdateRenderingWithStandardMode.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-          {"domain":"1734698728.auth.uat.auth0.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+          {"domain":"1734698728.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: 169
         uncompressed: false
-        body: '{"custom_domain_id":"cd_hW5C18CQPXRsKpDz","domain":"1733383424.auth.uat.auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-hw5c18cqpxrskpdz.edge.tenants.us.auth0.com","domain":"1733383424.auth.uat.auth0.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_hW5C18CQPXRsKpDz","domain":"1733383424.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-hw5c18cqpxrskpdz.edge.tenants.us.auth0.com","domain":"1733383424.tempdomain.com"}]},"tls_policy":"recommended"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8


### PR DESCRIPTION
<!--  
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.  
  
By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.  
-->

### 🔧 Changes

This PR adds support for listing prompt rendering settings via the `PromptManager`. The following changes are included:

* Introduced `PromptRenderingList` struct to encapsulate multiple rendering settings.
* Implemented `ListRendering` method on `PromptManager` to retrieve all prompt rendering configurations.
* Added unit tests for `ListRendering` to validate expected behavior and response structure.
* Updated test recordings to reflect usage of temporary domain names, ensuring better test isolation and consistency.
* Adjusted existing test recordings across various managers to align with new domain setup.

### 📚 References

<!--  
Add any relevant references here, or remove this section if none exist.  
-->

### 🔬 Testing

* Added unit tests to validate the functionality of `ListRendering`.
* Verified end-to-end behavior through updated HTTP test recordings.
* Ensured consistency across test domains to avoid conflicts and improve test reliability.

### 📝 Checklist

* [x] All new/changed/fixed functionality is covered by tests (or N/A)
* [x] I have added documentation for all new/changed functionality (or N/A)
