### PR TITLE
feat(prompt): add Filters and UsePageTemplate support to PromptRendering

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -10024,6 +10024,14 @@ func (p *PromptRendering) GetDefaultHeadTagsDisabled() bool {
 	return *p.DefaultHeadTagsDisabled
 }
 
+// GetFilters returns the Filters field.
+func (p *PromptRendering) GetFilters() *PromptRenderingFilters {
+	if p == nil {
+		return nil
+	}
+	return p.Filters
+}
+
 // GetPrompt returns the Prompt field.
 func (p *PromptRendering) GetPrompt() *PromptType {
 	if p == nil {
@@ -10056,8 +10064,74 @@ func (p *PromptRendering) GetTenant() string {
 	return *p.Tenant
 }
 
+// GetUsePageTemplate returns the UsePageTemplate field if it's non-nil, zero value otherwise.
+func (p *PromptRendering) GetUsePageTemplate() bool {
+	if p == nil || p.UsePageTemplate == nil {
+		return false
+	}
+	return *p.UsePageTemplate
+}
+
 // String returns a string representation of PromptRendering.
 func (p *PromptRendering) String() string {
+	return Stringify(p)
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (p *PromptRenderingFilter) GetID() string {
+	if p == nil || p.ID == nil {
+		return ""
+	}
+	return *p.ID
+}
+
+// GetMetadata returns the Metadata field if it's non-nil, zero value otherwise.
+func (p *PromptRenderingFilter) GetMetadata() map[string]interface{} {
+	if p == nil || p.Metadata == nil {
+		return map[string]interface{}{}
+	}
+	return *p.Metadata
+}
+
+// String returns a string representation of PromptRenderingFilter.
+func (p *PromptRenderingFilter) String() string {
+	return Stringify(p)
+}
+
+// GetClients returns the Clients field if it's non-nil, zero value otherwise.
+func (p *PromptRenderingFilters) GetClients() []PromptRenderingFilter {
+	if p == nil || p.Clients == nil {
+		return nil
+	}
+	return *p.Clients
+}
+
+// GetDomains returns the Domains field if it's non-nil, zero value otherwise.
+func (p *PromptRenderingFilters) GetDomains() []PromptRenderingFilter {
+	if p == nil || p.Domains == nil {
+		return nil
+	}
+	return *p.Domains
+}
+
+// GetMatchType returns the MatchType field if it's non-nil, zero value otherwise.
+func (p *PromptRenderingFilters) GetMatchType() string {
+	if p == nil || p.MatchType == nil {
+		return ""
+	}
+	return *p.MatchType
+}
+
+// GetOrganizations returns the Organizations field if it's non-nil, zero value otherwise.
+func (p *PromptRenderingFilters) GetOrganizations() []PromptRenderingFilter {
+	if p == nil || p.Organizations == nil {
+		return nil
+	}
+	return *p.Organizations
+}
+
+// String returns a string representation of PromptRenderingFilters.
+func (p *PromptRenderingFilters) String() string {
 	return Stringify(p)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -12572,6 +12572,13 @@ func TestPromptRendering_GetDefaultHeadTagsDisabled(tt *testing.T) {
 	p.GetDefaultHeadTagsDisabled()
 }
 
+func TestPromptRendering_GetFilters(tt *testing.T) {
+	p := &PromptRendering{}
+	p.GetFilters()
+	p = nil
+	p.GetFilters()
+}
+
 func TestPromptRendering_GetPrompt(tt *testing.T) {
 	p := &PromptRendering{}
 	p.GetPrompt()
@@ -12603,9 +12610,95 @@ func TestPromptRendering_GetTenant(tt *testing.T) {
 	p.GetTenant()
 }
 
+func TestPromptRendering_GetUsePageTemplate(tt *testing.T) {
+	var zeroValue bool
+	p := &PromptRendering{UsePageTemplate: &zeroValue}
+	p.GetUsePageTemplate()
+	p = &PromptRendering{}
+	p.GetUsePageTemplate()
+	p = nil
+	p.GetUsePageTemplate()
+}
+
 func TestPromptRendering_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &PromptRendering{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestPromptRenderingFilter_GetID(tt *testing.T) {
+	var zeroValue string
+	p := &PromptRenderingFilter{ID: &zeroValue}
+	p.GetID()
+	p = &PromptRenderingFilter{}
+	p.GetID()
+	p = nil
+	p.GetID()
+}
+
+func TestPromptRenderingFilter_GetMetadata(tt *testing.T) {
+	var zeroValue map[string]interface{}
+	p := &PromptRenderingFilter{Metadata: &zeroValue}
+	p.GetMetadata()
+	p = &PromptRenderingFilter{}
+	p.GetMetadata()
+	p = nil
+	p.GetMetadata()
+}
+
+func TestPromptRenderingFilter_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &PromptRenderingFilter{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestPromptRenderingFilters_GetClients(tt *testing.T) {
+	var zeroValue []PromptRenderingFilter
+	p := &PromptRenderingFilters{Clients: &zeroValue}
+	p.GetClients()
+	p = &PromptRenderingFilters{}
+	p.GetClients()
+	p = nil
+	p.GetClients()
+}
+
+func TestPromptRenderingFilters_GetDomains(tt *testing.T) {
+	var zeroValue []PromptRenderingFilter
+	p := &PromptRenderingFilters{Domains: &zeroValue}
+	p.GetDomains()
+	p = &PromptRenderingFilters{}
+	p.GetDomains()
+	p = nil
+	p.GetDomains()
+}
+
+func TestPromptRenderingFilters_GetMatchType(tt *testing.T) {
+	var zeroValue string
+	p := &PromptRenderingFilters{MatchType: &zeroValue}
+	p.GetMatchType()
+	p = &PromptRenderingFilters{}
+	p.GetMatchType()
+	p = nil
+	p.GetMatchType()
+}
+
+func TestPromptRenderingFilters_GetOrganizations(tt *testing.T) {
+	var zeroValue []PromptRenderingFilter
+	p := &PromptRenderingFilters{Organizations: &zeroValue}
+	p.GetOrganizations()
+	p = &PromptRenderingFilters{}
+	p.GetOrganizations()
+	p = nil
+	p.GetOrganizations()
+}
+
+func TestPromptRenderingFilters_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &PromptRenderingFilters{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/management/prompt.go
+++ b/management/prompt.go
@@ -469,6 +469,30 @@ type PromptRendering struct {
 	ContextConfiguration    *[]string      `json:"context_configuration,omitempty"`
 	DefaultHeadTagsDisabled *bool          `json:"default_head_tags_disabled,omitempty"`
 	HeadTags                []interface{}  `json:"head_tags,omitempty"`
+	// Filters are optional filters to apply rendering rules to specific entities.
+	Filters *PromptRenderingFilters `json:"filters,omitempty"`
+	// UsePageTemplate indicates whether to use the page template with ACUL.
+	UsePageTemplate *bool `json:"use_page_template,omitempty"`
+}
+
+// PromptRenderingFilters is used to filter rendering rules based on specific entities.
+type PromptRenderingFilters struct {
+	// MatchType defines the type of match to apply.
+	MatchType *string `json:"match_type,omitempty"`
+	// Clients is a list of client filters.
+	Clients *[]PromptRenderingFilter `json:"clients,omitempty"`
+	// Organizations is a list of organization filters.
+	Organizations *[]PromptRenderingFilter `json:"organizations,omitempty"`
+	// Domains is a list of domain filters.
+	Domains *[]PromptRenderingFilter `json:"domains,omitempty"`
+}
+
+// PromptRenderingFilter is used to filter rendering rules based on specific entities.
+type PromptRenderingFilter struct {
+	// ID is the identifier of the entity.
+	ID *string `json:"id,omitempty"`
+	// Metadata is the metadata associated with the entity.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // PromptRenderingList is a list of prompt rendering settings.
@@ -480,10 +504,12 @@ type PromptRenderingList struct {
 // MarshalJSON implements a custom [json.Marshaler].
 func (c *PromptRendering) MarshalJSON() ([]byte, error) {
 	type RenderingSubSet struct {
-		RenderingMode           *RenderingMode `json:"rendering_mode,omitempty"`
-		ContextConfiguration    *[]string      `json:"context_configuration,omitempty"`
-		DefaultHeadTagsDisabled *bool          `json:"default_head_tags_disabled,omitempty"`
-		HeadTags                []interface{}  `json:"head_tags,omitempty"`
+		RenderingMode           *RenderingMode          `json:"rendering_mode,omitempty"`
+		ContextConfiguration    *[]string               `json:"context_configuration,omitempty"`
+		DefaultHeadTagsDisabled *bool                   `json:"default_head_tags_disabled,omitempty"`
+		HeadTags                []interface{}           `json:"head_tags,omitempty"`
+		Filters                 *PromptRenderingFilters `json:"filters,omitempty"`
+		UsePageTemplate         *bool                   `json:"use_page_template,omitempty"`
 	}
 
 	return json.Marshal(&RenderingSubSet{
@@ -491,6 +517,8 @@ func (c *PromptRendering) MarshalJSON() ([]byte, error) {
 		ContextConfiguration:    c.ContextConfiguration,
 		DefaultHeadTagsDisabled: c.DefaultHeadTagsDisabled,
 		HeadTags:                c.HeadTags,
+		Filters:                 c.Filters,
+		UsePageTemplate:         c.UsePageTemplate,
 	})
 }
 

--- a/test/data/recordings/TestPromptManager_ListRendering.yaml
+++ b/test/data/recordings/TestPromptManager_ListRendering.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 98
+        content_length: 95
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1747220381.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1751011709.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.20.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains
         method: POST
       response:
@@ -28,15 +28,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 339
+        content_length: 407
         uncompressed: false
-        body: '{"custom_domain_id":"cd_i4mVcdyPwpPCzUD3","domain":"1747220381.tempdomain.com","primary":false,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-i4mvcdypwppczud3.edge.tenants.us.auth0.com","domain":"1747220381.tempdomain.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_hv7NGPLTPFhPcF6l","domain":"1751011709.tempdomain.com","primary":false,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-hv7ngpltpfhpcf6l.edge.tenants.test-aws-tenacious-guppy-1564.auth0c.com","domain":"1751011709.tempdomain.com"}]},"tls_policy":"recommended","created_at":"2025-06-27T08:08:30.242Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 981.391125ms
+        duration: 636.94725ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,7 +55,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.20.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
         method: PUT
       response:
@@ -72,26 +72,62 @@ interactions:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 637.245667ms
+        duration: 368.363666ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 408
+        content_length: 1125
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}]}
+            {"name":"Test Client (Jun 27 13:38:30.681)","description":"This is just a test client.","jwt_configuration":{"alg":"RS256"},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"name":"Test Credential (Jun 27 13:38:30.681)","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAua6LXMfgDE/tDdkOL1Oe\n3oWUwg1r4dSTg9L7RCcI5hItUzmkVofHtWN0H4CH2lm2ANmaJUsnhzctYowYW2+R\ntHvU9afTmtbdhpy993972hUqZSYLsE3iGziphYkOKVsqq38+VRH3TNg93zSLoRao\nJnTTkMXseVqiyqYRmFN8+gQQoEclHSGPUWQG5XMZ+hhuXeFyo+Yw/qbZWca/6/2I\n3rsca9jXR1alhxhHrXrg8N4Dm3gBgGbmiht6YYYT2Tyl1OqB9+iOI/9D7dfoCF6X\nAWJXRE454cmC8k8oucpjZVpflA+ocKshwPDR6YTLQYbXYiaWxEoaz0QGUErNQBnG\nI+sr9jDY3ua/s6HF6h0qyi/HVZH4wx+m4CtOfJoYTjrGBbaRszzUxhtSN2/MhXDu\n+a35q9/2zcu/3fjkkfVvGUt+NyyiYOKQ9vsJC1g/xxdUWtowjNwjfZE2zcG4usi8\nr38Bp0lmiipAsMLduZM/D5dFXkRdWCBNDfULmmg/4nv2wwjbjQuLemAMh7mmrztW\ni/85WMnjKQZT8NqS43pmgyIzg1gK1neMqdS90YmQ/PvJ36qALxCs245w1JpN9BAL\nJbwxCg/dbmKT7PalfWrksx9hGcJxtGqebldaOpw+5GVIPxxtC1C0gVr9BKeiDS3f\naibASY5pIRiKENmbZELDtucCAwEAAQ==\n-----END PUBLIC KEY-----"}]}}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.20.0
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client (Jun 27 13:38:30.681)","description":"This is just a test client.","client_id":"SPOw9QzF554tNbQP7i3EZKgRSjgLnw0B","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qNcyweraXctqzUca31hVpx","name":"Test Credential (Jun 27 13:38:30.681)","kid":"4e7yYf0TKdyTLbVnpq2wLN6mZ8t7eb9UJkMksyHj9iU","credential_type":"public_key","alg":"RS256","created_at":"2025-06-27T08:08:30.977Z","updated_at":"2025-06-27T08:08:30.977Z"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 437.773209ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 556
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}],"filters":{"match_type":"includes_any","clients":[{"id":"SPOw9QzF554tNbQP7i3EZKgRSjgLnw0B","metadata":{"key1":"value1"}}]},"use_page_template":true}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
         method: PATCH
       response:
@@ -102,48 +138,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}]}'
+        body: '{"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}],"filters":{"match_type":"includes_any","clients":[{"id":"SPOw9QzF554tNbQP7i3EZKgRSjgLnw0B","metadata":{"key1":"value1"}}]},"use_page_template":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 455.612792ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: go-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.20.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/rendering?include_totals=true&per_page=50
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"configs":[{"prompt":"signup","screen":"signup","rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"tag":"script","content":"","attributes":{"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js","async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="]}}],"filters":null}],"start":0,"limit":50,"total":1}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 370.402167ms
+        duration: 332.258583ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -158,10 +159,74 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.20.0
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/rendering?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"configs":[{"prompt":"signup","screen":"signup","rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"tag":"script","content":"","attributes":{"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js","async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="]}}],"filters":{"clients":[{"id":"SPOw9QzF554tNbQP7i3EZKgRSjgLnw0B","metadata":{"key1":"value1"}}],"match_type":"includes_any"},"use_page_template":true}],"start":0,"limit":50,"total":1}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 360.8385ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/SPOw9QzF554tNbQP7i3EZKgRSjgLnw0B
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 683.974042ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
         method: DELETE
       response:
@@ -178,8 +243,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 444.462459ms
-    - id: 5
+        duration: 338.899292ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -193,11 +258,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.20.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_i4mVcdyPwpPCzUD3
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_hv7NGPLTPFhPcF6l
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -213,4 +276,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 391.238541ms
+        duration: 510.367375ms

--- a/test/data/recordings/TestPromptManager_ReadRendering.yaml
+++ b/test/data/recordings/TestPromptManager_ReadRendering.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 93
+        content_length: 95
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1730881029.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1751011704.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains
         method: POST
       response:
@@ -28,15 +28,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 328
+        content_length: 407
         uncompressed: false
-        body: '{"custom_domain_id":"cd_7SgKHnrmHQNuTXEs","domain":"1730881029.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-7sgkhnrmhqnutxes.edge.tenants.us.auth0.com","domain":"1730881029.tempdomain.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_n8r2obkZmwfbWMds","domain":"1751011704.tempdomain.com","primary":false,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-n8r2obkzmwfbwmds.edge.tenants.test-aws-tenacious-guppy-1564.auth0c.com","domain":"1751011704.tempdomain.com"}]},"tls_policy":"recommended","created_at":"2025-06-27T08:08:26.265Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 923.825708ms
+        duration: 1.618713416s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,7 +55,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
         method: PUT
       response:
@@ -72,26 +72,62 @@ interactions:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 2.783568542s
+        duration: 727.637917ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 408
+        content_length: 1125
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}]}
+            {"name":"Test Client (Jun 27 13:38:27.060)","description":"This is just a test client.","jwt_configuration":{"alg":"RS256"},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"name":"Test Credential (Jun 27 13:38:27.060)","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAua6LXMfgDE/tDdkOL1Oe\n3oWUwg1r4dSTg9L7RCcI5hItUzmkVofHtWN0H4CH2lm2ANmaJUsnhzctYowYW2+R\ntHvU9afTmtbdhpy993972hUqZSYLsE3iGziphYkOKVsqq38+VRH3TNg93zSLoRao\nJnTTkMXseVqiyqYRmFN8+gQQoEclHSGPUWQG5XMZ+hhuXeFyo+Yw/qbZWca/6/2I\n3rsca9jXR1alhxhHrXrg8N4Dm3gBgGbmiht6YYYT2Tyl1OqB9+iOI/9D7dfoCF6X\nAWJXRE454cmC8k8oucpjZVpflA+ocKshwPDR6YTLQYbXYiaWxEoaz0QGUErNQBnG\nI+sr9jDY3ua/s6HF6h0qyi/HVZH4wx+m4CtOfJoYTjrGBbaRszzUxhtSN2/MhXDu\n+a35q9/2zcu/3fjkkfVvGUt+NyyiYOKQ9vsJC1g/xxdUWtowjNwjfZE2zcG4usi8\nr38Bp0lmiipAsMLduZM/D5dFXkRdWCBNDfULmmg/4nv2wwjbjQuLemAMh7mmrztW\ni/85WMnjKQZT8NqS43pmgyIzg1gK1neMqdS90YmQ/PvJ36qALxCs245w1JpN9BAL\nJbwxCg/dbmKT7PalfWrksx9hGcJxtGqebldaOpw+5GVIPxxtC1C0gVr9BKeiDS3f\naibASY5pIRiKENmbZELDtucCAwEAAQ==\n-----END PUBLIC KEY-----"}]}}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client (Jun 27 13:38:27.060)","description":"This is just a test client.","client_id":"SeunfRe6p8EXxV6I0g9kMYdT1DxpfC38","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_1ub9qw8TNSQqNSgzw7K2Ym","name":"Test Credential (Jun 27 13:38:27.060)","kid":"4e7yYf0TKdyTLbVnpq2wLN6mZ8t7eb9UJkMksyHj9iU","credential_type":"public_key","alg":"RS256","created_at":"2025-06-27T08:08:27.404Z","updated_at":"2025-06-27T08:08:27.404Z"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 657.374042ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 556
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}],"filters":{"match_type":"includes_any","clients":[{"id":"SeunfRe6p8EXxV6I0g9kMYdT1DxpfC38","metadata":{"key1":"value1"}}]},"use_page_template":true}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
         method: PATCH
       response:
