### PR TITLE
feat(logstreams): Add PIIConfig to LogStream struct for PII masking upport

### DIFF
--- a/management/log_stream.go
+++ b/management/log_stream.go
@@ -52,6 +52,19 @@ type LogStream struct {
 
 	// Sink for validation.
 	Sink interface{} `json:"-"`
+
+	// PIIConfig is used to configure the PII handling for the log stream.
+	PIIConfig *LogStreamPiiConfig `json:"pii_config,omitempty"`
+}
+
+// LogStreamPiiConfig is used to configure the PII handling for the log stream.
+type LogStreamPiiConfig struct {
+	// LogFields is a list of fields that should be handled as PII.
+	LogFields *[]string `json:"log_fields,omitempty"`
+	// Method is the method to use for handling PII. Can be "mask" or "hash".
+	Method *string `json:"method,omitempty"`
+	// Algorithm is the algorithm to use for hashing PII. Can be "xxhash".
+	Algorithm *string `json:"algorithm,omitempty"`
 }
 
 // MarshalJSON is a custom serializer for the LogStream type.

--- a/management/log_stream_test.go
+++ b/management/log_stream_test.go
@@ -23,6 +23,13 @@ var logStreamTestCases = []logStreamTestCase{
 				AccountID: auth0.String("999999999999"),
 				Region:    auth0.String("us-west-2"),
 			},
+			PIIConfig: &LogStreamPiiConfig{
+				LogFields: &[]string{
+					"first_name",
+				},
+				Method:    auth0.String("mask"),
+				Algorithm: auth0.String("xxhash"),
+			},
 		},
 	},
 	// { // This test requires an active subscription.
@@ -49,6 +56,13 @@ var logStreamTestCases = []logStreamTestCase{
 				ContentFormat: auth0.String("JSONLINES"),
 				ContentType:   auth0.String("application/json"),
 			},
+			PIIConfig: &LogStreamPiiConfig{
+				LogFields: &[]string{
+					"first_name",
+				},
+				Method:    auth0.String("mask"),
+				Algorithm: auth0.String("xxhash"),
+			},
 		},
 	},
 	{
@@ -61,6 +75,13 @@ var logStreamTestCases = []logStreamTestCase{
 				APIKey: auth0.String("121233123455"),
 				Region: auth0.String("us"),
 			},
+			PIIConfig: &LogStreamPiiConfig{
+				LogFields: &[]string{
+					"first_name",
+				},
+				Method:    auth0.String("mask"),
+				Algorithm: auth0.String("xxhash"),
+			},
 		},
 	},
 	{
@@ -71,6 +92,13 @@ var logStreamTestCases = []logStreamTestCase{
 			IsPriority: auth0.Bool(true),
 			Sink: &LogStreamSinkSegment{
 				WriteKey: auth0.String("121233123455"),
+			},
+			PIIConfig: &LogStreamPiiConfig{
+				LogFields: &[]string{
+					"first_name",
+				},
+				Method:    auth0.String("mask"),
+				Algorithm: auth0.String("xxhash"),
 			},
 		},
 	},
@@ -86,6 +114,13 @@ var logStreamTestCases = []logStreamTestCase{
 				Secure: auth0.Bool(true),
 				Token:  auth0.String("12a34ab5-c6d7-8901-23ef-456b7c89d0c1"),
 			},
+			PIIConfig: &LogStreamPiiConfig{
+				LogFields: &[]string{
+					"first_name",
+				},
+				Method:    auth0.String("mask"),
+				Algorithm: auth0.String("xxhash"),
+			},
 		},
 	},
 	{
@@ -96,6 +131,13 @@ var logStreamTestCases = []logStreamTestCase{
 			IsPriority: auth0.Bool(true),
 			Sink: &LogStreamSinkSumo{
 				SourceAddress: auth0.String("https://example.com"),
+			},
+			PIIConfig: &LogStreamPiiConfig{
+				LogFields: &[]string{
+					"first_name",
+				},
+				Method:    auth0.String("mask"),
+				Algorithm: auth0.String("xxhash"),
 			},
 		},
 	},
