### PR TITLE
chore: optimize lint configuration and fix lint violations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # pin@9.2.0
         with:
           version: latest
-          args: -v -c .golangci.yml
+          args: -v -c .golangci.yml . ./authentication/... ./internal/...
 
   tests:
     name: Tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,8 +18,12 @@ linters:
     - fatcontext
     - govet
     - misspell
-    - wsl
+    - wsl_v5
   settings:
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
     godot:
       scope: declarations
       capital: true
@@ -32,19 +36,10 @@ linters:
       - linters:
           - gosec
         path: (.+)_test.go
-      - path: (.+)\.go$
-        text: Error return value of `response.Body.Close` is not checked
-      - path: (.+)\.go$
-        text: Error return value of `w.Write` is not checked
-      - path: (.+)\.go$
-        text: 'G307: Deferring unsafe method "Close" on type "io.ReadCloser"'
-      - path: (.+)\.go$
-        text: should have a package comment
     paths:
       - third_party$
       - builtin$
       - examples$
-      - management/ #Remove after Beta
 formatters:
   enable:
     - gofmt
@@ -61,4 +56,3 @@ formatters:
       - third_party$
       - builtin$
       - examples$
-      - management/ #Remove after Beta

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ $(GO_BIN)/govulncheck:
 
 lint: $(GO_BIN)/golangci-lint ## Run linting on the go files
 	@echo "==> Running linting on the library with golangci-lint..."
-	@golangci-lint run -v --fix -c .golangci.yml ./...
+	@golangci-lint run -v --fix -c .golangci.yml . ./authentication/... ./internal/...
 
 check-vuln: $(GO_BIN)/govulncheck ## Check for vulnerabilities
 	@echo "==> Checking for vulnerabilities..."