@@ -102,48 +138,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}]}'
+        body: '{"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}],"filters":{"match_type":"includes_any","clients":[{"id":"SeunfRe6p8EXxV6I0g9kMYdT1DxpfC38","metadata":{"key1":"value1"}}]},"use_page_template":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.701625ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: go-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.13.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"tenant":"go-auth0-dev.eu.auth0.com","prompt":"signup","screen":"signup","rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"tag":"script","content":"","attributes":{"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js","async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="]}}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 348.5575ms
+        duration: 335.474792ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -158,10 +159,74 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"tenant":"go-auth0-dev.eu.auth0.com","prompt":"signup","screen":"signup","rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"tag":"script","content":"","attributes":{"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js","async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="]}}],"filters":{"clients":[{"id":"SeunfRe6p8EXxV6I0g9kMYdT1DxpfC38","metadata":{"key1":"value1"}}],"match_type":"includes_any"},"use_page_template":true}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 315.528459ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/SeunfRe6p8EXxV6I0g9kMYdT1DxpfC38
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 452.216417ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
         method: DELETE
       response:
@@ -178,8 +243,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 433.247666ms
-    - id: 5
+        duration: 352.384166ms
+    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -193,11 +258,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_7SgKHnrmHQNuTXEs
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_n8r2obkZmwfbWMds
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -213,4 +276,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 383.460542ms
+        duration: 489.065125ms

