### PR TITLE
Add `ReadEnabledClients` and `UpdateEnabledClients` methods; deprecate `EnabledClients` field in `Connection` struct of `ConnectionManager`

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -253,6 +253,15 @@ func (st *SCIMToken) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// UpdateEnabledClients represents the payload for updating the clients for a connection.
+type UpdateEnabledClients struct {
+	// ClientID is The client_id of the client to be the subject to change status
+	ClientID string `json:"client_id"`
+
+	// Status indicates if the connection is enabled or not for this client_id
+	Status bool `json:"status"`
+}
+
 // MarshalJSON implements the json.Marshaler interface.
 func (c *Connection) MarshalJSON() ([]byte, error) {
 	type connection Connection
@@ -1572,6 +1581,13 @@ func (m *ConnectionManager) ReadByName(ctx context.Context, name string, opts ..
 		return c.Connections[0], nil
 	}
 	return nil, &managementError{404, "Not Found", "Connection not found"}
+}
+
+// UpdateEnabledClients updates the enabled clients for a connection by its connection ID.
+//
+// See: https://auth0.com/docs/api/management/v2/connections/patch-clients
+func (m *ConnectionManager) UpdateEnabledClients(ctx context.Context, id string, update []UpdateEnabledClients, opts ...RequestOption) error {
+	return m.management.Request(ctx, "PATCH", m.management.URI("connections", id, "clients"), update, opts...)
 }
 
 // CreateSCIMConfiguration creates a SCIM configuration for a connection by its connection ID.