--- a/auth0.go
+++ b/auth0.go
@@ -1,3 +1,4 @@
+// Package auth0 provides Go client libraries for the Auth0 platform.
 package auth0
 
 import (

--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -203,7 +203,6 @@ func New(ctx context.Context, domain string, options ...Option) (*Authentication
 		a.idTokenSigningAlg,
 		validatorOpts...,
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/authentication/authentication_error_test.go
+++ b/authentication/authentication_error_test.go
@@ -103,6 +103,7 @@ func Test_newError(t *testing.T) {
 			err := newError(&testCase.givenResponse)
 
 			var actualError *Error
+
 			ok := errors.As(err, &actualError)
 			assert.True(t, ok, "newError should return an *Error")
 			assert.Equal(t, testCase.expectedError, *actualError)

--- a/authentication/authentication_request.go
+++ b/authentication/authentication_request.go
@@ -106,6 +106,7 @@ func (a *Authentication) Request(ctx context.Context, method, uri string, payloa
 	var request *http.Request
 
 	var err error
+
 	switch p := payload.(type) {
 	case url.Values:
 		request, err = a.NewFormRequest(ctx, method, uri, p, opts...)
@@ -121,7 +122,8 @@ func (a *Authentication) Request(ctx context.Context, method, uri string, payloa
 	if err != nil {
 		return fmt.Errorf("failed to send the request: %w", err)
 	}
-	defer response.Body.Close()
+
+	defer func() { _ = response.Body.Close() }()
 
 	// If the response contains a client or a server error then return the error.
 	if response.StatusCode >= http.StatusBadRequest {

--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -126,7 +126,6 @@ func initializeTestClient() {
 		domain,
 		option.WithClientCredentials(context.Background(), mgmtClientID, mgmtClientSecret),
 	)
-
 	if err != nil {
 		log.Fatal("failed to initialize the management api client")
 	}
@@ -232,6 +231,7 @@ func TestAuth0Client(t *testing.T) {
 			assert.NoError(t, err)
 
 			var auth0Client client.Auth0ClientInfo
+
 			err = json.Unmarshal(auth0ClientDecoded, &auth0Client)
 
 			assert.NoError(t, err)
@@ -289,6 +289,7 @@ func TestAuth0Client(t *testing.T) {
 			assert.NoError(t, err)
 
 			var auth0Client client.Auth0ClientInfo
+
 			err = json.Unmarshal(auth0ClientDecoded, &auth0Client)
 
 			assert.NoError(t, err)

--- a/authentication/ciba/ciba.go
+++ b/authentication/ciba/ciba.go
@@ -1,3 +1,4 @@
+// Package ciba provides types for the Auth0 Client Initiated Backchannel Authentication endpoints.
 package ciba
 
 // Request defines the request body for calling the bc-authorize endpoint.

--- a/authentication/database.go
+++ b/authentication/database.go
@@ -36,7 +36,6 @@ func (d *Database) ChangePassword(ctx context.Context, params database.ChangePas
 	}
 
 	request, err := d.authentication.NewRequest(ctx, "POST", d.authentication.URI("dbconnections", "change_password"), params, opts...)
-
 	if err != nil {
 		return "", fmt.Errorf("failed to create a new request: %w", err)
 	}
@@ -45,7 +44,8 @@ func (d *Database) ChangePassword(ctx context.Context, params database.ChangePas
 	if err != nil {
 		return "", fmt.Errorf("failed to send the request: %w", err)
 	}
-	defer response.Body.Close()
+
+	defer func() { _ = response.Body.Close() }()
 
 	// If the response contains a client or a server error then return the error.
 	if response.StatusCode >= http.StatusBadRequest {

--- a/authentication/database/database.go
+++ b/authentication/database/database.go
@@ -1,3 +1,4 @@
+// Package database provides types for the Auth0 database connection authentication endpoints.
 package database
 
 import (

--- a/authentication/mfa.go
+++ b/authentication/mfa.go
@@ -28,13 +28,11 @@ func (m *MFA) Challenge(ctx context.Context, body mfa.ChallengeRequest, opts ...
 	}
 
 	err = m.authentication.addClientAuthenticationToClientAuthStruct(&body.ClientAuthentication, false)
-
 	if err != nil {
 		return nil, err
 	}
 
 	err = m.authentication.Request(ctx, "POST", m.authentication.URI("mfa", "challenge"), body, &c, opts...)
-
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +61,6 @@ func (m *MFA) VerifyWithOTP(ctx context.Context, body mfa.VerifyWithOTPRequest, 
 	}
 
 	err = m.authentication.addClientAuthenticationToURLValues(body.ClientAuthentication, data, true)
-
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +96,6 @@ func (m *MFA) VerifyWithOOB(ctx context.Context, body mfa.VerifyWithOOBRequest, 
 	}
 
 	err = m.authentication.addClientAuthenticationToURLValues(body.ClientAuthentication, data, true)
-
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +126,6 @@ func (m *MFA) VerifyWithRecoveryCode(ctx context.Context, body mfa.VerifyWithRec
 	}
 
 	err = m.authentication.addClientAuthenticationToURLValues(body.ClientAuthentication, data, true)
-
 	if err != nil {
 		return nil, err
 	}

--- a/authentication/mfa/mfa.go
+++ b/authentication/mfa/mfa.go
@@ -1,3 +1,4 @@
+// Package mfa provides types for the Auth0 multi-factor authentication endpoints.
 package mfa
 
 import (

--- a/authentication/oauth.go
+++ b/authentication/oauth.go
@@ -26,7 +26,6 @@ func (o *OAuth) LoginWithGrant(ctx context.Context, grantType string, body url.V
 			Nonce:        validationOptions.Nonce,
 			Organization: validationOptions.Organization,
 		})
-
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +72,6 @@ func (o *OAuth) LoginWithPassword(ctx context.Context, body oauth.LoginWithPassw
 	}
 
 	err = o.authentication.addClientAuthenticationToURLValues(body.ClientAuthentication, data, false)
-
 	if err != nil {
 		return
 	}
@@ -99,7 +97,6 @@ func (o *OAuth) LoginWithAuthCode(ctx context.Context, body oauth.LoginWithAuthC
 	}
 
 	err = o.authentication.addClientAuthenticationToURLValues(body.ClientAuthentication, data, true)
-
 	if err != nil {
 		return
 	}
@@ -127,7 +124,6 @@ func (o *OAuth) LoginWithAuthCodeWithPKCE(ctx context.Context, body oauth.LoginW
 	}
 
 	err = o.authentication.addClientAuthenticationToURLValues(body.ClientAuthentication, data, false)
-
 	if err != nil {
 		return
 	}
@@ -157,7 +153,6 @@ func (o *OAuth) LoginWithClientCredentials(ctx context.Context, body oauth.Login
 	}
 
 	err = o.authentication.addClientAuthenticationToURLValues(body.ClientAuthentication, data, true)
-
 	if err != nil {
 		return
 	}
@@ -180,7 +175,6 @@ func (o *OAuth) RefreshToken(ctx context.Context, body oauth.RefreshTokenRequest
 	}
 
 	err = o.authentication.addClientAuthenticationToURLValues(body.ClientAuthentication, data, false)
-
 	if err != nil {
 		return
 	}
@@ -244,13 +238,11 @@ func (o *OAuth) PushedAuthorization(ctx context.Context, body oauth.PushedAuthor
 	}
 
 	err = o.authentication.addClientAuthenticationToURLValues(body.ClientAuthentication, data, true)
-
 	if err != nil {
 		return nil, err
 	}
 
 	err = o.authentication.Request(ctx, "POST", o.authentication.URI("oauth", "par"), data, &p, opts...)
-
 	if err != nil {
 		return nil, err
 	}

--- a/authentication/oauth/oauth.go
+++ b/authentication/oauth/oauth.go
@@ -1,3 +1,4 @@
+// Package oauth provides types for the Auth0 OAuth authentication endpoints.
 package oauth
 
 import "time"

--- a/authentication/oauth_test.go
+++ b/authentication/oauth_test.go
@@ -586,7 +586,6 @@ func withIDToken(t *testing.T, extras map[string]interface{}) (*Authentication, 
 	}
 
 	token, err := builder.Build()
-
 	if err != nil {
 		return nil, err
 	}

--- a/authentication/passwordless.go
+++ b/authentication/passwordless.go
@@ -50,7 +50,6 @@ func (p *Passwordless) LoginWithEmail(ctx context.Context, params passwordless.L
 			Nonce:        validationOptions.Nonce,
 			Organization: validationOptions.Organization,
 		})
-
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +82,6 @@ func (p *Passwordless) SendSMS(ctx context.Context, params passwordless.SendSMSR
 // See: https://auth0.com/docs/api/authentication?http#authenticate-user
 func (p *Passwordless) LoginWithSMS(ctx context.Context, params passwordless.LoginWithSMSRequest, validationOptions oauth.IDTokenValidationOptions, opts ...RequestOption) (t *oauth.TokenSet, err error) {
 	err = p.authentication.addClientAuthenticationToClientAuthStruct(&params.ClientAuthentication, false)
-
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +97,6 @@ func (p *Passwordless) LoginWithSMS(ctx context.Context, params passwordless.Log
 			Nonce:        validationOptions.Nonce,
 			Organization: validationOptions.Organization,
 		})
-
 		if err != nil {
 			return nil, err
 		}

--- a/authentication/passwordless/passwordless.go
+++ b/authentication/passwordless/passwordless.go
@@ -1,3 +1,4 @@
+// Package passwordless provides types for the Auth0 passwordless authentication endpoints.
 package passwordless
 
 import "github.com/auth0/go-auth0/v2/authentication/oauth"

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,3 +1,4 @@
+// Package client provides the internal HTTP client used by the Auth0 SDK.
 package client
 
 import (

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -822,6 +822,7 @@ func TestWrapAuth0ClientInfo(t *testing.T) {
 			assert.NoError(t, err)
 
 			var auth0Client Auth0ClientInfo
+
 			err = json.Unmarshal(auth0ClientDecoded, &auth0Client)
 			assert.NoError(t, err)
 

--- a/internal/client/jwt_token_source_test.go
+++ b/internal/client/jwt_token_source_test.go
@@ -196,6 +196,7 @@ func TestECClientAssertion(t *testing.T) {
 
 	// Parse the header as JSON
 	var header map[string]interface{}
+
 	err = json.Unmarshal(headerBytes, &header)
 	require.NoError(t, err)
 
@@ -287,7 +288,7 @@ func TestPrivateKeyJwtTokenSource(t *testing.T) {
 
 		// Return a mock token
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{
+		_, _ = w.Write([]byte(`{
 			"access_token": "mock-access-token",
 			"token_type": "Bearer",
 			"expires_in": 3600
@@ -332,7 +333,7 @@ func TestPrivateKeyJwtTokenSourceRefresh(t *testing.T) {
 
 		// Return a token with short expiration
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(fmt.Appendf(nil, `{
+		_, _ = w.Write(fmt.Appendf(nil, `{
             "access_token": "mock-token-%d",
             "token_type": "Bearer",
             "expires_in": 2
@@ -428,7 +429,7 @@ func TestPrivateKeyJwtTokenSourceErrors(t *testing.T) {
 		// Create a server that returns an error
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(`{"error": "server_error"}`))
+			_, _ = w.Write([]byte(`{"error": "server_error"}`))
 		}))
 		defer server.Close()
 

--- a/internal/idtokenvalidator/idtokenvalidator_option.go
+++ b/internal/idtokenvalidator/idtokenvalidator_option.go
@@ -1,3 +1,4 @@
+// Package idtokenvalidator provides ID token validation for the Auth0 SDK.
 package idtokenvalidator
 
 import (

--- a/internal/idtokenvalidator/idtokenvalidator_test.go
+++ b/internal/idtokenvalidator/idtokenvalidator_test.go
@@ -611,7 +611,6 @@ func givenAJWT(t *testing.T, args jwtArgs) (string, *httptest.Server, error) {
 	}
 
 	token, err := builder.Build()
-
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/tag/tag.go
+++ b/internal/tag/tag.go
@@ -1,3 +1,4 @@
+// Package tag provides struct tag parsing utilities.
 package tag
 
 import (


### PR DESCRIPTION
<!--
By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- **Lint scope**: Exclude `management/` from lint targets in both `Makefile` and CI workflow since it is auto-generated and not yet linted. This avoids loading 278 sub-packages during lint, significantly reducing lint execution time.
- **Upgrade `wsl` to `wsl_v5`**: Replace deprecated `wsl` linter with `wsl_v5` and configure its settings.
- **Remove stale exclusion rules**: Remove suppression rules for `response.Body.Close`, `w.Write`, `G307`, and missing package comments — fix the underlying issues instead.
- **Fix `response.Body.Close`**: Use `defer func() { _ = response.Body.Close() }()` to properly handle the error return value and avoid the deferred unsafe Close warning.
- **Fix unchecked `w.Write`**: Explicitly discard return values with `_, _ = w.Write(...)` in test HTTP handlers.
- **Add package comments**: Add doc comments to `auth0`, `database`, `passwordless`, `ciba`, `oauth`, `mfa`, `client`, `idtokenvalidator`, and `tag` packages.

### 📚 References

- golangci-lint v2 `wsl` deprecation notice recommending migration to `wsl_v5`

### 🔬 Testing

- `golangci-lint run --fix -c .golangci.yml . ./authentication/... ./internal/...` passes with 0 issues.
- All existing tests remain unaffected.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)