### PR TITLE
fix: skip nil RequestOptions to prevent nil pointer dereferences on `option.apply(r)`

### DIFF
--- a/authentication/authentication_request.go
+++ b/authentication/authentication_request.go
@@ -52,7 +52,6 @@ func (a *Authentication) NewRequest(
 		}
 
 		option.apply(request, nil)
-
 	}
 
 	return request, nil
@@ -80,7 +79,6 @@ func (a *Authentication) NewFormRequest(
 		}
 
 		option.apply(request, payload)
-
 	}
 
 	body := strings.NewReader(payload.Encode())

--- a/management/actions.go
+++ b/management/actions.go
@@ -234,7 +234,6 @@ func applyActionsListDefaults(options []RequestOption) RequestOption {
 			}
 
 			option.apply(r)
-
 		}
 	})
 }

--- a/management/job.go
+++ b/management/job.go
@@ -207,7 +207,6 @@ func (m *JobManager) ImportUsers(ctx context.Context, j *Job, opts ...RequestOpt
 		}
 
 		option.apply(request)
-
 	}
 
 	response, err := m.management.Do(request)

--- a/management/management_request.go
+++ b/management/management_request.go
@@ -133,7 +133,6 @@ func (m *Management) NewRequest(
 		}
 
 		option.apply(request)
-
 	}
 
 	return request, nil
@@ -261,7 +260,6 @@ func applyListDefaults(options []RequestOption) RequestOption {
 			}
 
 			option.apply(r)
-
 		}
 	})
 }
@@ -276,7 +274,6 @@ func applyListCheckpointDefaults(options []RequestOption) RequestOption {
 			}
 
 			option.apply(r)
-
 		}
 	})
 }

--- a/management/management_request_test.go
+++ b/management/management_request_test.go
@@ -187,7 +187,7 @@ func TestNewRequest(t *testing.T) {
 	}
 }
 
-// TestNilOptionsInHelperFunctions tests that helper functions handle nil options correctly
+// TestNilOptionsInHelperFunctions tests that helper functions handle nil options correctly.
 func TestNilOptionsInHelperFunctions(t *testing.T) {
 	t.Run("applyListDefaults with nil options", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "https://example.com", nil)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
-->
Prevents API misuse. Perhaps I should've checked the function types closer before hitting this runtime error, but this should eliminate the panic.
- When iterating `[]RequestOption`, skips when `option == nil` to prevent a runtime nil pointer dereference via `option.apply(r)`

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

Existing test suite can be extended to include passing `nil` into variadic `RequestOption` parameters on different management SDK functions, like `{SDK}.Organization.Invitations(ctx, organizationID, nil)`

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests 
- [x] I have added documentation for all new/changed functionality (N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
