### PR TITLE
feat: add SSO ticket endpoint to custom domain header whitelist paths

### DIFF
--- a/management/management_request.go
+++ b/management/management_request.go
@@ -24,6 +24,7 @@ func compileWhitelistedPathPatterns() []*regexp.Regexp {
 		`^/api/v2/users$`,
 		`^/api/v2/users/[^/]+$`,
 		`^/api/v2/guardian/enrollments/ticket$`,
+		"^/api/v2/self-service-profiles/[^/]+/sso-ticket$",
 	}
 
 	compiled := make([]*regexp.Regexp, len(patterns))


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
This pull request makes a small update to the list of whitelisted API path patterns in `management_request.go`, allowing requests to the self-service SSO ticket endpoint to pass through the whitelist. 

- Added a new regex pattern to `compileWhitelistedPathPatterns` to whitelist the path `/api/v2/self-service-profiles/{id}/sso-ticket`.
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
