### PR TITLE
fix: serialize client assertion aud claim as string instead of array

### DIFF
--- a/internal/client/jwt_token_source.go
+++ b/internal/client/jwt_token_source.go
@@ -139,6 +139,10 @@ func CreateClientAssertion(alg jwa.SignatureAlgorithm, signingKey, clientID, aud
 		return "", fmt.Errorf("failed to build JWT: %w", err)
 	}
 
+	// Serialize "aud" as a string instead of a single-element array,
+	// as required by some authorization servers for client assertions.
+	token.Options().Enable(jwt.FlattenAudience)
+
 	signedToken, err := jwt.Sign(token, jwt.WithKey(alg, key))
 	if err != nil {
 		return "", fmt.Errorf("failed to sign JWT: %w", err)

--- a/internal/client/jwt_token_source_test.go
+++ b/internal/client/jwt_token_source_test.go
@@ -112,6 +112,24 @@ func TestClientAssertion(t *testing.T) {
 	require.Len(t, audiences, 1)
 	assert.Equal(t, ts.audience, audiences[0])
 
+	// Verify that the "aud" claim is serialized as a string, not an array.
+	parts := strings.Split(assertion, ".")
+	require.Len(t, parts, 3, "JWT should have 3 parts")
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+
+	var claims map[string]interface{}
+
+	err = json.Unmarshal(payloadBytes, &claims)
+	require.NoError(t, err)
+
+	audValue, ok := claims["aud"]
+	require.True(t, ok, "aud claim should be present")
+
+	_, isString := audValue.(string)
+	assert.True(t, isString, "aud claim should be a string, not an array")
+
 	// Check expiration
 	now := time.Now()
 	assert.True(t, parsedToken.IssuedAt().Before(now) || parsedToken.IssuedAt().Equal(now))


### PR DESCRIPTION
### 🔧 Changes

The `aud` claim in client assertion JWTs was being serialized as a single-element JSON array (e.g. `["https://domain.auth0.com/"]`) instead of a plain string (`"https://domain.auth0.com/"`). Some authorization servers reject the array form for client assertions.

This change enables `jwt.FlattenAudience` per-token in `CreateClientAssertion` so the `aud` claim is always emitted as a string when there is a single audience value.

### 📚 References

- [RFC 7523 Section 3](https://datatracker.ietf.org/doc/html/rfc7523#section-3) — JWT Profile for OAuth 2.0 Client Authentication
- [lestrrat-go/jwx FlattenAudience docs](https://github.com/lestrrat-go/jwx/blob/main/docs/01-jwt.md#flatten-audience)

### 🔬 Testing

- Added test assertion in `TestClientAssertion` that decodes the JWT payload and verifies the `aud` claim is a JSON string, not an array.
- All existing tests in `./internal/client/...` pass.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)