### PR TITLE
docs: update comment to reflect DPoP support in `ResourceServerManager`

### DIFF
--- a/management/resource_server.go
+++ b/management/resource_server.go
@@ -126,6 +126,7 @@ type ResourceServerProofOfPossession struct {
 	//
 	// Available options:
 	//   - "mtls"
+	//   - "dpop"
 	Mechanism *string `json:"mechanism,omitempty"`
 
 	// Whether the use of Proof-of-Possession is required for the resource server.


### PR DESCRIPTION

<!--  
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.  

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.  
-->

### 🔧 Changes

This PR updates the documentation comment for the `ResourceServerProofOfPossession` struct within the `ResourceServerManager`, clarifying support for the `dpop` (Demonstration of Proof-of-Possession) mechanism.

* Updated comment on the `Mechanism` field to include `"dpop"` as a valid option.
* Improves clarity and discoverability for developers implementing DPoP support via this SDK.

### 📚 References


### 🔬 Testing

* Documentation-only change; no functional code was modified.
* No testing required.

### 📝 Checklist

* [ ] All new/changed/fixed functionality is covered by tests (or N/A)
* [x] I have added documentation for all new/changed functionality (or N/A)