--- a/test/data/recordings/TestPromptManager_UpdateRendering.yaml
+++ b/test/data/recordings/TestPromptManager_UpdateRendering.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 99
+        content_length: 95
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"domain":"1734698728.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1751011720.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains
         method: POST
       response:
@@ -28,15 +28,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 342
+        content_length: 407
         uncompressed: false
-        body: '{"custom_domain_id":"cd_hW5C18CQPXRsKpDz","domain":"1733383424.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-hw5c18cqpxrskpdz.edge.tenants.us.auth0.com","domain":"1733383424.tempdomain.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_5cRptX54JE2wp1up","domain":"1751011720.tempdomain.com","primary":false,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-5crptx54je2wp1up.edge.tenants.test-aws-tenacious-guppy-1564.auth0c.com","domain":"1751011720.tempdomain.com"}]},"tls_policy":"recommended","created_at":"2025-06-27T08:08:41.152Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 994.566333ms
+        duration: 466.868166ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,7 +55,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
         method: PUT
       response:
@@ -72,62 +72,62 @@ interactions:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 779.822584ms
+        duration: 447.577417ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 30
+        content_length: 1125
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"rendering_mode":"standard"}
+            {"name":"Test Client (Jun 27 13:38:41.665)","description":"This is just a test client.","jwt_configuration":{"alg":"RS256"},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"name":"Test Credential (Jun 27 13:38:41.665)","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAua6LXMfgDE/tDdkOL1Oe\n3oWUwg1r4dSTg9L7RCcI5hItUzmkVofHtWN0H4CH2lm2ANmaJUsnhzctYowYW2+R\ntHvU9afTmtbdhpy993972hUqZSYLsE3iGziphYkOKVsqq38+VRH3TNg93zSLoRao\nJnTTkMXseVqiyqYRmFN8+gQQoEclHSGPUWQG5XMZ+hhuXeFyo+Yw/qbZWca/6/2I\n3rsca9jXR1alhxhHrXrg8N4Dm3gBgGbmiht6YYYT2Tyl1OqB9+iOI/9D7dfoCF6X\nAWJXRE454cmC8k8oucpjZVpflA+ocKshwPDR6YTLQYbXYiaWxEoaz0QGUErNQBnG\nI+sr9jDY3ua/s6HF6h0qyi/HVZH4wx+m4CtOfJoYTjrGBbaRszzUxhtSN2/MhXDu\n+a35q9/2zcu/3fjkkfVvGUt+NyyiYOKQ9vsJC1g/xxdUWtowjNwjfZE2zcG4usi8\nr38Bp0lmiipAsMLduZM/D5dFXkRdWCBNDfULmmg/4nv2wwjbjQuLemAMh7mmrztW\ni/85WMnjKQZT8NqS43pmgyIzg1gK1neMqdS90YmQ/PvJ36qALxCs245w1JpN9BAL\nJbwxCg/dbmKT7PalfWrksx9hGcJxtGqebldaOpw+5GVIPxxtC1C0gVr9BKeiDS3f\naibASY5pIRiKENmbZELDtucCAwEAAQ==\n-----END PUBLIC KEY-----"}]}}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
-        method: PATCH
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 29
+        content_length: -1
         uncompressed: false
