### PR TITLE
feat: Set default User-Agent and fix request option merging

### DIFF
--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -172,6 +172,7 @@ func New(ctx context.Context, domain string, options ...Option) (*Authentication
 
 	a.http = client.Wrap(
 		a.http,
+		client.WithUserAgent(client.UserAgent),
 		client.WithDebug(a.debug),
 		client.WithAuth0ClientInfo(a.auth0ClientInfo),
 		client.WithRetries(a.retryStrategy),

--- a/management/core/request_option.go
+++ b/management/core/request_option.go
@@ -114,7 +114,13 @@ type HTTPHeaderOption struct {
 }
 
 func (h *HTTPHeaderOption) applyRequestOptions(opts *RequestOptions) {
-	opts.HTTPHeader = h.HTTPHeader
+	// Merge headers instead of replacing to preserve existing headers
+	if opts.HTTPHeader == nil {
+		opts.HTTPHeader = make(http.Header)
+	}
+	for key, values := range h.HTTPHeader {
+		opts.HTTPHeader[key] = values
+	}
 }
 
 // BodyPropertiesOption implements the RequestOption interface.
@@ -123,7 +129,13 @@ type BodyPropertiesOption struct {
 }
 
 func (b *BodyPropertiesOption) applyRequestOptions(opts *RequestOptions) {
-	opts.BodyProperties = b.BodyProperties
+	// Merge properties instead of replacing to preserve existing properties
+	if opts.BodyProperties == nil {
+		opts.BodyProperties = make(map[string]interface{})
+	}
+	for key, value := range b.BodyProperties {
+		opts.BodyProperties[key] = value
+	}
 }
 
 // QueryParametersOption implements the RequestOption interface.
@@ -132,7 +144,13 @@ type QueryParametersOption struct {
 }
 
 func (q *QueryParametersOption) applyRequestOptions(opts *RequestOptions) {
-	opts.QueryParameters = q.QueryParameters
+	// Merge query parameters instead of replacing to preserve existing parameters
+	if opts.QueryParameters == nil {
+		opts.QueryParameters = make(url.Values)
+	}
+	for key, values := range q.QueryParameters {
+		opts.QueryParameters[key] = values
+	}
 }
 
 // MaxAttemptsOption implements the RequestOption interface.


### PR DESCRIPTION
### 🔧 Changes

This PR fixes multiple issues related to HTTP headers and request options in the SDK:

#### User-Agent Header
- **Changed**: Management client now uses `internal.UserAgentTransport()` to set User-Agent header via transport wrapper
- **Fixed**: User-Agent now correctly shows as `Go-Auth0/v2.0.0` instead of `Go-http-client/1.1`
- **Why**: Transport wrappers ensure headers are set reliably at the transport layer, preventing them from being overwritten

#### Auth0-Client Header
- **Changed**: Management client now uses `internal.Auth0ClientInfoTransport()` for Auth0-Client header
- **Why**: Using transport wrapper instead of `WithHTTPHeader` ensures the header cannot be accidentally overwritten by user options

#### Request Options - Merging Behavior
- **Fixed**: `HTTPHeaderOption` now merges headers instead of replacing the entire header map
- **Fixed**: `BodyPropertiesOption` now merges properties instead of replacing
- **Fixed**: `QueryParametersOption` now merges query parameters instead of replacing
- **Why**: Multiple option calls should add to each other, not overwrite. This matches the documented behavior in EXAMPLES.md

#### Debug Logging
- **Fixed**: `DebugTransport` now dumps request after inner transports modify it
- **Why**: Debug logs now show the actual headers that were sent (including User-Agent and Auth0-Client)

#### Code Cleanup
- **Removed**: Unused imports (`encoding/base64`, `encoding/json`) from management.go

### 📚 References

This addresses issues where:
- User-Agent header was not being set correctly in management API requests
- Debug logs showed incomplete header information
- Multiple `WithHTTPHeader`/`WithBodyProperties`/`WithQueryParameters` calls would overwrite instead of merge

### 🔬 Testing

**Existing Tests**: All existing tests pass
- `go test ./internal/client/... -run TestDebug` - ✅ Pass
- `go test ./management/client/...` - ✅ Pass
- `make lint` - ✅ Pass

**Manual Testing**: 
Created test client with debug logging enabled and verified:
- User-Agent header shows as `Go-Auth0/v2.0.0` in debug output
- Auth0-Client header is present in debug output
- Multiple option calls properly merge instead of replace

**Test Scenario**:
```go
client, _ := mgmtclient.New(domain,
    option.WithDebug(true),
    option.WithInsecure(),
)
client.Clients.List(ctx, &management.ListClientsRequestParameters{})
```

**Before**: Debug log showed `User-Agent: Go-http-client/1.1`
**After**: Debug log shows `User-Agent: Go-Auth0/v2.0.0`

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)