### PR TITLE
fix: add missing mgmt api fields to guardian enrollment ticket structure

### DIFF
--- a/management/guardian.go
+++ b/management/guardian.go
@@ -138,8 +138,8 @@ type CreateEnrollmentTicket struct {
 	// be sent. If empty, the email will be sent to the user's default email
 	// address.
 	Email string `json:"email,omitempty"`
-	// SendMail indicates whether to send an email to the user to start the
-	// multi-factor authentication enrollment process.
+	// SendMail indicates whether to email the user to start the
+	// multifactor authentication enrollment process.
 	SendMail bool `json:"send_mail,omitempty"`
 	// EmailLocale is used to specify the locale of the enrollment email. Used with send_email.
 	EmailLocale string `json:"email_locale,omitempty"`

--- a/management/guardian.go
+++ b/management/guardian.go
@@ -141,6 +141,15 @@ type CreateEnrollmentTicket struct {
 	// SendMail indicates whether to send an email to the user to start the
 	// multi-factor authentication enrollment process.
 	SendMail bool `json:"send_mail,omitempty"`
+	// EmailLocale is used to specify the locale of the enrollment email. Used with send_email.
+	EmailLocale string `json:"email_locale,omitempty"`
+	// Factor specifies which factor the user must enroll with.
+	// Possible values: [push-notification, phone, email, otp, webauthn-roaming, webauthn-platform]
+	// Note: Parameter can only be used with Universal Login; it cannot be used with Classic Login or custom MFA pages.
+	Factor string `json:"factor,omitempty"`
+	// AllowMultipleEnrollments allows a user who has previously enrolled in MFA to enroll with additional factors.
+	// Note: Parameter can only be used with Universal Login; it cannot be used with Classic Login or custom MFA pages.
+	AllowMultipleEnrollments bool `json:"allow_multiple_enrollments,omitempty"`
 }
 
 // EnrollmentTicket holds information on the ticket ID and URL.

--- a/management/guardian_test.go
+++ b/management/guardian_test.go
@@ -496,8 +496,12 @@ func TestGuardian(t *testing.T) {
 			user := givenAUser(t)
 
 			ticket := &CreateEnrollmentTicket{
-				UserID:   user.GetID(),
-				SendMail: false,
+				user.GetID(),
+				"jon@example.com",
+				false,
+				"",
+				"Phone",
+				true,
 			}
 
 			createdTicket, err := api.Guardian.Enrollment.CreateTicket(context.Background(), ticket)

--- a/management/guardian_test.go
+++ b/management/guardian_test.go
@@ -496,12 +496,11 @@ func TestGuardian(t *testing.T) {
 			user := givenAUser(t)
 
 			ticket := &CreateEnrollmentTicket{
-				user.GetID(),
-				"jon@example.com",
-				false,
-				"",
-				"Phone",
-				true,
+				UserID:                   user.GetID(),
+				Email:                    "jon@example.com",
+				SendMail:                 false,
+				Factor:                   "push-notification",
+				AllowMultipleEnrollments: true,
 			}
 
 			createdTicket, err := api.Guardian.Enrollment.CreateTicket(context.Background(), ticket)

--- a/test/data/recordings/TestGuardian/Enrollment/CreateTicket.yaml
+++ b/test/data/recordings/TestGuardian/Enrollment/CreateTicket.yaml
@@ -13,13 +13,13 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection":"Username-Password-Authentication","email":"chuck878@example.com","given_name":"Chuck","family_name":"Sanchez","username":"test-user636","nickname":"Chucky","password":"Passwords hide their chuck","user_metadata":{"favourite_attack":"roundhouse_kick"},"verify_email":false,"app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]},"picture":"https://example-picture-url.jpg","blocked":false,"email_verified":true}
+            {"connection":"Username-Password-Authentication","email":"chuck782@example.com","given_name":"Chuck","family_name":"Sanchez","username":"test-user438","nickname":"Chucky","password":"Passwords hide their chuck","user_metadata":{"favourite_attack":"roundhouse_kick"},"verify_email":false,"app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]},"picture":"https://example-picture-url.jpg","blocked":false,"email_verified":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/latest
+                - Go-Auth0/1.25.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/users
         method: POST
       response:
@@ -30,32 +30,32 @@ interactions:
         trailer: {}
         content_length: 661
         uncompressed: false
-        body: '{"blocked":false,"created_at":"2023-01-25T17:47:40.889Z","email":"chuck878@example.com","email_verified":true,"family_name":"Sanchez","given_name":"Chuck","identities":[{"connection":"Username-Password-Authentication","user_id":"63d16b3c13efda064d3ab9fc","provider":"auth0","isSocial":false}],"name":"chuck878@example.com","nickname":"Chucky","picture":"https://example-picture-url.jpg","updated_at":"2023-01-25T17:47:40.889Z","user_id":"auth0|63d16b3c13efda064d3ab9fc","user_metadata":{"favourite_attack":"roundhouse_kick"},"username":"test-user636","app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]}}'
+        body: '{"blocked":false,"created_at":"2025-08-11T06:22:38.009Z","email":"chuck782@example.com","email_verified":true,"family_name":"Sanchez","given_name":"Chuck","identities":[{"connection":"Username-Password-Authentication","user_id":"68998c2d684ac37fcd52bfbe","provider":"auth0","isSocial":false}],"name":"chuck782@example.com","nickname":"Chucky","picture":"https://example-picture-url.jpg","updated_at":"2025-08-11T06:22:38.009Z","user_id":"auth0|68998c2d684ac37fcd52bfbe","user_metadata":{"favourite_attack":"roundhouse_kick"},"username":"test-user438","app_metadata":{"facts":["count_to_infinity_twice","kill_two_stones_with_one_bird","can_hear_sign_language"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 306.547333ms
+        duration: 1.417970292s
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 45
+        content_length: 134
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"user_id":"auth0|63d16b3c13efda064d3ab9fc"}
+            {"user_id":"auth0|68998c2d684ac37fcd52bfbe","email":"jon@example.com","factor":"push-notification","allow_multiple_enrollments":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/latest
+                - Go-Auth0/1.25.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/guardian/enrollments/ticket
         method: POST
       response:
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"ticket_id":"sYSkuOgGWJaVoQCrFHciryBKU840644v","ticket_url":"https://go-auth0-dev.eu.auth0.com.guardian.eu.auth0.com/enrollment?ticket_id=sYSkuOgGWJaVoQCrFHciryBKU840644v"}'
+        body: '{"ticket_id":"jip3H2Q20fiUyQCcMmS0gBAinoBe4rOV","ticket_url":"https://go-auth0-dev.eu.auth0.com.us.auth0.com/mfa/enrollment?ticket=jip3H2Q20fiUyQCcMmS0gBAinoBe4rOV"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.793625ms
+        duration: 388.9275ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -87,11 +87,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0-SDK/latest
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C63d16b3c13efda064d3ab9fc
+                - Go-Auth0/1.25.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C68998c2d684ac37fcd52bfbe
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -107,4 +105,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 161.688208ms
+        duration: 632.82725ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adding the fields missing from the guardian enrollment ticket mgmt API create ticket structure. Matching what is available in the mgmt API:

https://auth0.com/docs/api/management/v2/guardian/post-ticket

Example JSON:
```json
{
  "user_id": "string",
  "email": "user@example.com",
  "send_mail": true,
  "email_locale": "string",
  "factor": "push-notification",
  "allow_multiple_enrollments": true
}
```

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