-        body: '{"rendering_mode":"standard"}'
+        body: '{"name":"Test Client (Jun 27 13:38:41.665)","description":"This is just a test client.","client_id":"qkTxebDC5HUGmUiaSrwQNPD5f1Q0W8px","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_81RSkjyePwQkq79m1no27f","name":"Test Credential (Jun 27 13:38:41.665)","kid":"4e7yYf0TKdyTLbVnpq2wLN6mZ8t7eb9UJkMksyHj9iU","credential_type":"public_key","alg":"RS256","created_at":"2025-06-27T08:08:41.964Z","updated_at":"2025-06-27T08:08:41.964Z"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 454.494375ms
+        status: 201 Created
+        code: 201
+        duration: 565.593084ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 126
+        content_length: 556
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true}
+            {"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}],"filters":{"match_type":"includes_any","clients":[{"id":"qkTxebDC5HUGmUiaSrwQNPD5f1Q0W8px","metadata":{"key1":"value1"}}]},"use_page_template":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
         method: PATCH
       response:
@@ -138,33 +138,34 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true}'
+        body: '{"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}],"filters":{"match_type":"includes_any","clients":[{"id":"qkTxebDC5HUGmUiaSrwQNPD5f1Q0W8px","metadata":{"key1":"value1"}}]},"use_page_template":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 425.653542ms
+        duration: 647.619458ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 275
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: |
+            {"context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true,"filters":{"match_type":"excludes_any","clients":[{"id":"qkTxebDC5HUGmUiaSrwQNPD5f1Q0W8px","metadata":{"key2":"value2"}}]},"use_page_template":false}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
-        method: GET
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -173,13 +174,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant":"go-auth0-dev.eu.auth0.com","prompt":"signup","screen":"signup","rendering_mode":"standard","context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true,"head_tags":[{"tag":"script","content":"","attributes":{"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js","async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="]}}]}'
+        body: '{"context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true,"filters":{"match_type":"excludes_any","clients":[{"id":"qkTxebDC5HUGmUiaSrwQNPD5f1Q0W8px","metadata":{"key2":"value2"}}]},"use_page_template":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 476.536875ms
+        duration: 326.907291ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -194,10 +195,74 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"tenant":"go-auth0-dev.eu.auth0.com","prompt":"signup","screen":"signup","rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true,"head_tags":[{"tag":"script","content":"","attributes":{"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js","async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="]}}],"filters":{"clients":[{"id":"qkTxebDC5HUGmUiaSrwQNPD5f1Q0W8px","metadata":{"key2":"value2"}}],"match_type":"excludes_any"},"use_page_template":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 344.398791ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/qkTxebDC5HUGmUiaSrwQNPD5f1Q0W8px
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 443.196334ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
         method: DELETE
       response:
