### PR TITLE
feat(connection): Add SendBackChannelNonce to ConnectionOptionsOIDC

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -1176,6 +1176,11 @@ type ConnectionOptionsOIDC struct {
 	//      "jwks_uri":               "https://example.com/.well-known/jwks.json",
 	//  }
 	OIDCMetadata map[string]interface{} `json:"oidc_metadata,omitempty"`
+
+	// When true and type is 'back_channel',
+	// includes a cryptographic nonce in authorization requests to prevent replay attacks.
+	// The identity provider must include this nonce in the ID token for validation.
+	SendBackChannelNonce *bool `json:"send_back_channel_nonce,omitempty"`
 }
 
 // ConnectionOptionsOIDCConnectionSettings contains PKCE configuration for the connection.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5581,6 +5581,14 @@ func (c *ConnectionOptionsOIDC) GetScope() string {
 	return *c.Scope
 }
 
+// GetSendBackChannelNonce returns the SendBackChannelNonce field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetSendBackChannelNonce() bool {
+	if c == nil || c.SendBackChannelNonce == nil {
+		return false
+	}
+	return *c.SendBackChannelNonce
+}
+
 // GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsOIDC) GetSetUserAttributes() string {
 	if c == nil || c.SetUserAttributes == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -6894,6 +6894,16 @@ func TestConnectionOptionsOIDC_GetScope(tt *testing.T) {
 	c.GetScope()
 }
 
+func TestConnectionOptionsOIDC_GetSendBackChannelNonce(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsOIDC{SendBackChannelNonce: &zeroValue}
+	c.GetSendBackChannelNonce()
+	c = &ConnectionOptionsOIDC{}
+	c.GetSendBackChannelNonce()
+	c = nil
+	c.GetSendBackChannelNonce()
+}
+
 func TestConnectionOptionsOIDC_GetSetUserAttributes(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsOIDC{SetUserAttributes: &zeroValue}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds `SendBackChannelNonce` field to `ConnectionOptionsOIDC` struct.

**Added:**
- `SendBackChannelNonce` boolean field to `ConnectionOptionsOIDC`
- `GetSendBackChannelNonce()` getter method with nil-safe handling

**Purpose:**
To Support setting send_back_channel_nonce for OpenID Connect Enterprise Connections

### 📚 References

N/A

### 🔬 Testing

**Automated:**
- Added unit tests for `GetSendBackChannelNonce()` covering nil, zero value, and populated cases

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
