### PR TITLE
feat: add SkipNonVerifiableCallbackURIConfirmationPrompt to Tenant and Client for custom URI schemes

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -168,6 +168,18 @@ type Client struct {
 
 	// ResourceServerIdentifier is the identifier of the resource server that this client is associated with.
 	ResourceServerIdentifier *string `json:"resource_server_identifier,omitempty"`
+
+	// SkipNonVerifiableCallbackURIConfirmationPrompt controls whether a confirmation prompt is shown during login flows when the redirect URI uses non-verifiable callback URIs (for example, a custom URI schema such as `myapp://`, or `localhost`).
+	//
+	// To unset values (set to null), use a PATCH request like this:
+	// PATCH /api/v2/clients/{id}
+	// {
+	//	 "skip_non_verifiable_callback_uri_confirmation_prompt": null
+	// }
+	//
+	// For more details on making custom requests, refer to the Auth0 Go SDK examples:
+	// https://github.com/auth0/go-auth0/blob/main/EXAMPLES.md#providing-a-custom-user-struct
+	SkipNonVerifiableCallbackURIConfirmationPrompt *bool `json:"skip_non_verifiable_callback_uri_confirmation_prompt,omitempty"`
 }
 
 // ClientTokenExchange allows configuration for token exchange.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1883,6 +1883,14 @@ func (c *Client) GetSignedRequestObject() *ClientSignedRequestObject {
 	return c.SignedRequestObject
 }
 
+// GetSkipNonVerifiableCallbackURIConfirmationPrompt returns the SkipNonVerifiableCallbackURIConfirmationPrompt field if it's non-nil, zero value otherwise.
+func (c *Client) GetSkipNonVerifiableCallbackURIConfirmationPrompt() bool {
+	if c == nil || c.SkipNonVerifiableCallbackURIConfirmationPrompt == nil {
+		return false
+	}
+	return *c.SkipNonVerifiableCallbackURIConfirmationPrompt
+}
+
 // GetSSO returns the SSO field if it's non-nil, zero value otherwise.
 func (c *Client) GetSSO() bool {
 	if c == nil || c.SSO == nil {
@@ -12792,6 +12800,14 @@ func (t *Tenant) GetSessions() *TenantSessions {
 		return nil
 	}
 	return t.Sessions
+}
+
+// GetSkipNonVerifiableCallbackURIConfirmationPrompt returns the SkipNonVerifiableCallbackURIConfirmationPrompt field if it's non-nil, zero value otherwise.
+func (t *Tenant) GetSkipNonVerifiableCallbackURIConfirmationPrompt() bool {
+	if t == nil || t.SkipNonVerifiableCallbackURIConfirmationPrompt == nil {
+		return false
+	}
+	return *t.SkipNonVerifiableCallbackURIConfirmationPrompt
 }
 
 // GetSupportEmail returns the SupportEmail field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2364,6 +2364,16 @@ func TestClient_GetSignedRequestObject(tt *testing.T) {
 	c.GetSignedRequestObject()
 }
 
+func TestClient_GetSkipNonVerifiableCallbackURIConfirmationPrompt(tt *testing.T) {
+	var zeroValue bool
+	c := &Client{SkipNonVerifiableCallbackURIConfirmationPrompt: &zeroValue}
+	c.GetSkipNonVerifiableCallbackURIConfirmationPrompt()
+	c = &Client{}
+	c.GetSkipNonVerifiableCallbackURIConfirmationPrompt()
+	c = nil
+	c.GetSkipNonVerifiableCallbackURIConfirmationPrompt()
+}
+
 func TestClient_GetSSO(tt *testing.T) {
 	var zeroValue bool
 	c := &Client{SSO: &zeroValue}
@@ -16051,6 +16061,16 @@ func TestTenant_GetSessions(tt *testing.T) {
 	t.GetSessions()
 	t = nil
 	t.GetSessions()
+}
+
+func TestTenant_GetSkipNonVerifiableCallbackURIConfirmationPrompt(tt *testing.T) {
+	var zeroValue bool
+	t := &Tenant{SkipNonVerifiableCallbackURIConfirmationPrompt: &zeroValue}
+	t.GetSkipNonVerifiableCallbackURIConfirmationPrompt()
+	t = &Tenant{}
+	t.GetSkipNonVerifiableCallbackURIConfirmationPrompt()
+	t = nil
+	t.GetSkipNonVerifiableCallbackURIConfirmationPrompt()
 }
 
 func TestTenant_GetSupportEmail(tt *testing.T) {

--- a/management/tenant.go
+++ b/management/tenant.go
@@ -133,6 +133,19 @@ type Tenant struct {
 	// For more details on making custom requests, refer to the Auth0 Go SDK examples:
 	// https://github.com/auth0/go-auth0/blob/main/EXAMPLES.md#providing-a-custom-user-struct
 	DefaultTokenQuota *TenantDefaultTokenQuota `json:"default_token_quota,omitempty"`
+
+	// SkipNonVerifiableCallbackURIConfirmationPrompt controls whether a confirmation prompt is shown during login flows when the redirect URI uses non-verifiable callback URIs (for example, a custom URI schema such as `myapp://`, or `localhost`).
+	//
+	// To unset values (set to null), use a PATCH request like this:
+	//
+	// PATCH /api/v2/tenants/settings
+	// {
+	//   "skip_non_verifiable_callback_uri_confirmation_prompt": null
+	// }
+	//
+	// For more details on making custom requests, refer to the Auth0 Go SDK examples:
+	// https://github.com/auth0/go-auth0/blob/main/EXAMPLES.md#providing-a-custom-user-struct
+	SkipNonVerifiableCallbackURIConfirmationPrompt *bool `json:"skip_non_verifiable_callback_uri_confirmation_prompt,omitempty"`
 }
 
 // TenantDefaultTokenQuota holds settings for the default token quota.


### PR DESCRIPTION

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
This pull request adds support for managing the Skip Non-Verifiable Callback URI Confirmation Prompt setting at both the client and tenant levels. This setting controls whether a confirmation prompt is shown during login flows when the redirect URI uses non-verifiable callback URIs (such as custom URI schemes or localhost). The changes include updates to the relevant structs, getter methods, and corresponding unit tests.

**Support for Skip Non-Verifiable Callback URI Confirmation Prompt:**

* Added the `SkipNonVerifiableCallbackURIConfirmationPrompt` field to the `Client` struct in `client.go`, including documentation on how to set or unset this value via the API.
* Added the `SkipNonVerifiableCallbackURIConfirmationPrompt` field to the `Tenant` struct in `tenant.go`, with similar documentation and usage notes.

**Getter Methods:**

* Implemented `GetSkipNonVerifiableCallbackURIConfirmationPrompt` methods for both `Client` and `Tenant` types in `management.gen.go` to safely retrieve the value of the new field. 
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Unit tests added to validate correct handling of the new field at both client and tenant levels. 
- Verified behaviour by setting/unsetting the field and ensuring correct serialisation in API calls.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