@@ -214,8 +279,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 699.654875ms
-    - id: 6
+        duration: 400.1235ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -229,11 +294,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_hW5C18CQPXRsKpDz
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_5cRptX54JE2wp1up
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -249,4 +312,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 411.741083ms
+        duration: 415.471792ms

--- a/test/data/recordings/TestPromptManager_UpdateRenderingWithAdvancedMode.yaml
+++ b/test/data/recordings/TestPromptManager_UpdateRenderingWithAdvancedMode.yaml
@@ -6,37 +6,37 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 99
-        transfer_encoding: [ ]
-        trailer: { }
+        content_length: 95
+        transfer_encoding: []
+        trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-          {"domain":"1734698728.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
-        form: { }
+            {"domain":"1751011713.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+        form: {}
         headers:
-          Content-Type:
-            - application/json
-          User-Agent:
-            - Go-Auth0/1.13.0
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: [ ]
-        trailer: { }
-        content_length: 342
+        transfer_encoding: []
+        trailer: {}
+        content_length: 407
         uncompressed: false
-        body: '{"custom_domain_id":"cd_hW5C18CQPXRsKpDz","domain":"1733383424.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-hw5c18cqpxrskpdz.edge.tenants.us.auth0.com","domain":"1733383424.tempdomain.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_febFvQyr3N1Jxfz0","domain":"1751011713.tempdomain.com","primary":false,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-febfvqyr3n1jxfz0.edge.tenants.test-aws-tenacious-guppy-1564.auth0c.com","domain":"1751011713.tempdomain.com"}]},"tls_policy":"recommended","created_at":"2025-06-27T08:08:33.838Z"}'
         headers:
-          Content-Type:
-            - application/json; charset=utf-8
+            Content-Type:
+                - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 994.566333ms
+        duration: 604.648167ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,7 +55,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
         method: PUT
       response:
@@ -72,62 +72,62 @@ interactions:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 2.757435792s
+        duration: 395.460875ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 30
+        content_length: 1125
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"rendering_mode":"standard"}
+            {"name":"Test Client (Jun 27 13:38:34.360)","description":"This is just a test client.","jwt_configuration":{"alg":"RS256"},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"name":"Test Credential (Jun 27 13:38:34.360)","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAua6LXMfgDE/tDdkOL1Oe\n3oWUwg1r4dSTg9L7RCcI5hItUzmkVofHtWN0H4CH2lm2ANmaJUsnhzctYowYW2+R\ntHvU9afTmtbdhpy993972hUqZSYLsE3iGziphYkOKVsqq38+VRH3TNg93zSLoRao\nJnTTkMXseVqiyqYRmFN8+gQQoEclHSGPUWQG5XMZ+hhuXeFyo+Yw/qbZWca/6/2I\n3rsca9jXR1alhxhHrXrg8N4Dm3gBgGbmiht6YYYT2Tyl1OqB9+iOI/9D7dfoCF6X\nAWJXRE454cmC8k8oucpjZVpflA+ocKshwPDR6YTLQYbXYiaWxEoaz0QGUErNQBnG\nI+sr9jDY3ua/s6HF6h0qyi/HVZH4wx+m4CtOfJoYTjrGBbaRszzUxhtSN2/MhXDu\n+a35q9/2zcu/3fjkkfVvGUt+NyyiYOKQ9vsJC1g/xxdUWtowjNwjfZE2zcG4usi8\nr38Bp0lmiipAsMLduZM/D5dFXkRdWCBNDfULmmg/4nv2wwjbjQuLemAMh7mmrztW\ni/85WMnjKQZT8NqS43pmgyIzg1gK1neMqdS90YmQ/PvJ36qALxCs245w1JpN9BAL\nJbwxCg/dbmKT7PalfWrksx9hGcJxtGqebldaOpw+5GVIPxxtC1C0gVr9BKeiDS3f\naibASY5pIRiKENmbZELDtucCAwEAAQ==\n-----END PUBLIC KEY-----"}]}}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
-        method: PATCH
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 29
+        content_length: -1
         uncompressed: false