--- a/management/connection.go
+++ b/management/connection.go
@@ -138,11 +138,12 @@ type Connection struct {
 	// Options for validation.
 	Options interface{} `json:"-"`
 
-	// The identifiers of the clients for which the connection is to be
-	// enabled. If the array is empty or the property is not specified, no
-	// clients are enabled.
+	// EnabledClients holds the identifiers of clients for which the connection is enabled.
+	//
+	// Deprecated: This field is deprecated and will be removed in future versions.
+	// Use UpdateEnabledClients and ReadEnabledClients methods instead for managing enabled clients.
 	EnabledClients *[]string `json:"enabled_clients,omitempty"`
-
+	
 	// Defines the realms for which the connection will be used (ie: email
 	// domains). If the array is empty or the property is not specified, the
 	// connection name will be added as realm.
@@ -158,13 +159,19 @@ type Connection struct {
 	ShowAsButton *bool `json:"show_as_button,omitempty"`
 }
 
+// ConnectionEnabledClientList is a list of enabled clients for a connection.
+type ConnectionEnabledClientList struct {
+	List
+	Clients *[]ConnectionEnabledClient `json:"clients,omitempty"`
+}
+
 // ConnectionEnabledClient represents the payload for the clients status for a connection.
 type ConnectionEnabledClient struct {
 	// ClientID is The client_id of the client
-	ClientID string `json:"client_id"`
+	ClientID *string `json:"client_id,omitempty"`
 
 	// Status indicates if the connection is enabled or not for this client_id
-	Status bool `json:"status"`
+	Status *bool `json:"status,omitempty"`
 }
 
 // SCIMConfiguration represents the SCIM configuration for a connection.
@@ -1583,11 +1590,19 @@ func (m *ConnectionManager) ReadByName(ctx context.Context, name string, opts ..
 	return nil, &managementError{404, "Not Found", "Connection not found"}
 }
 
+// ReadEnabledClients  retrieves the enabled clients for a connection by its connection ID.
+//
+// See: https://auth0.com/docs/api/management/v2/connections/get-connection-clients
+func (m *ConnectionManager) ReadEnabledClients(ctx context.Context, id string, opts ...RequestOption) (c *ConnectionEnabledClientList, err error) {
+	err = m.management.Request(ctx, "GET", m.management.URI("connections", id, "clients"), &c, opts...)
+	return
+}
+
 // UpdateEnabledClients updates the enabled clients for a connection by its connection ID.
 //
 // See: https://auth0.com/docs/api/management/v2/connections/patch-clients
-func (m *ConnectionManager) UpdateEnabledClients(ctx context.Context, id string, update []ConnectionEnabledClient, opts ...RequestOption) error {
-	return m.management.Request(ctx, "PATCH", m.management.URI("connections", id, "clients"), update, opts...)
+func (m *ConnectionManager) UpdateEnabledClients(ctx context.Context, id string, c []ConnectionEnabledClient, opts ...RequestOption) error {
+	return m.management.Request(ctx, "PATCH", m.management.URI("connections", id, "clients"), c, opts...)
 }
 
 // CreateSCIMConfiguration creates a SCIM configuration for a connection by its connection ID.

--- a/management/connection.go
+++ b/management/connection.go
@@ -158,6 +158,15 @@ type Connection struct {
 	ShowAsButton *bool `json:"show_as_button,omitempty"`
 }
 
+// ConnectionEnabledClient represents the payload for the clients status for a connection.
+type ConnectionEnabledClient struct {
+	// ClientID is The client_id of the client
+	ClientID string `json:"client_id"`
+
+	// Status indicates if the connection is enabled or not for this client_id
+	Status bool `json:"status"`
+}
+
 // SCIMConfiguration represents the SCIM configuration for a connection.
 // This struct is used primarily for enterprise connections.
 type SCIMConfiguration struct {
@@ -251,15 +260,6 @@ func (st *SCIMToken) MarshalJSON() ([]byte, error) {
 		Scopes:        st.Scopes,
 		TokenLifeTime: st.TokenLifeTime,
 	})
-}
-
-// UpdateEnabledClients represents the payload for updating the clients for a connection.
-type UpdateEnabledClients struct {
-	// ClientID is The client_id of the client to be the subject to change status
-	ClientID string `json:"client_id"`
-
-	// Status indicates if the connection is enabled or not for this client_id
-	Status bool `json:"status"`
 }
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -1586,7 +1586,7 @@ func (m *ConnectionManager) ReadByName(ctx context.Context, name string, opts ..
 // UpdateEnabledClients updates the enabled clients for a connection by its connection ID.
 //
 // See: https://auth0.com/docs/api/management/v2/connections/patch-clients
-func (m *ConnectionManager) UpdateEnabledClients(ctx context.Context, id string, update []UpdateEnabledClients, opts ...RequestOption) error {
+func (m *ConnectionManager) UpdateEnabledClients(ctx context.Context, id string, update []ConnectionEnabledClient, opts ...RequestOption) error {
 	return m.management.Request(ctx, "PATCH", m.management.URI("connections", id, "clients"), update, opts...)
 }
 

--- a/management/connection.go
+++ b/management/connection.go
@@ -143,7 +143,7 @@ type Connection struct {
 	// Deprecated: This field is deprecated and will be removed in future versions.
 	// Use UpdateEnabledClients and ReadEnabledClients methods instead for managing enabled clients.
 	EnabledClients *[]string `json:"enabled_clients,omitempty"`
-	
+
 	// Defines the realms for which the connection will be used (ie: email
 	// domains). If the array is empty or the property is not specified, the
 	// connection name will be added as realm.

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -888,7 +888,7 @@ func TestConnectionManager_UpdateEnabledClients_Add(t *testing.T) {
 		},
 	})
 
-	connectionWithUpdatedOptions := []UpdateEnabledClients{
+	connectionWithUpdatedOptions := []ConnectionEnabledClient{
 		{
 			ClientID: *client.ClientID,
 			Status:   true,
@@ -915,7 +915,7 @@ func TestConnectionManager_UpdateEnabledClients_Remove(t *testing.T) {
 		},
 	})
 
-	connectionWithUpdatedOptions := []UpdateEnabledClients{
+	connectionWithUpdatedOptions := []ConnectionEnabledClient{
 		{
 			ClientID: *client.ClientID,
 			Status:   false,

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -12506,6 +12506,11 @@ func (t *TokenExchangeProfileList) String() string {
 	return Stringify(t)
 }
 
+// String returns a string representation of UpdateEnabledClients.
+func (u *UpdateEnabledClients) String() string {
+	return Stringify(u)
+}
+
 // GetAppMetadata returns the AppMetadata field if it's non-nil, zero value otherwise.
 func (u *User) GetAppMetadata() map[string]interface{} {
 	if u == nil || u.AppMetadata == nil {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2602,8 +2602,37 @@ func (c *Connection) String() string {
 	return Stringify(c)
 }
 
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionEnabledClient) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (c *ConnectionEnabledClient) GetStatus() bool {
+	if c == nil || c.Status == nil {
+		return false
+	}
+	return *c.Status
+}
+
 // String returns a string representation of ConnectionEnabledClient.
 func (c *ConnectionEnabledClient) String() string {
+	return Stringify(c)
+}
+
+// GetClients returns the Clients field if it's non-nil, zero value otherwise.
+func (c *ConnectionEnabledClientList) GetClients() []ConnectionEnabledClient {
+	if c == nil || c.Clients == nil {
+		return nil
+	}
+	return *c.Clients
+}
+
+// String returns a string representation of ConnectionEnabledClientList.
+func (c *ConnectionEnabledClientList) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2602,6 +2602,11 @@ func (c *Connection) String() string {
 	return Stringify(c)
 }
 
+// String returns a string representation of ConnectionEnabledClient.
+func (c *ConnectionEnabledClient) String() string {
+	return Stringify(c)
+}
+
 // GetAudience returns the Audience field if it's non-nil, zero value otherwise.
 func (c *ConnectionGatewayAuthentication) GetAudience() string {
 	if c == nil || c.Audience == nil {
@@ -12504,11 +12509,6 @@ func (t *TokenExchangeProfile) String() string {
 // String returns a string representation of TokenExchangeProfileList.
 func (t *TokenExchangeProfileList) String() string {
 	return Stringify(t)
-}
-
-// String returns a string representation of UpdateEnabledClients.
-func (u *UpdateEnabledClients) String() string {
-	return Stringify(u)
 }
 
 // GetAppMetadata returns the AppMetadata field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -3182,9 +3182,47 @@ func TestConnection_String(t *testing.T) {
 	}
 }
 
+func TestConnectionEnabledClient_GetClientID(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionEnabledClient{ClientID: &zeroValue}
+	c.GetClientID()
+	c = &ConnectionEnabledClient{}
+	c.GetClientID()
+	c = nil
+	c.GetClientID()
+}
+
+func TestConnectionEnabledClient_GetStatus(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionEnabledClient{Status: &zeroValue}
+	c.GetStatus()
+	c = &ConnectionEnabledClient{}
+	c.GetStatus()
+	c = nil
+	c.GetStatus()
+}
+
 func TestConnectionEnabledClient_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ConnectionEnabledClient{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionEnabledClientList_GetClients(tt *testing.T) {
+	var zeroValue []ConnectionEnabledClient
+	c := &ConnectionEnabledClientList{Clients: &zeroValue}
+	c.GetClients()
+	c = &ConnectionEnabledClientList{}
+	c.GetClients()
+	c = nil
+	c.GetClients()
+}
+
+func TestConnectionEnabledClientList_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionEnabledClientList{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -15706,6 +15706,14 @@ func TestTokenExchangeProfileList_String(t *testing.T) {
 	}
 }
 
+func TestUpdateEnabledClients_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &UpdateEnabledClients{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestUser_GetAppMetadata(tt *testing.T) {
 	var zeroValue map[string]interface{}
 	u := &User{AppMetadata: &zeroValue}

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -3182,6 +3182,14 @@ func TestConnection_String(t *testing.T) {
 	}
 }
 
+func TestConnectionEnabledClient_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionEnabledClient{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestConnectionGatewayAuthentication_GetAudience(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionGatewayAuthentication{Audience: &zeroValue}
@@ -15701,14 +15709,6 @@ func TestTokenExchangeProfile_String(t *testing.T) {
 func TestTokenExchangeProfileList_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &TokenExchangeProfileList{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
-func TestUpdateEnabledClients_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &UpdateEnabledClients{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/test/data/recordings/TestConnectionManager_EnabledClients.yaml
+++ b/test/data/recordings/TestConnectionManager_EnabledClients.yaml
@@ -1,0 +1,287 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1125
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client (May 20 14:16:49.784)","description":"This is just a test client.","jwt_configuration":{"alg":"RS256"},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"name":"Test Credential (May 20 14:16:49.784)","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAua6LXMfgDE/tDdkOL1Oe\n3oWUwg1r4dSTg9L7RCcI5hItUzmkVofHtWN0H4CH2lm2ANmaJUsnhzctYowYW2+R\ntHvU9afTmtbdhpy993972hUqZSYLsE3iGziphYkOKVsqq38+VRH3TNg93zSLoRao\nJnTTkMXseVqiyqYRmFN8+gQQoEclHSGPUWQG5XMZ+hhuXeFyo+Yw/qbZWca/6/2I\n3rsca9jXR1alhxhHrXrg8N4Dm3gBgGbmiht6YYYT2Tyl1OqB9+iOI/9D7dfoCF6X\nAWJXRE454cmC8k8oucpjZVpflA+ocKshwPDR6YTLQYbXYiaWxEoaz0QGUErNQBnG\nI+sr9jDY3ua/s6HF6h0qyi/HVZH4wx+m4CtOfJoYTjrGBbaRszzUxhtSN2/MhXDu\n+a35q9/2zcu/3fjkkfVvGUt+NyyiYOKQ9vsJC1g/xxdUWtowjNwjfZE2zcG4usi8\nr38Bp0lmiipAsMLduZM/D5dFXkRdWCBNDfULmmg/4nv2wwjbjQuLemAMh7mmrztW\ni/85WMnjKQZT8NqS43pmgyIzg1gK1neMqdS90YmQ/PvJ36qALxCs245w1JpN9BAL\nJbwxCg/dbmKT7PalfWrksx9hGcJxtGqebldaOpw+5GVIPxxtC1C0gVr9BKeiDS3f\naibASY5pIRiKENmbZELDtucCAwEAAQ==\n-----END PUBLIC KEY-----"}]}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client (May 20 14:16:49.784)","description":"This is just a test client.","client_id":"Ca4v8gSpiV5oIlYH2aVkfRCn0A1uIAdB","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_tgn3kHmu9HmAca3f1Qu1iQ","name":"Test Credential (May 20 14:16:49.784)","kid":"4e7yYf0TKdyTLbVnpq2wLN6mZ8t7eb9UJkMksyHj9iU","credential_type":"public_key","alg":"RS256","created_at":"2025-05-20T08:46:50.765Z","updated_at":"2025-05-20T08:46:50.765Z"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1.2002765s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 72
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Auth0-Connection-1747730810985929000","strategy":"auth0"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 538
+        uncompressed: false
+        body: '{"id":"con_1D0JFKzHjd17eNfe","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Test-Auth0-Connection-1747730810985929000","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Auth0-Connection-1747730810985929000"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 429.214834ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 65
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            [{"client_id":"Ca4v8gSpiV5oIlYH2aVkfRCn0A1uIAdB","status":true}]
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_1D0JFKzHjd17eNfe/clients
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 414.089459ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_1D0JFKzHjd17eNfe/clients
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"clients":[{"client_id":"Ca4v8gSpiV5oIlYH2aVkfRCn0A1uIAdB"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 353.890459ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 66
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            [{"client_id":"Ca4v8gSpiV5oIlYH2aVkfRCn0A1uIAdB","status":false}]
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_1D0JFKzHjd17eNfe/clients
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 519.070375ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_1D0JFKzHjd17eNfe/clients
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"clients":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 375.432459ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_1D0JFKzHjd17eNfe
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2025-05-20T08:46:53.492Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 470.89375ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/Ca4v8gSpiV5oIlYH2aVkfRCn0A1uIAdB
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 428.191583ms

--- a/test/data/recordings/TestConnectionManager_UpdateEnabledClients_Add.yaml
+++ b/test/data/recordings/TestConnectionManager_UpdateEnabledClients_Add.yaml
@@ -1,0 +1,216 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1125
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client (May 16 13:56:03.125)","description":"This is just a test client.","jwt_configuration":{"alg":"RS256"},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"name":"Test Credential (May 16 13:56:03.126)","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAua6LXMfgDE/tDdkOL1Oe\n3oWUwg1r4dSTg9L7RCcI5hItUzmkVofHtWN0H4CH2lm2ANmaJUsnhzctYowYW2+R\ntHvU9afTmtbdhpy993972hUqZSYLsE3iGziphYkOKVsqq38+VRH3TNg93zSLoRao\nJnTTkMXseVqiyqYRmFN8+gQQoEclHSGPUWQG5XMZ+hhuXeFyo+Yw/qbZWca/6/2I\n3rsca9jXR1alhxhHrXrg8N4Dm3gBgGbmiht6YYYT2Tyl1OqB9+iOI/9D7dfoCF6X\nAWJXRE454cmC8k8oucpjZVpflA+ocKshwPDR6YTLQYbXYiaWxEoaz0QGUErNQBnG\nI+sr9jDY3ua/s6HF6h0qyi/HVZH4wx+m4CtOfJoYTjrGBbaRszzUxhtSN2/MhXDu\n+a35q9/2zcu/3fjkkfVvGUt+NyyiYOKQ9vsJC1g/xxdUWtowjNwjfZE2zcG4usi8\nr38Bp0lmiipAsMLduZM/D5dFXkRdWCBNDfULmmg/4nv2wwjbjQuLemAMh7mmrztW\ni/85WMnjKQZT8NqS43pmgyIzg1gK1neMqdS90YmQ/PvJ36qALxCs245w1JpN9BAL\nJbwxCg/dbmKT7PalfWrksx9hGcJxtGqebldaOpw+5GVIPxxtC1C0gVr9BKeiDS3f\naibASY5pIRiKENmbZELDtucCAwEAAQ==\n-----END PUBLIC KEY-----"}]}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client (May 16 13:56:03.125)","description":"This is just a test client.","client_id":"li3LVZNp65uTEKY24io5nutAeoC10YAb","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_6kcKsfJQAHVZkgzHuLWzBw","name":"Test Credential (May 16 13:56:03.126)","kid":"4e7yYf0TKdyTLbVnpq2wLN6mZ8t7eb9UJkMksyHj9iU","credential_type":"public_key","alg":"RS256","created_at":"2025-05-16T11:56:03.365Z","updated_at":"2025-05-16T11:56:03.365Z"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 290.33075ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 63
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Auth0-Connection-1747396563","strategy":"auth0"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 520
+        uncompressed: false
+        body: '{"id":"con_s3vZb8dKdbSb63f2","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Test-Auth0-Connection-1747396563","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Auth0-Connection-1747396563"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 95.299667ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 65
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            [{"client_id":"li3LVZNp65uTEKY24io5nutAeoC10YAb","status":true}]
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_s3vZb8dKdbSb63f2/clients
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 109.86075ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_s3vZb8dKdbSb63f2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_s3vZb8dKdbSb63f2","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Test-Auth0-Connection-1747396563","is_domain_connection":false,"enabled_clients":["li3LVZNp65uTEKY24io5nutAeoC10YAb"],"realms":["Test-Auth0-Connection-1747396563"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 78.797708ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_s3vZb8dKdbSb63f2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2025-05-16T11:56:03.788Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 78.731375ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/li3LVZNp65uTEKY24io5nutAeoC10YAb
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 148.927458ms

--- a/test/data/recordings/TestConnectionManager_UpdateEnabledClients_Remove.yaml
+++ b/test/data/recordings/TestConnectionManager_UpdateEnabledClients_Remove.yaml
@@ -1,0 +1,216 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1125
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client (May 16 13:55:56.648)","description":"This is just a test client.","jwt_configuration":{"alg":"RS256"},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"name":"Test Credential (May 16 13:55:56.648)","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAua6LXMfgDE/tDdkOL1Oe\n3oWUwg1r4dSTg9L7RCcI5hItUzmkVofHtWN0H4CH2lm2ANmaJUsnhzctYowYW2+R\ntHvU9afTmtbdhpy993972hUqZSYLsE3iGziphYkOKVsqq38+VRH3TNg93zSLoRao\nJnTTkMXseVqiyqYRmFN8+gQQoEclHSGPUWQG5XMZ+hhuXeFyo+Yw/qbZWca/6/2I\n3rsca9jXR1alhxhHrXrg8N4Dm3gBgGbmiht6YYYT2Tyl1OqB9+iOI/9D7dfoCF6X\nAWJXRE454cmC8k8oucpjZVpflA+ocKshwPDR6YTLQYbXYiaWxEoaz0QGUErNQBnG\nI+sr9jDY3ua/s6HF6h0qyi/HVZH4wx+m4CtOfJoYTjrGBbaRszzUxhtSN2/MhXDu\n+a35q9/2zcu/3fjkkfVvGUt+NyyiYOKQ9vsJC1g/xxdUWtowjNwjfZE2zcG4usi8\nr38Bp0lmiipAsMLduZM/D5dFXkRdWCBNDfULmmg/4nv2wwjbjQuLemAMh7mmrztW\ni/85WMnjKQZT8NqS43pmgyIzg1gK1neMqdS90YmQ/PvJ36qALxCs245w1JpN9BAL\nJbwxCg/dbmKT7PalfWrksx9hGcJxtGqebldaOpw+5GVIPxxtC1C0gVr9BKeiDS3f\naibASY5pIRiKENmbZELDtucCAwEAAQ==\n-----END PUBLIC KEY-----"}]}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client (May 16 13:55:56.648)","description":"This is just a test client.","client_id":"clpeL3VYKkKq8neIWJIvgc6ZDSoZ7MQ6","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_bxKDP6hq3SQusdvDkpH9CS","name":"Test Credential (May 16 13:55:56.648)","kid":"4e7yYf0TKdyTLbVnpq2wLN6mZ8t7eb9UJkMksyHj9iU","credential_type":"public_key","alg":"RS256","created_at":"2025-05-16T11:55:56.964Z","updated_at":"2025-05-16T11:55:56.964Z"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 378.8255ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 118
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Auth0-Connection-1747396557","strategy":"auth0","enabled_clients":["clpeL3VYKkKq8neIWJIvgc6ZDSoZ7MQ6"]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 554
+        uncompressed: false
+        body: '{"id":"con_5RT9Nayx5Lo924bI","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Test-Auth0-Connection-1747396557","is_domain_connection":false,"enabled_clients":["clpeL3VYKkKq8neIWJIvgc6ZDSoZ7MQ6"],"realms":["Test-Auth0-Connection-1747396557"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 121.676ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 66
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            [{"client_id":"clpeL3VYKkKq8neIWJIvgc6ZDSoZ7MQ6","status":false}]
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_5RT9Nayx5Lo924bI/clients
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 128.24725ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_5RT9Nayx5Lo924bI
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_5RT9Nayx5Lo924bI","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Test-Auth0-Connection-1747396557","is_domain_connection":false,"enabled_clients":[],"realms":["Test-Auth0-Connection-1747396557"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 86.7435ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_5RT9Nayx5Lo924bI
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2025-05-16T11:55:57.465Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 88.566042ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.18.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/clpeL3VYKkKq8neIWJIvgc6ZDSoZ7MQ6
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 158.560667ms


### PR DESCRIPTION
### 🔧 Changes

* Added `ReadEnabledClients` and `UpdateEnabledClients` methods to manage clients enabled on a connection.
* Deprecated the `EnabledClients` field in the `Connection` struct in favor of these explicit methods.

Refer to:

* [Update enabled clients on a connection (PATCH)](https://auth0.com/docs/api/management/v2/connections/patch-clients)
* [Read enabled clients on a connection (GET)](https://auth0.com/docs/api/management/v2/connections/get-connection-clients)

### 📚 References

* Auth0 Management API documentation on connection clients

### 🔬 Testing

* Created a client
* Created a connection
* Assigned the client to the connection using the new Go methods
* Verified the assignment in the Auth0 UI

### 📝 Checklist

* [x] All new/changed/fixed functionality is covered by tests (or N/A)
* [x] Documentation for new/changed functionality has been added (or N/A)