@@ -110,6 +152,13 @@ var logStreamTestCases = []logStreamTestCase{
 				ProjectID:              auth0.String("123456789"),
 				ServiceAccountUsername: auth0.String("fake-account.123abc.mp-service-account"),
 				ServiceAccountPassword: auth0.String("8iwyKSzwV2brfakepassGGKhsZ3INozo"),
+			},
+			PIIConfig: &LogStreamPiiConfig{
+				LogFields: &[]string{
+					"first_name",
+				},
+				Method:    auth0.String("mask"),
+				Algorithm: auth0.String("xxhash"),
 			},
 		},
 	},

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -8581,6 +8581,14 @@ func (l *LogStream) GetName() string {
 	return *l.Name
 }
 
+// GetPIIConfig returns the PIIConfig field.
+func (l *LogStream) GetPIIConfig() *LogStreamPiiConfig {
+	if l == nil {
+		return nil
+	}
+	return l.PIIConfig
+}
+
 // GetStatus returns the Status field if it's non-nil, zero value otherwise.
 func (l *LogStream) GetStatus() string {
 	if l == nil || l.Status == nil {
@@ -8599,6 +8607,35 @@ func (l *LogStream) GetType() string {
 
 // String returns a string representation of LogStream.
 func (l *LogStream) String() string {
+	return Stringify(l)
+}
+
+// GetAlgorithm returns the Algorithm field if it's non-nil, zero value otherwise.
+func (l *LogStreamPiiConfig) GetAlgorithm() string {
+	if l == nil || l.Algorithm == nil {
+		return ""
+	}
+	return *l.Algorithm
+}
+
+// GetLogFields returns the LogFields field if it's non-nil, zero value otherwise.
+func (l *LogStreamPiiConfig) GetLogFields() []string {
+	if l == nil || l.LogFields == nil {
+		return nil
+	}
+	return *l.LogFields
+}
+
+// GetMethod returns the Method field if it's non-nil, zero value otherwise.
+func (l *LogStreamPiiConfig) GetMethod() string {
+	if l == nil || l.Method == nil {
+		return ""
+	}
+	return *l.Method
+}
+
+// String returns a string representation of LogStreamPiiConfig.
+func (l *LogStreamPiiConfig) String() string {
 	return Stringify(l)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -10702,6 +10702,13 @@ func TestLogStream_GetName(tt *testing.T) {
 	l.GetName()
 }
 
+func TestLogStream_GetPIIConfig(tt *testing.T) {
+	l := &LogStream{}
+	l.GetPIIConfig()
+	l = nil
+	l.GetPIIConfig()
+}
+
 func TestLogStream_GetStatus(tt *testing.T) {
 	var zeroValue string
 	l := &LogStream{Status: &zeroValue}
@@ -10725,6 +10732,44 @@ func TestLogStream_GetType(tt *testing.T) {
 func TestLogStream_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &LogStream{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestLogStreamPiiConfig_GetAlgorithm(tt *testing.T) {
+	var zeroValue string
+	l := &LogStreamPiiConfig{Algorithm: &zeroValue}
+	l.GetAlgorithm()
+	l = &LogStreamPiiConfig{}
+	l.GetAlgorithm()
+	l = nil
+	l.GetAlgorithm()
+}
+
+func TestLogStreamPiiConfig_GetLogFields(tt *testing.T) {
+	var zeroValue []string
+	l := &LogStreamPiiConfig{LogFields: &zeroValue}
+	l.GetLogFields()
+	l = &LogStreamPiiConfig{}
+	l.GetLogFields()
+	l = nil
+	l.GetLogFields()
+}
+
+func TestLogStreamPiiConfig_GetMethod(tt *testing.T) {
+	var zeroValue string
+	l := &LogStreamPiiConfig{Method: &zeroValue}
+	l.GetMethod()
+	l = &LogStreamPiiConfig{}
+	l.GetMethod()
+	l = nil
+	l.GetMethod()
+}
+
+func TestLogStreamPiiConfig_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &LogStreamPiiConfig{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_AmazonEventBridge_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_AmazonEventBridge_LogStream.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"eventbridge","isPriority":true,"sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2"}}
+            {"name":"Test-LogStream-1732609495","type":"eventbridge","isPriority":true,"sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002059","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-879cfb72-351f-4e66-82a7-2b570ce6e963/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000002059","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-879cfb72-351f-4e66-82a7-2b570ce6e963/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_DataDog_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_DataDog_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 133
+        content_length: 213
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"datadog","isPriority":true,"sink":{"datadogRegion":"us","datadogApiKey":"121233123455"}}
+            {"name":"Test-LogStream-1751988058","type":"datadog","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"datadogRegion":"us","datadogApiKey":"121233123455"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002061","name":"Test-LogStream-1732609495","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000026","name":"Test-LogStream-1751988058","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 417.121583ms
+        duration: 456.375416ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002061
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000026
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,4 +69,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 384.841708ms
+        duration: 453.16ms

--- a/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_HTTP_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_HTTP_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 252
+        content_length: 332
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"http","isPriority":false,"sink":{"httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs","httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad"}}
+            {"name":"Test-LogStream-1751988058","type":"http","isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs","httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002060","name":"Test-LogStream-1732609495","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"isPriority":false}'
+        body: '{"id":"lst_0000000000000025","name":"Test-LogStream-1751988058","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 440.237875ms
+        duration: 904.73775ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002060
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000025
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,4 +69,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 360.544ms
+        duration: 1.038240709s

--- a/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_Mixpanel_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_Mixpanel_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 279
+        content_length: 359
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"mixpanel","isPriority":false,"sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"8iwyKSzwV2brfakepassGGKhsZ3INozo"}}
+            {"name":"Test-LogStream-1751988058","type":"mixpanel","isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"8iwyKSzwV2brfakepassGGKhsZ3INozo"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002065","name":"Test-LogStream-1732609495","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"isPriority":false}'
+        body: '{"id":"lst_0000000000000030","name":"Test-LogStream-1751988058","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 378.886167ms
+        duration: 479.979917ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002065
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000030
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,4 +69,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 328.02275ms
+        duration: 410.444583ms

--- a/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_Segment_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_Segment_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 114
+        content_length: 194
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"segment","isPriority":true,"sink":{"segmentWriteKey":"121233123455"}}
+            {"name":"Test-LogStream-1751988058","type":"segment","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"segmentWriteKey":"121233123455"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002062","name":"Test-LogStream-1732609495","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000027","name":"Test-LogStream-1751988058","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 387.390583ms
+        duration: 484.579583ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002062
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000027
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,4 +69,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 461.028542ms
+        duration: 364.642875ms

--- a/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_Splunk_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_Splunk_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 206
+        content_length: 286
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"splunk","isPriority":true,"sink":{"splunkDomain":"demo.splunk.com","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkPort":"8080","splunkSecure":true}}
+            {"name":"Test-LogStream-1751988058","type":"splunk","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"splunkDomain":"demo.splunk.com","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkPort":"8080","splunkSecure":true}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002063","name":"Test-LogStream-1732609495","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000028","name":"Test-LogStream-1751988058","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 371.139291ms
+        duration: 415.785583ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002063
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000028
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,4 +69,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 391.289791ms
+        duration: 1.031882292s

--- a/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_Sumo_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Create/It_can_successfully_create_a_Sumo_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 120
+        content_length: 200
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"sumo","isPriority":true,"sink":{"sumoSourceAddress":"https://example.com"}}
+            {"name":"Test-LogStream-1751988058","type":"sumo","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"sumoSourceAddress":"https://example.com"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002064","name":"Test-LogStream-1732609495","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000029","name":"Test-LogStream-1751988058","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.469416ms
+        duration: 378.886ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002064
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000029
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,4 +69,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 344.974042ms
+        duration: 529.246417ms

--- a/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_AmazonEventBridge_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_AmazonEventBridge_LogStream.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"eventbridge","isPriority":true,"sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2"}}
+            {"name":"Test-LogStream-1732609495","type":"eventbridge","isPriority":true,"sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002080","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-eefdf333-8cea-49d2-bf59-054e2adc3915/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000002080","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-eefdf333-8cea-49d2-bf59-054e2adc3915/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_DataDog_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_DataDog_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 133
+        content_length: 213
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"datadog","isPriority":true,"sink":{"datadogRegion":"us","datadogApiKey":"121233123455"}}
+            {"name":"Test-LogStream-1751988058","type":"datadog","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"datadogRegion":"us","datadogApiKey":"121233123455"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002082","name":"Test-LogStream-1732609495","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000044","name":"Test-LogStream-1751988058","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 477.875292ms
+        duration: 415.048584ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002082
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000044
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,7 +69,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 410.047042ms
+        duration: 520.224125ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002082
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000044
         method: GET
       response:
         proto: HTTP/2.0
@@ -106,7 +102,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 404 Not Found
         code: 404
-        duration: 319.197125ms
+        duration: 497.795458ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -121,11 +117,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002082
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000044
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -141,4 +135,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 395.307ms
+        duration: 512.712875ms

--- a/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_HTTP_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_HTTP_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 252
+        content_length: 332
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"http","isPriority":false,"sink":{"httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs","httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad"}}
+            {"name":"Test-LogStream-1751988058","type":"http","isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs","httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002081","name":"Test-LogStream-1732609495","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"isPriority":false}'
+        body: '{"id":"lst_0000000000000043","name":"Test-LogStream-1751988058","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 383.806583ms
+        duration: 383.694875ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002081
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000043
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,7 +69,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 354.5835ms
+        duration: 515.143167ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002081
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000043
         method: GET
       response:
         proto: HTTP/2.0
@@ -106,7 +102,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 404 Not Found
         code: 404
-        duration: 335.853166ms
+        duration: 565.270458ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -121,11 +117,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002081
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000043
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -141,4 +135,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 368.563875ms
+        duration: 483.32625ms

--- a/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_Mixpanel_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_Mixpanel_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 279
+        content_length: 359
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"mixpanel","isPriority":false,"sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"8iwyKSzwV2brfakepassGGKhsZ3INozo"}}
+            {"name":"Test-LogStream-1751988058","type":"mixpanel","isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"8iwyKSzwV2brfakepassGGKhsZ3INozo"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002086","name":"Test-LogStream-1732609495","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"isPriority":false}'
+        body: '{"id":"lst_0000000000000048","name":"Test-LogStream-1751988058","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 407.578625ms
+        duration: 448.311041ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002086
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000048
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,7 +69,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 407.664125ms
+        duration: 455.559375ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002086
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000048
         method: GET
       response:
         proto: HTTP/2.0
@@ -106,7 +102,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 404 Not Found
         code: 404
-        duration: 419.244708ms
+        duration: 478.666083ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -121,11 +117,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002086
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000048
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -141,4 +135,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 400.46025ms
+        duration: 415.184708ms

--- a/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_Segment_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_Segment_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 114
+        content_length: 194
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"segment","isPriority":true,"sink":{"segmentWriteKey":"121233123455"}}
+            {"name":"Test-LogStream-1751988058","type":"segment","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"segmentWriteKey":"121233123455"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002083","name":"Test-LogStream-1732609495","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000045","name":"Test-LogStream-1751988058","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 919.987416ms
+        duration: 669.902334ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002083
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000045
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,7 +69,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 366.154458ms
+        duration: 419.5265ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002083
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000045
         method: GET
       response:
         proto: HTTP/2.0
@@ -106,7 +102,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 404 Not Found
         code: 404
-        duration: 333.113667ms
+        duration: 432.628958ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -121,11 +117,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002083
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000045
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -141,4 +135,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 415.458584ms
+        duration: 416.875542ms

--- a/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_Splunk_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_Splunk_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 206
+        content_length: 286
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"splunk","isPriority":true,"sink":{"splunkDomain":"demo.splunk.com","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkPort":"8080","splunkSecure":true}}
+            {"name":"Test-LogStream-1751988058","type":"splunk","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"splunkDomain":"demo.splunk.com","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkPort":"8080","splunkSecure":true}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002084","name":"Test-LogStream-1732609495","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000046","name":"Test-LogStream-1751988058","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 360.852916ms
+        duration: 509.115584ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002084
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000046
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,7 +69,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 360.073667ms
+        duration: 350.695667ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002084
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000046
         method: GET
       response:
         proto: HTTP/2.0
@@ -106,7 +102,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 404 Not Found
         code: 404
-        duration: 356.942708ms
+        duration: 1.0065725s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -121,11 +117,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002084
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000046
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -141,4 +135,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 328.353625ms
+        duration: 589.4335ms

--- a/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_Sumo_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Delete/It_can_successfully_delete_a_Sumo_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 120
+        content_length: 200
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"sumo","isPriority":true,"sink":{"sumoSourceAddress":"https://example.com"}}
+            {"name":"Test-LogStream-1751988058","type":"sumo","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"sumoSourceAddress":"https://example.com"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002085","name":"Test-LogStream-1732609495","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000047","name":"Test-LogStream-1751988058","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.744833ms
+        duration: 506.523958ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002085
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000047
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -71,7 +69,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 394.19775ms
+        duration: 503.767708ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002085
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000047
         method: GET
       response:
         proto: HTTP/2.0
@@ -106,7 +102,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 404 Not Found
         code: 404
-        duration: 334.377292ms
+        duration: 990.32425ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -121,11 +117,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002085
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000047
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -141,4 +135,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 379.745458ms
+        duration: 397.101959ms

--- a/test/data/recordings/TestLogStreamManager_List.yaml
+++ b/test/data/recordings/TestLogStreamManager_List.yaml
@@ -15,10 +15,8 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: GET
       response:
@@ -27,12 +25,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"lst_0000000000001960","name":"stream1","type":"sumo","status":"suspended","sink":{"sumoSourceAddress":"sumoaourceaddresshere"},"isPriority":false}]'
+        content_length: 2
+        uncompressed: false
+        body: '[]'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 876.122875ms
+        duration: 398.287042ms

--- a/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_AmazonEventBridge_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_AmazonEventBridge_LogStream.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"eventbridge","isPriority":true,"sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2"}}
+            {"name":"Test-LogStream-1732609495","type":"eventbridge","isPriority":true,"sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002066","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-e15f958a-fc65-492a-ad8c-e094ff013b07/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000002066","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-e15f958a-fc65-492a-ad8c-e094ff013b07/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
@@ -65,7 +65,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002066","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-e15f958a-fc65-492a-ad8c-e094ff013b07/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000002066","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-e15f958a-fc65-492a-ad8c-e094ff013b07/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_DataDog_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_DataDog_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 133
+        content_length: 213
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"datadog","isPriority":true,"sink":{"datadogRegion":"us","datadogApiKey":"121233123455"}}
+            {"name":"Test-LogStream-1751988058","type":"datadog","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"datadogRegion":"us","datadogApiKey":"121233123455"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002068","name":"Test-LogStream-1732609495","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000032","name":"Test-LogStream-1751988058","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 370.935792ms
+        duration: 497.908417ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002068
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000032
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002068","name":"Test-LogStream-1732609495","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000032","name":"Test-LogStream-1751988058","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 370.296792ms
+        duration: 381.031ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002068
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000032
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -106,4 +102,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 469.629208ms
+        duration: 562.624583ms

--- a/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_HTTP_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_HTTP_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 252
+        content_length: 332
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"http","isPriority":false,"sink":{"httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs","httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad"}}
+            {"name":"Test-LogStream-1751988058","type":"http","isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs","httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002067","name":"Test-LogStream-1732609495","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"isPriority":false}'
+        body: '{"id":"lst_0000000000000031","name":"Test-LogStream-1751988058","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 363.537333ms
+        duration: 899.464166ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002067
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000031
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002067","name":"Test-LogStream-1732609495","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"isPriority":false}'
+        body: '{"id":"lst_0000000000000031","name":"Test-LogStream-1751988058","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.282166ms
+        duration: 482.461708ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002067
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000031
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -106,4 +102,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 339.626542ms
+        duration: 494.343125ms

--- a/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_Mixpanel_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_Mixpanel_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 279
+        content_length: 359
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"mixpanel","isPriority":false,"sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"8iwyKSzwV2brfakepassGGKhsZ3INozo"}}
+            {"name":"Test-LogStream-1751988058","type":"mixpanel","isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"8iwyKSzwV2brfakepassGGKhsZ3INozo"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002072","name":"Test-LogStream-1732609495","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"isPriority":false}'
+        body: '{"id":"lst_0000000000000036","name":"Test-LogStream-1751988058","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 510.789ms
+        duration: 367.239541ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002072
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000036
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002072","name":"Test-LogStream-1732609495","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"isPriority":false}'
+        body: '{"id":"lst_0000000000000036","name":"Test-LogStream-1751988058","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.080209ms
+        duration: 500.359917ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002072
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000036
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -106,4 +102,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 362.489958ms
+        duration: 483.421ms

--- a/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_Segment_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_Segment_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 114
+        content_length: 194
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"segment","isPriority":true,"sink":{"segmentWriteKey":"121233123455"}}
+            {"name":"Test-LogStream-1751988058","type":"segment","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"segmentWriteKey":"121233123455"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002069","name":"Test-LogStream-1732609495","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000033","name":"Test-LogStream-1751988058","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 484.707083ms
+        duration: 517.18875ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002069
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000033
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002069","name":"Test-LogStream-1732609495","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000033","name":"Test-LogStream-1751988058","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.433459ms
+        duration: 546.54975ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002069
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000033
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -106,4 +102,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 346.89675ms
+        duration: 440.026334ms

--- a/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_Splunk_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_Splunk_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 206
+        content_length: 286
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"splunk","isPriority":true,"sink":{"splunkDomain":"demo.splunk.com","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkPort":"8080","splunkSecure":true}}
+            {"name":"Test-LogStream-1751988058","type":"splunk","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"splunkDomain":"demo.splunk.com","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkPort":"8080","splunkSecure":true}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002070","name":"Test-LogStream-1732609495","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000034","name":"Test-LogStream-1751988058","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 386.556042ms
+        duration: 422.858416ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002070
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000034
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002070","name":"Test-LogStream-1732609495","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000034","name":"Test-LogStream-1751988058","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.698667ms
+        duration: 1.036468125s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002070
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000034
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -106,4 +102,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 357.352625ms
+        duration: 566.662291ms

--- a/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_Sumo_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Read/It_can_successfully_read_a_Sumo_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 120
+        content_length: 200
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"sumo","isPriority":true,"sink":{"sumoSourceAddress":"https://example.com"}}
+            {"name":"Test-LogStream-1751988058","type":"sumo","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"sumoSourceAddress":"https://example.com"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002071","name":"Test-LogStream-1732609495","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000035","name":"Test-LogStream-1751988058","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 409.453292ms
+        duration: 534.9865ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -51,11 +51,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002071
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000035
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002071","name":"Test-LogStream-1732609495","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000035","name":"Test-LogStream-1751988058","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 408.735791ms
+        duration: 362.264375ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,11 +84,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002071
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000035
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -106,4 +102,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 408.674292ms
+        duration: 1.035290375s

--- a/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_AmazonEventBridge_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_AmazonEventBridge_LogStream.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"eventbridge","isPriority":true,"sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2"}}
+            {"name":"Test-LogStream-1732609495","type":"eventbridge","isPriority":true,"sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}}
         form: {}
         headers:
             Content-Type:
@@ -30,7 +30,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002073","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-9a52b706-9cf7-4c9c-ac8b-fb90387e1fc1/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000002073","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-9a52b706-9cf7-4c9c-ac8b-fb90387e1fc1/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
@@ -66,7 +66,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002073","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-9a52b706-9cf7-4c9c-ac8b-fb90387e1fc1/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000002073","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-9a52b706-9cf7-4c9c-ac8b-fb90387e1fc1/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
@@ -101,7 +101,7 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002073","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-9a52b706-9cf7-4c9c-ac8b-fb90387e1fc1/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000002073","name":"Test-LogStream-1732609495","type":"eventbridge","status":"active","sink":{"awsAccountId":"999999999999","awsRegion":"us-west-2","awsPartnerEventSource":"aws.partner/auth0.com/go-auth0-dev.eu.auth0.com-9a52b706-9cf7-4c9c-ac8b-fb90387e1fc1/auth0.logs"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8

--- a/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_DataDog_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_DataDog_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 133
+        content_length: 213
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"datadog","isPriority":true,"sink":{"datadogRegion":"us","datadogApiKey":"121233123455"}}
+            {"name":"Test-LogStream-1751988058","type":"datadog","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"datadogRegion":"us","datadogApiKey":"121233123455"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002075","name":"Test-LogStream-1732609495","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000038","name":"Test-LogStream-1751988058","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 376.277292ms
+        duration: 506.531916ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,8 +55,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002075
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000038
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002075","name":"Test-LogStream-1732609495","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000038","name":"Test-LogStream-1751988058","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 411.343708ms
+        duration: 439.55025ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -87,11 +87,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002075
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000038
         method: GET
       response:
         proto: HTTP/2.0
@@ -101,13 +99,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002075","name":"Test-LogStream-1732609495","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000038","name":"Test-LogStream-1751988058","type":"datadog","status":"active","sink":{"datadogApiKey":"121233123455","datadogRegion":"us"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 408.340084ms
+        duration: 512.721417ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -122,11 +120,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002075
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000038
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -142,4 +138,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 409.014625ms
+        duration: 392.876792ms

--- a/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_HTTP_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_HTTP_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 252
+        content_length: 332
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"http","isPriority":false,"sink":{"httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs","httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad"}}
+            {"name":"Test-LogStream-1751988058","type":"http","isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs","httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002074","name":"Test-LogStream-1732609495","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"isPriority":false}'
+        body: '{"id":"lst_0000000000000037","name":"Test-LogStream-1751988058","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.00525ms
+        duration: 509.537458ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,8 +55,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002074
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000037
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002074","name":"Test-LogStream-1732609495","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"filters":[{"name":"auth.login.fail","type":"category"}],"isPriority":false}'
+        body: '{"id":"lst_0000000000000037","name":"Test-LogStream-1751988058","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"filters":[{"name":"auth.login.fail","type":"category"}],"isPriority":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.3535ms
+        duration: 423.569583ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -87,11 +87,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002074
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000037
         method: GET
       response:
         proto: HTTP/2.0
@@ -101,13 +99,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002074","name":"Test-LogStream-1732609495","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"filters":[{"name":"auth.login.fail","type":"category"}],"isPriority":false}'
+        body: '{"id":"lst_0000000000000037","name":"Test-LogStream-1751988058","type":"http","status":"active","sink":{"httpAuthorization":"Bearer f2368bbe77074527a37be2fdd5b92bad","httpContentFormat":"JSONLINES","httpContentType":"application/json","httpEndpoint":"https://example.com/logs"},"filters":[{"name":"auth.login.fail","type":"category"}],"isPriority":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.754041ms
+        duration: 1.018659208s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -122,11 +120,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002074
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000037
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -142,4 +138,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 350.862584ms
+        duration: 383.103792ms

--- a/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_Mixpanel_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_Mixpanel_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 279
+        content_length: 359
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"mixpanel","isPriority":false,"sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"8iwyKSzwV2brfakepassGGKhsZ3INozo"}}
+            {"name":"Test-LogStream-1751988058","type":"mixpanel","isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"8iwyKSzwV2brfakepassGGKhsZ3INozo"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002079","name":"Test-LogStream-1732609495","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"isPriority":false}'
+        body: '{"id":"lst_0000000000000042","name":"Test-LogStream-1751988058","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"isPriority":false,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 385.484584ms
+        duration: 359.915208ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,8 +55,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002079
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000042
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002079","name":"Test-LogStream-1732609495","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"filters":[{"name":"auth.login.fail","type":"category"}],"isPriority":false}'
+        body: '{"id":"lst_0000000000000042","name":"Test-LogStream-1751988058","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"filters":[{"name":"auth.login.fail","type":"category"}],"isPriority":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.285583ms
+        duration: 359.1385ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -87,11 +87,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002079
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000042
         method: GET
       response:
         proto: HTTP/2.0
@@ -101,13 +99,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002079","name":"Test-LogStream-1732609495","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"filters":[{"name":"auth.login.fail","type":"category"}],"isPriority":false}'
+        body: '{"id":"lst_0000000000000042","name":"Test-LogStream-1751988058","type":"mixpanel","status":"active","sink":{"mixpanelRegion":"us","mixpanelProjectId":"123456789","mixpanelServiceAccountUsername":"fake-account.123abc.mp-service-account","mixpanelServiceAccountPassword":"********"},"filters":[{"name":"auth.login.fail","type":"category"}],"isPriority":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.543375ms
+        duration: 451.983ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -122,11 +120,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002079
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000042
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -142,4 +138,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 361.933209ms
+        duration: 435.5725ms