-        body: '{"rendering_mode":"standard"}'
+        body: '{"name":"Test Client (Jun 27 13:38:34.360)","description":"This is just a test client.","client_id":"753twTkstH6aaBMqb63cyLx72pSfqWND","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_jZkKPW6aEDUWsZGCetLMYq","name":"Test Credential (Jun 27 13:38:34.360)","kid":"4e7yYf0TKdyTLbVnpq2wLN6mZ8t7eb9UJkMksyHj9iU","credential_type":"public_key","alg":"RS256","created_at":"2025-06-27T08:08:34.659Z","updated_at":"2025-06-27T08:08:34.659Z"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 909.9325ms
+        status: 201 Created
+        code: 201
+        duration: 487.623417ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 154
+        content_length: 556
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true}
+            {"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}],"filters":{"match_type":"includes_any","clients":[{"id":"753twTkstH6aaBMqb63cyLx72pSfqWND","metadata":{"key1":"value1"}}]},"use_page_template":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
         method: PATCH
       response:
@@ -138,33 +138,34 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true}'
+        body: '{"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}],"filters":{"match_type":"includes_any","clients":[{"id":"753twTkstH6aaBMqb63cyLx72pSfqWND","metadata":{"key1":"value1"}}]},"use_page_template":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 683.566875ms
+        duration: 367.547209ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 303
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: |
+            {"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true,"filters":{"match_type":"excludes_any","clients":[{"id":"753twTkstH6aaBMqb63cyLx72pSfqWND","metadata":{"key2":"value2"}}]},"use_page_template":false}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
-        method: GET
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -173,13 +174,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant":"go-auth0-dev.eu.auth0.com","prompt":"signup","screen":"signup","rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true,"head_tags":[{"tag":"script","content":"","attributes":{"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js","async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="]}}]}'
+        body: '{"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true,"filters":{"match_type":"excludes_any","clients":[{"id":"753twTkstH6aaBMqb63cyLx72pSfqWND","metadata":{"key2":"value2"}}]},"use_page_template":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 391.312833ms
+        duration: 350.218ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -194,10 +195,74 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"tenant":"go-auth0-dev.eu.auth0.com","prompt":"signup","screen":"signup","rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default","client.logo_uri"],"default_head_tags_disabled":true,"head_tags":[{"tag":"script","content":"","attributes":{"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js","async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="]}}],"filters":{"clients":[{"id":"753twTkstH6aaBMqb63cyLx72pSfqWND","metadata":{"key2":"value2"}}],"match_type":"excludes_any"},"use_page_template":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 311.432542ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/753twTkstH6aaBMqb63cyLx72pSfqWND
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 332.336416ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
         method: DELETE
       response:
