### PR TITLE
feat: Allow configuration of required_for param in Resource Servers

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -11434,6 +11434,14 @@ func (r *ResourceServerProofOfPossession) GetRequired() bool {
 	return *r.Required
 }
 
+// GetRequiredFor returns the RequiredFor field if it's non-nil, zero value otherwise.
+func (r *ResourceServerProofOfPossession) GetRequiredFor() string {
+	if r == nil || r.RequiredFor == nil {
+		return ""
+	}
+	return *r.RequiredFor
+}
+
 // String returns a string representation of ResourceServerProofOfPossession.
 func (r *ResourceServerProofOfPossession) String() string {
 	return Stringify(r)

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -14337,6 +14337,16 @@ func TestResourceServerProofOfPossession_GetRequired(tt *testing.T) {
 	r.GetRequired()
 }
 
+func TestResourceServerProofOfPossession_GetRequiredFor(tt *testing.T) {
+	var zeroValue string
+	r := &ResourceServerProofOfPossession{RequiredFor: &zeroValue}
+	r.GetRequiredFor()
+	r = &ResourceServerProofOfPossession{}
+	r.GetRequiredFor()
+	r = nil
+	r.GetRequiredFor()
+}
+
 func TestResourceServerProofOfPossession_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ResourceServerProofOfPossession{}

--- a/management/resource_server.go
+++ b/management/resource_server.go
@@ -172,6 +172,12 @@ type ResourceServerProofOfPossession struct {
 
 	// Whether the use of Proof-of-Possession is required for the resource server.
 	Required *bool `json:"required,omitempty"`
+
+	// Specifies which client types require Proof-of-Possession.
+	// Available options:
+	//   - "all_clients"
+	//   - "public_clients"
+	RequiredFor *string `json:"required_for,omitempty"`
 }
 
 // ResourceServerTokenEncryption specifies the token encryption for the resource server.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
Allow configuring new parameter `RequiredFor` under `proof_of_possession` for Auth0 Resource Servers.


<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