--- a/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_Segment_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_Segment_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 114
+        content_length: 194
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"segment","isPriority":true,"sink":{"segmentWriteKey":"121233123455"}}
+            {"name":"Test-LogStream-1751988058","type":"segment","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"segmentWriteKey":"121233123455"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002076","name":"Test-LogStream-1732609495","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000039","name":"Test-LogStream-1751988058","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.053334ms
+        duration: 410.9955ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,8 +55,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002076
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000039
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002076","name":"Test-LogStream-1732609495","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000039","name":"Test-LogStream-1751988058","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.684125ms
+        duration: 405.614458ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -87,11 +87,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002076
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000039
         method: GET
       response:
         proto: HTTP/2.0
@@ -101,13 +99,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002076","name":"Test-LogStream-1732609495","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000039","name":"Test-LogStream-1751988058","type":"segment","status":"active","sink":{"segmentWriteKey":"121233123455"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.871292ms
+        duration: 478.195584ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -122,11 +120,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002076
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000039
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -142,4 +138,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 320.371292ms
+        duration: 952.628833ms

--- a/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_Splunk_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_Splunk_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 206
+        content_length: 286
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"splunk","isPriority":true,"sink":{"splunkDomain":"demo.splunk.com","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkPort":"8080","splunkSecure":true}}
+            {"name":"Test-LogStream-1751988058","type":"splunk","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"splunkDomain":"demo.splunk.com","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkPort":"8080","splunkSecure":true}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002077","name":"Test-LogStream-1732609495","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000040","name":"Test-LogStream-1751988058","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.517083ms
+        duration: 451.090959ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,8 +55,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002077
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000040
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002077","name":"Test-LogStream-1732609495","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000040","name":"Test-LogStream-1751988058","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.153666ms
+        duration: 509.384209ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -87,11 +87,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002077
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000040
         method: GET
       response:
         proto: HTTP/2.0
@@ -101,13 +99,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002077","name":"Test-LogStream-1732609495","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000040","name":"Test-LogStream-1751988058","type":"splunk","status":"active","sink":{"splunkDomain":"demo.splunk.com","splunkPort":"8080","splunkToken":"12a34ab5-c6d7-8901-23ef-456b7c89d0c1","splunkSecure":true},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 313.050625ms
+        duration: 405.754708ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -122,11 +120,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002077
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000040
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -142,4 +138,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 351.772875ms
+        duration: 511.4205ms

--- a/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_Sumo_LogStream.yaml
+++ b/test/data/recordings/TestLogStreamManager_Update/It_can_successfully_update_a_Sumo_LogStream.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 120
+        content_length: 200
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-LogStream-1732609495","type":"sumo","isPriority":true,"sink":{"sumoSourceAddress":"https://example.com"}}
+            {"name":"Test-LogStream-1751988058","type":"sumo","isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"},"sink":{"sumoSourceAddress":"https://example.com"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
+                - Go-Auth0/1.23.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002078","name":"Test-LogStream-1732609495","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000041","name":"Test-LogStream-1751988058","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true,"pii_config":{"log_fields":["first_name"],"method":"mask","algorithm":"xxhash"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.437541ms
+        duration: 506.598375ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,8 +55,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002078
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000041
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002078","name":"Test-LogStream-1732609495","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000041","name":"Test-LogStream-1751988058","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 365.856667ms
+        duration: 1.073484083s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -87,11 +87,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002078
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000041
         method: GET
       response:
         proto: HTTP/2.0
@@ -101,13 +99,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"lst_0000000000002078","name":"Test-LogStream-1732609495","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
+        body: '{"id":"lst_0000000000000041","name":"Test-LogStream-1751988058","type":"sumo","status":"active","sink":{"sumoSourceAddress":"https://example.com"},"filters":[{"type":"category","name":"security"}],"isPriority":true}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.865541ms
+        duration: 399.684792ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -122,11 +120,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.11.2
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000002078
+                - Go-Auth0/1.23.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/log-streams/lst_0000000000000041
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -142,4 +138,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 369.37975ms
+        duration: 389.976291ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- Added a new `PIIConfig` field to the `LogStream` struct to support PII masking.
- Extended `LogStreamManager` to handle the `PIIConfig` logic.
- Updated test recordings to reflect the new `LogStream` schema.

This change enhances log stream configuration flexibility by enabling fine-grained control over which PII fields should be masked.

### 📚 References

### 🔬 Testing

- Verified unit tests covering `LogStreamManager` have been updated to include `PIIConfig`.
- Adjusted existing test fixtures to reflect the new schema.
- Manually validated PII masking behavior in affected log stream types.

### 📝 Checklist

- [x] All new/changed functionality is covered by tests (or N/A)
- [x] Documentation has been updated or is not required (or N/A)