@@ -214,39 +279,37 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 533.039666ms
-    - id: 6
+        duration: 358.609417ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         content_length: 0
-        transfer_encoding: [ ]
-        trailer: { }
+        transfer_encoding: []
+        trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: ""
-        form: { }
+        form: {}
         headers:
-          Content-Type:
-            - application/json
-          User-Agent:
-            - Go-Auth0/1.13.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_hW5C18CQPXRsKpDz
+            User-Agent:
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_febFvQyr3N1Jxfz0
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        transfer_encoding: [ ]
-        trailer: { }
+        transfer_encoding: []
+        trailer: {}
         content_length: 0
         uncompressed: false
         body: ""
         headers:
-          Content-Type:
-            - application/json; charset=utf-8
+            Content-Type:
+                - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 411.741083ms
+        duration: 465.445583ms

--- a/test/data/recordings/TestPromptManager_UpdateRenderingWithStandardMode.yaml
+++ b/test/data/recordings/TestPromptManager_UpdateRenderingWithStandardMode.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 99
+        content_length: 95
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-          {"domain":"1734698728.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
+            {"domain":"1751011717.tempdomain.com","type":"auth0_managed_certs","tls_policy":"recommended"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains
         method: POST
       response:
@@ -28,15 +28,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 169
+        content_length: 407
         uncompressed: false
-        body: '{"custom_domain_id":"cd_hW5C18CQPXRsKpDz","domain":"1733383424.tempdomain.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-hw5c18cqpxrskpdz.edge.tenants.us.auth0.com","domain":"1733383424.tempdomain.com"}]},"tls_policy":"recommended"}'
+        body: '{"custom_domain_id":"cd_0X4GuHy0daTVDp5D","domain":"1751011717.tempdomain.com","primary":false,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"CNAME","record":"go-auth0-dev.eu.auth0.com-cd-0x4guhy0datvdp5d.edge.tenants.test-aws-tenacious-guppy-1564.auth0c.com","domain":"1751011717.tempdomain.com"}]},"tls_policy":"recommended","created_at":"2025-06-27T08:08:37.521Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 994.566333ms
+        duration: 603.48325ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,7 +55,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
         method: PUT
       response:
@@ -72,26 +72,62 @@ interactions:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 1.247840334s
+        duration: 349.002667ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 408
+        content_length: 1125
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}]}
+            {"name":"Test Client (Jun 27 13:38:37.990)","description":"This is just a test client.","jwt_configuration":{"alg":"RS256"},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"name":"Test Credential (Jun 27 13:38:37.990)","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAua6LXMfgDE/tDdkOL1Oe\n3oWUwg1r4dSTg9L7RCcI5hItUzmkVofHtWN0H4CH2lm2ANmaJUsnhzctYowYW2+R\ntHvU9afTmtbdhpy993972hUqZSYLsE3iGziphYkOKVsqq38+VRH3TNg93zSLoRao\nJnTTkMXseVqiyqYRmFN8+gQQoEclHSGPUWQG5XMZ+hhuXeFyo+Yw/qbZWca/6/2I\n3rsca9jXR1alhxhHrXrg8N4Dm3gBgGbmiht6YYYT2Tyl1OqB9+iOI/9D7dfoCF6X\nAWJXRE454cmC8k8oucpjZVpflA+ocKshwPDR6YTLQYbXYiaWxEoaz0QGUErNQBnG\nI+sr9jDY3ua/s6HF6h0qyi/HVZH4wx+m4CtOfJoYTjrGBbaRszzUxhtSN2/MhXDu\n+a35q9/2zcu/3fjkkfVvGUt+NyyiYOKQ9vsJC1g/xxdUWtowjNwjfZE2zcG4usi8\nr38Bp0lmiipAsMLduZM/D5dFXkRdWCBNDfULmmg/4nv2wwjbjQuLemAMh7mmrztW\ni/85WMnjKQZT8NqS43pmgyIzg1gK1neMqdS90YmQ/PvJ36qALxCs245w1JpN9BAL\nJbwxCg/dbmKT7PalfWrksx9hGcJxtGqebldaOpw+5GVIPxxtC1C0gVr9BKeiDS3f\naibASY5pIRiKENmbZELDtucCAwEAAQ==\n-----END PUBLIC KEY-----"}]}}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client (Jun 27 13:38:37.990)","description":"This is just a test client.","client_id":"7P1L3CLCmVOFrICFdfz2E3hqY4nsEtSj","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_tiESjt1SChwF5b1arzWcKT","name":"Test Credential (Jun 27 13:38:37.990)","kid":"4e7yYf0TKdyTLbVnpq2wLN6mZ8t7eb9UJkMksyHj9iU","credential_type":"public_key","alg":"RS256","created_at":"2025-06-27T08:08:38.261Z","updated_at":"2025-06-27T08:08:38.261Z"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 686.633792ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 556
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}],"filters":{"match_type":"includes_any","clients":[{"id":"7P1L3CLCmVOFrICFdfz2E3hqY4nsEtSj","metadata":{"key1":"value1"}}]},"use_page_template":true}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
         method: PATCH
       response:
