### PR TITLE
Add `AllowRefreshToken` support to `SessionTransfer`  in `ClientManager`

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -378,6 +378,7 @@ type SessionTransfer struct {
 	CanCreateSessionTransferToken *bool     `json:"can_create_session_transfer_token,omitempty"`
 	AllowedAuthenticationMethods  *[]string `json:"allowed_authentication_methods,omitempty"`
 	EnforceDeviceBinding          *string   `json:"enforce_device_binding,omitempty"`
+	AllowRefreshToken 			  *bool     `json:"allow_refresh_token,omitempty"`
 }
 
 // ClientAddons defines the `addons` settings for a Client.

--- a/management/client.go
+++ b/management/client.go
@@ -378,7 +378,7 @@ type SessionTransfer struct {
 	CanCreateSessionTransferToken *bool     `json:"can_create_session_transfer_token,omitempty"`
 	AllowedAuthenticationMethods  *[]string `json:"allowed_authentication_methods,omitempty"`
 	EnforceDeviceBinding          *string   `json:"enforce_device_binding,omitempty"`
-	AllowRefreshToken 			  *bool     `json:"allow_refresh_token,omitempty"`
+	AllowRefreshToken             *bool     `json:"allow_refresh_token,omitempty"`
 }
 
 // ClientAddons defines the `addons` settings for a Client.

--- a/management/client_test.go
+++ b/management/client_test.go
@@ -121,6 +121,7 @@ func TestClient_SessionTransfer(t *testing.T) {
 			CanCreateSessionTransferToken: auth0.Bool(true),
 			AllowedAuthenticationMethods:  &[]string{"cookie", "query"},
 			EnforceDeviceBinding:          auth0.String("ip"),
+			AllowRefreshToken:             auth0.Bool(true),
 		},
 	}
 
@@ -143,6 +144,7 @@ func TestClient_SessionTransfer(t *testing.T) {
 		CanCreateSessionTransferToken: auth0.Bool(false),
 		AllowedAuthenticationMethods:  &[]string{"cookie"},
 		EnforceDeviceBinding:          auth0.String("none"),
+		AllowRefreshToken:             auth0.Bool(false), 
 	}
 
 	// Strip fields not allowed on update

--- a/management/client_test.go
+++ b/management/client_test.go
@@ -144,7 +144,7 @@ func TestClient_SessionTransfer(t *testing.T) {
 		CanCreateSessionTransferToken: auth0.Bool(false),
 		AllowedAuthenticationMethods:  &[]string{"cookie"},
 		EnforceDeviceBinding:          auth0.String("none"),
-		AllowRefreshToken:             auth0.Bool(false), 
+		AllowRefreshToken:             auth0.Bool(false),
 	}
 
 	// Strip fields not allowed on update

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -11458,6 +11458,14 @@ func (s *SessionTransfer) GetAllowedAuthenticationMethods() []string {
 	return *s.AllowedAuthenticationMethods
 }
 
