### PR TITLE
feat: Add AsyncApprovalNotificationChannels support to Client

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -194,6 +194,23 @@ type Client struct {
 	// For more details on making custom requests, refer to the Auth0 Go SDK examples:
 	// https://github.com/auth0/go-auth0/blob/main/EXAMPLES.md#providing-a-custom-user-struct
 	OrganizationDiscoveryMethods *[]string `json:"organization_discovery_methods,omitempty"`
+
+	// AsyncApprovalNotificationChannels is an array of notification channels for contacting
+	// the user when their approval is required.
+	//
+	// Valid values: "guardian-push", "email".
+	//
+	// Default value: ["guardian-push"]
+	//
+	// To unset values (set to null), use a PATCH request like this:
+	// PATCH /api/v2/clients/{id}
+	// {
+	//	 "async_approval_notification_channels": null
+	// }
+	//
+	// For more details on making custom requests, refer to the Auth0 Go SDK examples:
+	// https://github.com/auth0/go-auth0/blob/main/EXAMPLES.md#providing-a-custom-user-struct
+	AsyncApprovalNotificationChannels *[]string `json:"async_approval_notification_channels,omitempty"`
 }
 
 // ClientTokenExchange allows configuration for token exchange.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1608,6 +1608,14 @@ func (c *Client) GetAppType() string {
 	return *c.AppType
 }
 
+// GetAsyncApprovalNotificationChannels returns the AsyncApprovalNotificationChannels field if it's non-nil, zero value otherwise.
+func (c *Client) GetAsyncApprovalNotificationChannels() []string {
+	if c == nil || c.AsyncApprovalNotificationChannels == nil {
+		return nil
+	}
+	return *c.AsyncApprovalNotificationChannels
+}
+
 // GetCallbacks returns the Callbacks field if it's non-nil, zero value otherwise.
 func (c *Client) GetCallbacks() []string {
 	if c == nil || c.Callbacks == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2052,6 +2052,16 @@ func TestClient_GetAppType(tt *testing.T) {
 	c.GetAppType()
 }
 
+func TestClient_GetAsyncApprovalNotificationChannels(tt *testing.T) {
+	var zeroValue []string
+	c := &Client{AsyncApprovalNotificationChannels: &zeroValue}
+	c.GetAsyncApprovalNotificationChannels()
+	c = &Client{}
+	c.GetAsyncApprovalNotificationChannels()
+	c = nil
+	c.GetAsyncApprovalNotificationChannels()
+}
+
 func TestClient_GetCallbacks(tt *testing.T) {
 	var zeroValue []string
 	c := &Client{Callbacks: &zeroValue}


### PR DESCRIPTION
### 🔧 Changes

- Add AsyncApprovalNotificationChannels field to Client struct in management/client.go
- Auto-generate GetAsyncApprovalNotificationChannels getter method in management.gen.go
- Auto-generate test for GetAsyncApprovalNotificationChannels in management.gen_test.go

This feature allows configuring notification channels for contacting users when their approval is required.

- Valid values: "guardian-push", "email"
- Default value: ["guardian-push"]

The field is optional and can be null. To unset values, use a PATCH request with null value.

### 📚 References

- Related to CIBA and Risk Assessment Request (RAR) support

### 🔬 Testing

- Unit tests auto-generated for the new getter method
- Manual testing can verify the field is properly serialized/deserialized in Client struct

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (auto-generated)
- [x] I have added documentation for all new/changed functionality (included in struct comments)