@@ -102,14 +138,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}]}'
+        body: '{"rendering_mode":"advanced","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"attributes":{"async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="],"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"},"content":"","tag":"script"}],"filters":{"match_type":"includes_any","clients":[{"id":"7P1L3CLCmVOFrICFdfz2E3hqY4nsEtSj","metadata":{"key1":"value1"}}]},"use_page_template":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 894.029792ms
-    - id: 3
+        duration: 321.874167ms
+    - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -127,7 +163,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
         method: PATCH
       response:
@@ -144,42 +180,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 900.59625ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: go-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.13.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"tenant":"go-auth0-dev.eu.auth0.com","prompt":"signup","screen":"signup","rendering_mode":"standard","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"tag":"script","content":"","attributes":{"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js","async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="]}}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 952.041666ms
+        duration: 330.558125ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -194,10 +195,74 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/prompts/signup/screen/signup/rendering
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"tenant":"go-auth0-dev.eu.auth0.com","prompt":"signup","screen":"signup","rendering_mode":"standard","context_configuration":["branding.settings","branding.themes.default"],"default_head_tags_disabled":false,"head_tags":[{"tag":"script","content":"","attributes":{"src":"https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js","async":true,"defer":true,"integrity":["sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="]}}],"filters":{"clients":[{"id":"7P1L3CLCmVOFrICFdfz2E3hqY4nsEtSj","metadata":{"key1":"value1"}}],"match_type":"includes_any"},"use_page_template":true}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 327.602125ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/7P1L3CLCmVOFrICFdfz2E3hqY4nsEtSj
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 321.558041ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
         method: DELETE
       response:
@@ -214,8 +279,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 921.355709ms
-    - id: 6
+        duration: 350.337083ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -229,11 +294,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.13.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_hW5C18CQPXRsKpDz
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_0X4GuHy0daTVDp5D
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -249,4 +312,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 411.741083ms
+        duration: 413.724417ms


### PR DESCRIPTION

### 🔧 Changes

* Added support for `Filters` in the `PromptRendering` struct to enable applying rendering rules conditionally based on client ID, connection, etc. This is represented as an optional `*PromptRenderingFilters` field.
* Introduced `UsePageTemplate` as an optional `*bool` field in `PromptRendering` to control whether the ACUL-based page template is used.
* Updated relevant Go SDK types to reflect these changes.
* Added test coverage for the new fields in rendering logic and JSON marshaling.
* Included documentation and usage comments for both fields.

### 📚 References

* Supports ACUL configuration rendering enhancements

### 🔬 Testing

* Added unit tests to cover:

  * JSON serialization/deserialization of `Filters` and `UsePageTemplate`
  * Validation and conditional logic tied to these fields
* Verified compatibility with existing rendering payloads
* Manually tested the prompt configuration flow using these fields in development environment

### 📝 Checklist

* [x] All new/changed/fixed functionality is covered by tests
* [x] I have added documentation for all new/changed functionality
