### PR TITLE
Add Patch method and corresponding tests for Network ACL

### DIFF
--- a/management/network_acl.go
+++ b/management/network_acl.go
@@ -110,6 +110,11 @@ func (m *NetworkACLManager) Update(ctx context.Context, id string, n *NetworkACL
 	return m.management.Request(ctx, "PUT", m.management.URI("network-acls", id), n, opts...)
 }
 
+// Patch a Network ACL.
+func (m *NetworkACLManager) Patch(ctx context.Context, id string, n *NetworkACL, opts ...RequestOption) error {
+	return m.management.Request(ctx, "PATCH", m.management.URI("network-acls", id), n, opts...)
+}
+
 // Delete a Network ACL.
 func (m *NetworkACLManager) Delete(ctx context.Context, id string, opts ...RequestOption) (err error) {
 	return m.management.Request(ctx, "DELETE", m.management.URI("network-acls", id), nil, opts...)

--- a/management/network_acl_test.go
+++ b/management/network_acl_test.go
@@ -79,6 +79,24 @@ func TestNetworkACLManager_Update(t *testing.T) {
 	assert.Equal(t, networkACL, actualNetworkACL)
 }
 
+// TestNetworkACLManager_Patch tests the ability to patch a Network ACL.
+func TestNetworkACLManager_Patch(t *testing.T) {
+	configureHTTPTestRecordings(t)
+	networkACL := givenANetworkACL(t)
+
+	patch := &NetworkACL{
+		Description: auth0.String("patched-description"),
+		Priority:    auth0.Int(2),
+	}
+
+	err := api.NetworkACL.Patch(context.Background(), networkACL.GetID(), patch)
+	assert.NoError(t, err)
+
+	actualNetworkACL, err := api.NetworkACL.Read(context.Background(), networkACL.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, "patched-description", actualNetworkACL.GetDescription())
+	assert.Equal(t, 2, actualNetworkACL.GetPriority())
+}
 func TestNetworkACLManager_Delete(t *testing.T) {
 	configureHTTPTestRecordings(t)
 	networkACL := givenANetworkACL(t)

--- a/test/data/recordings/TestNetworkACLManager_Patch.yaml
+++ b/test/data/recordings/TestNetworkACLManager_Patch.yaml
@@ -1,0 +1,141 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 197
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"description":"some-description","active":true,"priority":1,"rule":{"action":{"redirect":true,"redirect_uri":"https://example.com"},"match":{"geo_country_codes":["US"]},"scope":"authentication"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.22.1
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/network-acls
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 310
+        uncompressed: false
+        body: '{"description":"some-description","active":true,"priority":1,"rule":{"match":{"geo_country_codes":["US"]},"scope":"authentication","action":{"redirect":true,"redirect_uri":"https://example.com"}},"created_at":"2025-06-10T04:57:21.081Z","updated_at":"2025-06-10T04:57:21.081Z","id":"acl_vWccXzbzVa86ryPTmgWCZi"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1.412902417s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 51
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"description":"patched-description","priority":2}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.22.1
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/network-acls/acl_vWccXzbzVa86ryPTmgWCZi
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"description":"patched-description","active":true,"priority":2,"rule":{"match":{"geo_country_codes":["US"]},"scope":"authentication","action":{"redirect":true,"redirect_uri":"https://example.com"}},"created_at":"2025-06-10T04:57:21.081Z","updated_at":"2025-06-10T04:57:21.490Z","id":"acl_vWccXzbzVa86ryPTmgWCZi"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 509.13925ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.22.1
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/network-acls/acl_vWccXzbzVa86ryPTmgWCZi
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"tenant_id":"go-auth0-dev.eu.auth0.com","description":"patched-description","active":true,"priority":2,"rule":{"match":{"geo_country_codes":["US"]},"scope":"authentication","action":{"redirect":true,"redirect_uri":"https://example.com"}},"created_at":"2025-06-10T04:57:21.081Z","updated_at":"2025-06-10T04:57:21.490Z","deleted_at":null,"id":"acl_vWccXzbzVa86ryPTmgWCZi"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 373.410458ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.22.1
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/network-acls/acl_vWccXzbzVa86ryPTmgWCZi
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 24
+        uncompressed: false
+        body: '{"code":204,"object":""}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 398.4605ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- Added `Patch` method to `NetworkACLManager` to support partial updates via the HTTP `PATCH` method.
- This method allows updating only a subset of fields in a Network ACL resource.
- The supported fields for partial updates include:
  - `description` (string)
  - `active` (boolean)
  - `priority` (number)
  - `rule` object:
    - `action`
    - `match`
    - `scope`

This improves efficiency by avoiding the need to send the entire object for minor changes.

### 📚 References

- Support PATCH-based partial updates to Network ACLs.
- Follows RESTful API conventions for partial modifications.

### 🔬 Testing

- Added unit tests to validate:
  - Successful partial updates using the `Patch` method.
  - Handling of invalid field values or unsupported fields.
- Verified end-to-end behavior with manual tests against a development instance.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
