### PR TITLE
fix(mfa): deprecate OOBChannels field and add OOBChannel in ListAuthenticatorsResponse; enhance tests for authenticator validation

### DIFF
--- a/authentication/mfa/mfa.go
+++ b/authentication/mfa/mfa.go
@@ -98,7 +98,9 @@ type AddAuthenticatorResponse struct {
 type ListAuthenticatorsResponse struct {
 	ID                string `json:"id,omitempty"`
 	AuthenticatorType string `json:"authenticator_type,omitempty"`
-	OOBChannels       string `json:"oob_channels,omitempty"`
-	Name              string `json:"name,omitempty"`
-	Active            bool   `json:"active,omitempty"`
+	// Deprecated: Use OOBChannel instead.
+	OOBChannels string `json:"oob_channels,omitempty"`
+	OOBChannel  string `json:"oob_channel,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Active      bool   `json:"active,omitempty"`
 }

--- a/authentication/mfa_test.go
+++ b/authentication/mfa_test.go
@@ -256,11 +256,29 @@ func TestMFAListAuthenticators(t *testing.T) {
 	skipE2E(t)
 	configureHTTPTestRecordings(t, authAPI)
 
-	authenticators, err := authAPI.MFA.ListAuthenticators(context.Background(),
-		"mfa-token",
-	)
+	authenticators, err := authAPI.MFA.ListAuthenticators(context.Background(), "mfa-token")
 	require.NoError(t, err)
 	assert.NotEmpty(t, authenticators)
+
+	for _, authenticator := range authenticators {
+		assert.NotEmpty(t, authenticator.ID)
+		assert.NotEmpty(t, authenticator.AuthenticatorType)
+		assert.NotNil(t, authenticator.Active)
+
+		// Conditionally assert only if fields are expected
+		if authenticator.AuthenticatorType == "oob" {
+			assert.NotEmpty(t, authenticator.OOBChannel)
+		}
+
+		if authenticator.AuthenticatorType == "oob" && authenticator.OOBChannel != "" {
+			assert.Contains(t, []string{"sms", "auth0", "email"}, authenticator.OOBChannel)
+		}
+
+		// Only assert Name if present
+		if authenticator.Name != "" {
+			assert.NotEmpty(t, authenticator.Name)
+		}
+	}
 }
 
 func TestMFADeleteAuthenticator(t *testing.T) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
This PR fixes a mismatch in the `ListAuthenticatorsResponse` model used in the MFA API by:
- Adding the correct `OOBChannel` field (singular) to the `ListAuthenticatorsResponse` model
- Deprecating the incorrect `OOBChannels` field (plural), which is not returned by the Auth0 API
- Enhancing `TestMFAListAuthenticators` to assert fields conditionally based on `authenticator_type` and response content, improving test reliability against real API responses

These changes ensure the SDK matches actual Auth0 API responses and prevents runtime issues or incorrect expectations during validation.
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References
- #581 
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing
- Ran `TestMFAListAuthenticators` against recorded HTTP fixtures and verified correct parsing of authenticators with/without optional fields
- Ensured no breaking changes for consumers still referencing `OOBChannels`, though its use is discouraged
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
