### PR TITLE
feat: Add support for Passkeys prompt patials (EA)

### DIFF
--- a/management/prompt.go
+++ b/management/prompt.go
@@ -133,6 +133,7 @@ var allowedPromptsWithPartials = []PromptType{
 	PromptLoginPassword,
 	PromptLoginPasswordLess,
 	PromptCustomizedConsent,
+	PromptPasskeys,
 }
 
 // PromptType defines the prompt that we are managing.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Add a new Prompt Partial type 'passkeys'

```
// Set partials for passkeys prompt
partials := &management.PromptScreenPartials{
    management.ScreenPasskeyEnrollment: {
        management.InsertionPointFormContentStart: "<div>Custom content</div>",
        management.InsertionPointFormContentEnd:   "<div>More content</div>",
    },
    management.ScreenPasskeyEnrollmentLocal: {
        management.InsertionPointFormFooterStart: "<div>Footer content</div>",
    },
}

err := client.Prompt.SetPartials(ctx, management.PromptPasskeys, partials)
```

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

https://auth0.com/docs/api/management/v2/prompts/get-partials
https://auth0.com/docs/api/management/v2/prompts/put-partials

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->



### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
