### PR TITLE
Add UseOauthSpecScope field to ConnectionOptionsOAuth2

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -1280,6 +1280,9 @@ type ConnectionOptionsOAuth2 struct {
 	// Email specifies whether to request the email scope.
 	// This field is used by some OAuth2 connections (e.g., Line), but not all.
 	Email *bool `json:"email,omitempty"`
+
+	// UseOauthSpecScope specifies whether to use the scope field as defined in the OAuth2 specification (space separated string) or as an array of strings.
+	UseOauthSpecScope *bool `json:"useOauthSpecScope,omitempty"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for ConnectionOptionsOAuth2.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5419,6 +5419,14 @@ func (c *ConnectionOptionsOAuth2) GetUpstreamParams() map[string]interface{} {
 	return c.UpstreamParams
 }
 
+// GetUseOauthSpecScope returns the UseOauthSpecScope field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOAuth2) GetUseOauthSpecScope() bool {
+	if c == nil || c.UseOauthSpecScope == nil {
+		return false
+	}
+	return *c.UseOauthSpecScope
+}
+
 // String returns a string representation of ConnectionOptionsOAuth2.
 func (c *ConnectionOptionsOAuth2) String() string {
 	return Stringify(c)

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -6694,6 +6694,16 @@ func TestConnectionOptionsOAuth2_GetUpstreamParams(tt *testing.T) {
 	c.GetUpstreamParams()
 }
 
+func TestConnectionOptionsOAuth2_GetUseOauthSpecScope(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsOAuth2{UseOauthSpecScope: &zeroValue}
+	c.GetUseOauthSpecScope()
+	c = &ConnectionOptionsOAuth2{}
+	c.GetUseOauthSpecScope()
+	c = nil
+	c.GetUseOauthSpecScope()
+}
+
 func TestConnectionOptionsOAuth2_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ConnectionOptionsOAuth2{}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds `UseOauthSpecScope` field to `ConnectionOptionsOAuth2` for OAuth2 scope format configuration.

**Added:**
- `UseOauthSpecScope` field in `ConnectionOptionsOAuth2` struct
- `GetUseOauthSpecScope()` getter method

### 📚 References
- https://auth0.com/docs/api/management/v2/connections/get-connections-by-id
- https://auth0.com/docs/api/management/v2/connections/patch-connections-by-id
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

**Automated Tests:**
- Added unit tests for `GetUseOauthSpecScope()` method.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