+// GetAllowRefreshToken returns the AllowRefreshToken field if it's non-nil, zero value otherwise.
+func (s *SessionTransfer) GetAllowRefreshToken() bool {
+	if s == nil || s.AllowRefreshToken == nil {
+		return false
+	}
+	return *s.AllowRefreshToken
+}
+
 // GetCanCreateSessionTransferToken returns the CanCreateSessionTransferToken field if it's non-nil, zero value otherwise.
 func (s *SessionTransfer) GetCanCreateSessionTransferToken() bool {
 	if s == nil || s.CanCreateSessionTransferToken == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -14399,6 +14399,16 @@ func TestSessionTransfer_GetAllowedAuthenticationMethods(tt *testing.T) {
 	s.GetAllowedAuthenticationMethods()
 }
 
+func TestSessionTransfer_GetAllowRefreshToken(tt *testing.T) {
+	var zeroValue bool
+	s := &SessionTransfer{AllowRefreshToken: &zeroValue}
+	s.GetAllowRefreshToken()
+	s = &SessionTransfer{}
+	s.GetAllowRefreshToken()
+	s = nil
+	s.GetAllowRefreshToken()
+}
+
 func TestSessionTransfer_GetCanCreateSessionTransferToken(tt *testing.T) {
 	var zeroValue bool
 	s := &SessionTransfer{CanCreateSessionTransferToken: &zeroValue}

--- a/test/data/recordings/TestClient_SessionTransfer.yaml
+++ b/test/data/recordings/TestClient_SessionTransfer.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 266
+        content_length: 293
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test Client SessionTransfer (Apr  4 17:47:46.709)","description":"This is a test client with Session Transfer.","session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"ip"}}
+            {"name":"Test Client SessionTransfer (May 19 17:21:18.342)","description":"This is a test client with Session Transfer.","session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"ip","allow_refresh_token":true}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.19.0
+                - Go-Auth0/1.20.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"name":"Test Client SessionTransfer (Apr  4 17:47:46.709)","description":"This is a test client with Session Transfer.","client_id":"OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"ip"}}'
+        body: '{"name":"Test Client SessionTransfer (May 19 17:21:18.342)","description":"This is a test client with Session Transfer.","client_id":"TklkDMWFH2whsuA43utENnXx32jbbjn2","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"ip","allow_refresh_token":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 1.277893167s
+        duration: 1.067644792s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -54,8 +54,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.19.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/TklkDMWFH2whsuA43utENnXx32jbbjn2
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,33 +65,33 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Test Client SessionTransfer (Apr  4 17:47:46.709)","description":"This is a test client with Session Transfer.","client_id":"OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"ip"}}'
+        body: '{"name":"Test Client SessionTransfer (May 19 17:21:18.342)","description":"This is a test client with Session Transfer.","client_id":"TklkDMWFH2whsuA43utENnXx32jbbjn2","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"ip","allow_refresh_token":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 408.076584ms
+        duration: 370.757417ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 869
+        content_length: 897
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test Client SessionTransfer (Apr  4 17:47:46.709)","description":"This is a test client with Session Transfer.","client_secret":"nU6OoYdxwJdih9_bUFrlUwu8aV9IVPe9YRnzLx4BdnBobiwa6BU_tVU6zr4XG2ke","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"lifetime_in_seconds":36000},"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":["cookie"],"enforce_device_binding":"none"}}
+            {"name":"Test Client SessionTransfer (May 19 17:21:18.342)","description":"This is a test client with Session Transfer.","client_secret":"u7h9UINS26cs-nWD3oF2s6h_iBM19JS4KV2rET8SYU6Cg4MHKYprzsSC2F7AaKol","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"lifetime_in_seconds":36000},"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":["cookie"],"enforce_device_binding":"none","allow_refresh_token":false}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.19.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/TklkDMWFH2whsuA43utENnXx32jbbjn2
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -101,13 +101,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Test Client SessionTransfer (Apr  4 17:47:46.709)","description":"This is a test client with Session Transfer.","client_id":"OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":["cookie"],"enforce_device_binding":"none"}}'
+        body: '{"name":"Test Client SessionTransfer (May 19 17:21:18.342)","description":"This is a test client with Session Transfer.","client_id":"TklkDMWFH2whsuA43utENnXx32jbbjn2","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":["cookie"],"enforce_device_binding":"none","allow_refresh_token":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 323.896292ms
+        duration: 379.890292ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -125,8 +125,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.19.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/TklkDMWFH2whsuA43utENnXx32jbbjn2
         method: GET
       response:
         proto: HTTP/2.0
@@ -136,13 +136,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Test Client SessionTransfer (Apr  4 17:47:46.709)","description":"This is a test client with Session Transfer.","client_id":"OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":["cookie"],"enforce_device_binding":"none"}}'
+        body: '{"name":"Test Client SessionTransfer (May 19 17:21:18.342)","description":"This is a test client with Session Transfer.","client_id":"TklkDMWFH2whsuA43utENnXx32jbbjn2","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":["cookie"],"enforce_device_binding":"none","allow_refresh_token":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 377.560084ms
+        duration: 387.15225ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -161,8 +161,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.19.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/TklkDMWFH2whsuA43utENnXx32jbbjn2
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -172,13 +172,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Test Client SessionTransfer (Apr  4 17:47:46.709)","description":"This is a test client with Session Transfer.","client_id":"OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Test Client SessionTransfer (May 19 17:21:18.342)","description":"This is a test client with Session Transfer.","client_id":"TklkDMWFH2whsuA43utENnXx32jbbjn2","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 509.780208ms
+        duration: 362.19175ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -196,8 +196,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.19.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/TklkDMWFH2whsuA43utENnXx32jbbjn2
         method: GET
       response:
         proto: HTTP/2.0
@@ -207,13 +207,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Test Client SessionTransfer (Apr  4 17:47:46.709)","description":"This is a test client with Session Transfer.","client_id":"OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Test Client SessionTransfer (May 19 17:21:18.342)","description":"This is a test client with Session Transfer.","client_id":"TklkDMWFH2whsuA43utENnXx32jbbjn2","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 408.792541ms
+        duration: 347.7805ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -231,8 +231,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.19.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/OxXzYYz2YAt8rlydYDdiRLvxWShcpw8d
+                - Go-Auth0/1.20.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/TklkDMWFH2whsuA43utENnXx32jbbjn2
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -248,4 +248,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 404.96675ms
+        duration: 414.035542ms


### PR DESCRIPTION
### 🔧 Changes

- Added support for the new `allow_refresh_token` field in the Session Transfer configuration.
This field has also been included in the existing test cases.

### 📚 References

This feature was introduced in the latest version of Auth0.

### 🔬 Testing

Updated the existing test cases to cover the `allow_refresh_token` field.

### 📝 Checklist

* [x] All new/changed/fixed functionality is covered by tests (or N/A)
* [x] I have added documentation for all new/changed functionality (or N/A)

