### PR TITLE
feat: MyOrg Details & IdP support on v1

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -215,6 +215,19 @@ type Client struct {
 	// ExpressConfiguration holds the express configuration for the client.
 	// Application-specific configuration for use with the OIN Express Configuration feature
 	ExpressConfiguration *ExpressConfiguration `json:"express_configuration,omitempty"`
+
+	// MyOrganizationConfiguration holds the configuration for self-service organization
+	// features, controlling how organizations are created and managed for this client.
+	//
+	// To unset values (set to null), use a PATCH request like this:
+	// PATCH /api/v2/clients/{id}
+	// {
+	//	 "my_organization_configuration": null
+	// }
+	//
+	// For more details on making custom requests, refer to the Auth0 Go SDK examples:
+	// https://github.com/auth0/go-auth0/blob/main/EXAMPLES.md#providing-a-custom-user-struct
+	MyOrganizationConfiguration *MyOrganizationConfiguration `json:"my_organization_configuration,omitempty"`
 }
 
 // ExpressConfiguration represents the OIN Express Configuration settings for a client.
@@ -246,6 +259,28 @@ type ExpressConfiguration struct {
 type LinkedClient struct {
 	// ClientID is the ID of the linked client.
 	ClientID *string `json:"client_id,omitempty"`
+}
+
+// MyOrganizationConfiguration represents the self-service organization configuration
+// for a client application. It controls how organizations are created and managed,
+// including which connection strategies are allowed and how connection deletion is handled.
+type MyOrganizationConfiguration struct {
+	// ConnectionProfileID is the ID of the connection profile to use when creating
+	// organizations for this client.
+	ConnectionProfileID *string `json:"connection_profile_id,omitempty"`
+
+	// UserAttributeProfileID is the ID of the user attribute profile to use when
+	// creating organizations for this client.
+	UserAttributeProfileID *string `json:"user_attribute_profile_id,omitempty"`
+
+	// AllowedStrategies is the list of connection strategies that are allowed when
+	// creating organizations for this client (e.g. "okta", "samlp").
+	AllowedStrategies *[]string `json:"allowed_strategies,omitempty"`
+
+	// ConnectionDeletionBehavior controls the behavior when deleting connections
+	// associated with organizations for this client.
+	// Possible values: "allow", "allow_if_empty".
+	ConnectionDeletionBehavior *string `json:"connection_deletion_behavior,omitempty"`
 }
 
 // ClientTokenExchange allows configuration for token exchange.

--- a/management/client_test.go
+++ b/management/client_test.go
@@ -1304,6 +1304,78 @@ func TestClient_OrganizationDiscoveryMethods(t *testing.T) {
 			cleanupClient(t, client.GetClientID())
 		})
 	})
+
+	t.Run("Full lifecycle of organization discovery methods", func(t *testing.T) {
+		ctx := context.Background()
+
+		// Step 1: Create a client with organization_usage "require",
+		// organization_require_behavior "pre_login_prompt", and
+		// organization_discovery_methods ["email"].
+		client := &Client{
+			Name:                         auth0.Stringf("Test Client (%s)", time.Now().Format(time.StampMilli)),
+			OIDCConformant:               auth0.Bool(true),
+			OrganizationUsage:            auth0.String("require"),
+			OrganizationRequireBehavior:  auth0.String("pre_login_prompt"),
+			OrganizationDiscoveryMethods: &[]string{"email"},
+		}
+
+		err := api.Client.Create(ctx, client)
+		require.NoError(t, err)
+		require.NotEmpty(t, client.GetClientID())
+
+		t.Cleanup(func() {
+			cleanupClient(t, client.GetClientID())
+		})
+
+		assert.Equal(t, "require", client.GetOrganizationUsage())
+		assert.Equal(t, "pre_login_prompt", client.GetOrganizationRequireBehavior())
+		assert.NotNil(t, client.OrganizationDiscoveryMethods)
+		assert.Contains(t, *client.OrganizationDiscoveryMethods, "email")
+
+		// Step 2: Read the client back and verify organization_discovery_methods
+		// contains ["email"]
+		retrievedClient, err := api.Client.Read(ctx, client.GetClientID())
+		require.NoError(t, err)
+		assert.Equal(t, "require", retrievedClient.GetOrganizationUsage())
+		assert.Equal(t, "pre_login_prompt", retrievedClient.GetOrganizationRequireBehavior())
+		assert.NotNil(t, retrievedClient.OrganizationDiscoveryMethods)
+		assert.ElementsMatch(t, []string{"email"}, *retrievedClient.OrganizationDiscoveryMethods)
+
+		// Step 3: Patch the client to change organization_usage to "allow" while
+		// organization_require_behavior remains "pre_login_prompt".
+		err = api.Client.Update(ctx, client.GetClientID(), &Client{
+			OrganizationUsage: auth0.String("allow"),
+		})
+		require.NoError(t, err)
+
+		patchedClient, err := api.Client.Read(ctx, client.GetClientID())
+		require.NoError(t, err)
+		assert.Equal(t, "allow", patchedClient.GetOrganizationUsage())
+		assert.Equal(t, "pre_login_prompt", patchedClient.GetOrganizationRequireBehavior())
+		assert.NotNil(t, patchedClient.GetOrganizationDiscoveryMethods())
+		assert.Contains(t, patchedClient.GetOrganizationDiscoveryMethods(), "email")
+
+		// Step 4: Patch the client to remove organization_discovery_methods (set to null)
+		// and change organization_require_behavior to "post_login_prompt".
+		// Since omitempty prevents sending null, use custom raw request.
+		type clientPatchNullDiscovery struct {
+			OrganizationRequireBehavior  *string   `json:"organization_require_behavior,omitempty"`
+			OrganizationDiscoveryMethods *[]string `json:"organization_discovery_methods"` // no omitempty to allow null.
+		}
+
+		patch := &clientPatchNullDiscovery{
+			OrganizationRequireBehavior:  auth0.String("post_login_prompt"),
+			OrganizationDiscoveryMethods: nil,
+		}
+		err = api.Request(ctx, http.MethodPatch, api.URI("clients", client.GetClientID()), patch)
+		require.NoError(t, err)
+
+		finalClient, err := api.Client.Read(ctx, client.GetClientID())
+		require.NoError(t, err)
+		assert.Equal(t, "allow", finalClient.GetOrganizationUsage())
+		assert.Equal(t, "post_login_prompt", finalClient.GetOrganizationRequireBehavior())
+		assert.Nil(t, finalClient.OrganizationDiscoveryMethods)
+	})
 }
 
 func cleanupCredential(t *testing.T, clientID string, credentialID string) {
@@ -1477,6 +1549,66 @@ aibASY5pIRiKENmbZELDtucCAwEAAQ==
 		assert.GreaterOrEqual(t, len(*createdClient.ExpressConfiguration.LinkedClients), 1)
 		assert.Equal(t, linkedWebClient.GetClientID(), (*createdClient.ExpressConfiguration.LinkedClients)[0].GetClientID())
 	})
+}
+
+func TestClient_MyOrganizationConfiguration(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	ctx := context.Background()
+	userAttributeProfile := givenAUserAttributeProfile(t)
+	// Case : Create a client with full my_organization_configuration fields.
+	fullStrategies := []string{"pingfederate", "adfs", "waad", "google-apps", "okta", "oidc", "samlp"}
+	clientWith := &Client{
+		Name:        auth0.Stringf("Test Client Full MyOrgConfig (%s)", time.Now().Format(time.StampMilli)),
+		Description: auth0.String("Client with full my_organization_configuration."),
+		MyOrganizationConfiguration: &MyOrganizationConfiguration{
+			ConnectionProfileID:        auth0.String("cop_1cu7hYRotxr9BYXXwLH14g"),
+			UserAttributeProfileID:     auth0.String(userAttributeProfile.GetID()),
+			AllowedStrategies:          &fullStrategies,
+			ConnectionDeletionBehavior: auth0.String("allow"),
+		},
+	}
+	err := api.Client.Create(ctx, clientWith)
+	require.NoError(t, err)
+	require.NotEmpty(t, clientWith.GetClientID())
+	t.Cleanup(func() {
+		cleanupClient(t, clientWith.GetClientID())
+	})
+
+	require.NotNil(t, clientWith.GetMyOrganizationConfiguration())
+	assert.Equal(t, "cop_1cu7hYRotxr9BYXXwLH14g", clientWith.GetMyOrganizationConfiguration().GetConnectionProfileID())
+	assert.Equal(t, userAttributeProfile.GetID(), clientWith.GetMyOrganizationConfiguration().GetUserAttributeProfileID())
+	assert.ElementsMatch(t, fullStrategies, clientWith.GetMyOrganizationConfiguration().GetAllowedStrategies())
+	assert.Equal(t, "allow", clientWith.GetMyOrganizationConfiguration().GetConnectionDeletionBehavior())
+
+	// Case: Create a client with wrong connection_profile_id / user_attribute_profile_id (404).
+	clientBadProfile := &Client{
+		Name: auth0.Stringf("Test Client Bad Profile (%s)", time.Now().Format(time.StampMilli)),
+		MyOrganizationConfiguration: &MyOrganizationConfiguration{
+			ConnectionProfileID:        auth0.String("cop_WRONG"),
+			UserAttributeProfileID:     auth0.String("uap_WRONG"),
+			AllowedStrategies:          &fullStrategies,
+			ConnectionDeletionBehavior: auth0.String("allow"),
+		},
+	}
+	err = api.Client.Create(ctx, clientBadProfile)
+	require.Error(t, err)
+	assert.Implements(t, (*Error)(nil), err)
+	assert.Equal(t, http.StatusBadRequest, err.(Error).Status())
+
+	// Case: List and Read clients to verify my_organization_configuration is present.
+	clientList, err := api.Client.List(ctx, IncludeFields("client_id", "my_organization_configuration"))
+	require.NoError(t, err)
+	assert.Greater(t, len(clientList.Clients), 0)
+
+	// Case: Read the specific client and verify my_organization_configuration fields.
+	readClient, err := api.Client.Read(ctx, clientWith.GetClientID())
+	require.NoError(t, err)
+	require.NotNil(t, readClient.GetMyOrganizationConfiguration())
+	assert.Equal(t, "cop_1cu7hYRotxr9BYXXwLH14g", readClient.GetMyOrganizationConfiguration().GetConnectionProfileID())
+	assert.Equal(t, userAttributeProfile.GetID(), readClient.GetMyOrganizationConfiguration().GetUserAttributeProfileID())
+	assert.ElementsMatch(t, fullStrategies, readClient.GetMyOrganizationConfiguration().GetAllowedStrategies())
+	assert.Equal(t, "allow", readClient.GetMyOrganizationConfiguration().GetConnectionDeletionBehavior())
 }
 
 func givenAnExpressConfigurationClient(t *testing.T) *Client {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1935,6 +1935,14 @@ func (c *Client) GetMobile() *ClientMobile {
 	return c.Mobile
 }
 
+// GetMyOrganizationConfiguration returns the MyOrganizationConfiguration field.
+func (c *Client) GetMyOrganizationConfiguration() *MyOrganizationConfiguration {
+	if c == nil {
+		return nil
+	}
+	return c.MyOrganizationConfiguration
+}
+
 // GetName returns the Name field if it's non-nil, zero value otherwise.
 func (c *Client) GetName() string {
 	if c == nil || c.Name == nil {
@@ -10076,6 +10084,43 @@ func (m *MultiFactorWebAuthnSettings) GetUserVerification() string {
 
 // String returns a string representation of MultiFactorWebAuthnSettings.
 func (m *MultiFactorWebAuthnSettings) String() string {
+	return Stringify(m)
+}
+
+// GetAllowedStrategies returns the AllowedStrategies field if it's non-nil, zero value otherwise.
+func (m *MyOrganizationConfiguration) GetAllowedStrategies() []string {
+	if m == nil || m.AllowedStrategies == nil {
+		return nil
+	}
+	return *m.AllowedStrategies
+}
+
+// GetConnectionDeletionBehavior returns the ConnectionDeletionBehavior field if it's non-nil, zero value otherwise.
+func (m *MyOrganizationConfiguration) GetConnectionDeletionBehavior() string {
+	if m == nil || m.ConnectionDeletionBehavior == nil {
+		return ""
+	}
+	return *m.ConnectionDeletionBehavior
+}
+
+// GetConnectionProfileID returns the ConnectionProfileID field if it's non-nil, zero value otherwise.
+func (m *MyOrganizationConfiguration) GetConnectionProfileID() string {
+	if m == nil || m.ConnectionProfileID == nil {
+		return ""
+	}
+	return *m.ConnectionProfileID
+}
+
+// GetUserAttributeProfileID returns the UserAttributeProfileID field if it's non-nil, zero value otherwise.
+func (m *MyOrganizationConfiguration) GetUserAttributeProfileID() string {
+	if m == nil || m.UserAttributeProfileID == nil {
+		return ""
+	}
+	return *m.UserAttributeProfileID
+}
+
+// String returns a string representation of MyOrganizationConfiguration.
+func (m *MyOrganizationConfiguration) String() string {
 	return Stringify(m)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2445,6 +2445,13 @@ func TestClient_GetMobile(tt *testing.T) {
 	c.GetMobile()
 }
 
+func TestClient_GetMyOrganizationConfiguration(tt *testing.T) {
+	c := &Client{}
+	c.GetMyOrganizationConfiguration()
+	c = nil
+	c.GetMyOrganizationConfiguration()
+}
+
 func TestClient_GetName(tt *testing.T) {
 	var zeroValue string
 	c := &Client{Name: &zeroValue}
@@ -12613,6 +12620,54 @@ func TestMultiFactorWebAuthnSettings_GetUserVerification(tt *testing.T) {
 func TestMultiFactorWebAuthnSettings_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &MultiFactorWebAuthnSettings{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestMyOrganizationConfiguration_GetAllowedStrategies(tt *testing.T) {
+	var zeroValue []string
+	m := &MyOrganizationConfiguration{AllowedStrategies: &zeroValue}
+	m.GetAllowedStrategies()
+	m = &MyOrganizationConfiguration{}
+	m.GetAllowedStrategies()
+	m = nil
+	m.GetAllowedStrategies()
+}
+
+func TestMyOrganizationConfiguration_GetConnectionDeletionBehavior(tt *testing.T) {
+	var zeroValue string
+	m := &MyOrganizationConfiguration{ConnectionDeletionBehavior: &zeroValue}
+	m.GetConnectionDeletionBehavior()
+	m = &MyOrganizationConfiguration{}
+	m.GetConnectionDeletionBehavior()
+	m = nil
+	m.GetConnectionDeletionBehavior()
+}
+
+func TestMyOrganizationConfiguration_GetConnectionProfileID(tt *testing.T) {
+	var zeroValue string
+	m := &MyOrganizationConfiguration{ConnectionProfileID: &zeroValue}
+	m.GetConnectionProfileID()
+	m = &MyOrganizationConfiguration{}
+	m.GetConnectionProfileID()
+	m = nil
+	m.GetConnectionProfileID()
+}
+
+func TestMyOrganizationConfiguration_GetUserAttributeProfileID(tt *testing.T) {
+	var zeroValue string
+	m := &MyOrganizationConfiguration{UserAttributeProfileID: &zeroValue}
+	m.GetUserAttributeProfileID()
+	m = &MyOrganizationConfiguration{}
+	m.GetUserAttributeProfileID()
+	m = nil
+	m.GetUserAttributeProfileID()
+}
+
+func TestMyOrganizationConfiguration_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &MyOrganizationConfiguration{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/test/data/recordings/TestClient_MyOrganizationConfiguration.yaml
+++ b/test/data/recordings/TestClient_MyOrganizationConfiguration.yaml
@@ -1,0 +1,243 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 824
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test User Attribute Profile (Mar 31 11:47:34.824)","user_id":{"oidc_mapping":"sub","saml_mapping":["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"],"scim_mapping":"userName"},"user_attributes":{"email":{"description":"User's email address","label":"Email","profile_required":true,"auth0_mapping":"email","oidc_mapping":{"mapping":"email"},"saml_mapping":["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"],"scim_mapping":"emails[primary eq true].value"},"name":{"description":"User's full name","label":"Name","profile_required":false,"auth0_mapping":"name","oidc_mapping":{"mapping":"email"},"saml_mapping":["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"],"scim_mapping":"displayName","strategy_overrides":{"oidc":{"scim_mapping":"name.givenName"}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/user-attribute-profiles
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 857
+        uncompressed: false
+        body: '{"id":"uap_1cyzEQFSNB3A82BQCargzi","name":"Test User Attribute Profile (Mar 31 11:47:34.824)","user_id":{"oidc_mapping":"sub","saml_mapping":["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"],"scim_mapping":"userName"},"user_attributes":{"name":{"label":"Name","description":"User''s full name","oidc_mapping":{"mapping":"email"},"saml_mapping":["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"],"scim_mapping":"displayName","auth0_mapping":"name","profile_required":false,"strategy_overrides":{"oidc":{"scim_mapping":"name.givenName"}}},"email":{"label":"Email","description":"User''s email address","oidc_mapping":{"mapping":"email"},"saml_mapping":["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"],"scim_mapping":"emails[primary eq true].value","auth0_mapping":"email","profile_required":true}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1.002260833s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 397
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client Full MyOrgConfig (Mar 31 11:47:35.828)","description":"Client with full my_organization_configuration.","my_organization_configuration":{"connection_profile_id":"cop_1cu7hYRotxr9BYXXwLH14g","user_attribute_profile_id":"uap_1cyzEQFSNB3A82BQCargzi","allowed_strategies":["pingfederate","adfs","waad","google-apps","okta","oidc","samlp"],"connection_deletion_behavior":"allow"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client Full MyOrgConfig (Mar 31 11:47:35.828)","description":"Client with full my_organization_configuration.","client_id":"xPkWwI7ROs4DbniMiwKfs5W0dq94tfP6","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"my_organization_configuration":{"connection_profile_id":"cop_1cu7hYRotxr9BYXXwLH14g","user_attribute_profile_id":"uap_1cyzEQFSNB3A82BQCargzi","allowed_strategies":["pingfederate","adfs","waad","google-apps","okta","oidc","samlp"],"connection_deletion_behavior":"allow"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 543.97975ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 294
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client Bad Profile (Mar 31 11:47:36.373)","my_organization_configuration":{"connection_profile_id":"cop_WRONG","user_attribute_profile_id":"uap_WRONG","allowed_strategies":["pingfederate","adfs","waad","google-apps","okta","oidc","samlp"],"connection_deletion_behavior":"allow"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 570
+        uncompressed: false
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 328.550917ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients?fields=client_id%2Cmy_organization_configuration&include_fields=true&include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"total":98,"start":0,"limit":50,"clients":[{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"u15kDcCf5WRegxf93WUzGNcoAMaedsDZ"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"T2QUXhLciH0CSlDCICirlExjNDIrsHJQ"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"z8LPbXcO2vfnz6Xq0fERNCbJhvBL1Prp"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"spOzDv4VNJc9yHh6NPOFLaOkttZ8cSKd"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"QjlAo2nIDERZYBBZozsv8apykJUBtCq4"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"GjP0CbEjCSSqMuG4EJcM42qQ9RwKsnMN"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"xZZtIIMJhPHjhFPwzi3asd6BaxsCWzh1"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"3ihEwMkDE0Jr4zWedAEvZDxgrPUarLKW"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"ayEdCv8BWKHzBKvNaBklfyw2BCWOchVw"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"O1ID0X3Vc4qHddCqHvlSvUi7wkhCG95l"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"BXUQ69RCKtH2Ef0kqQv2zIKW8gH9JdDz"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"xnpDN2UWVErhZEbWnXamXIxuqmDpn4Az"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"z0mDTXWYSaJwwaSw1A4MYoKz5w32HTy9"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"Tp16hZC8S7veGbeOX3lCYZMiNRhgIDOm"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"ST1BDB1sYqZtBpPHr0DP3GWGjye6vc2q"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"scCKDRkV4gnlzRujGEsAzss1UzXsrZN4"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"YM1Vheva4Zwf5iFzCNkLWOFG0ussmNjx"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"SysBSYT6saHyUk1qGcNT1sqx7poaawWi"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"i2ibhCdV0ZwxyAc9wdrvD0pIKTY2MdSi"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"RfUulaWtmglkg5dkVtht4fizwo0eg1q6"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"2mVXzDq4o8fkw2BuCdp1JJgV7cpb17MK"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"qmDEJnHTKw3ErCuOiOQ9Pub0sAUFlu5g"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"1bnDcBxbOcRNPvEYaOxqqkdSKDl6HIs8"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"5phgz9FlzUBpj9rKWGAALwCPaA04wS3s"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"dRqU4bTHsKgWE0c4mmaThMjPh6vM892U"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"2wnR7jYX71gpFVMbFFTZImHjIkt0rBcN"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"cq11NfGObmpEF1rkxrVuxiqJwdhJ6RBj"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"h32sYvZ6Zw2ymOueiP2NfP6UxidMkFjU"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"h33wMvZBp1WWCmbXpfDas21mnFZ6NhKo"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"RvGGHnAEV9ntaJJnkx4gIn5aonEcfBjq"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"EVwx6SzCkjzOogFDsvvAWyP3CFERuywq"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"9osqksGUVVEYiRpSspRGMGh7hkIOI0f2"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"0TBgiKIZcbJRUN0ytutidmSawarNnKKn"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"uPY2xJFVPBcAK6DFV3Yylh2VjbSbymXp"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"qnTD8C0YiZ4AtqrcEdLVxfZQVyNoRkzo"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"SWcKvYbiAX2JqXoRYo5erRCNLPPwwHwC"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"Mu6jpTsoQQeo8Oe7kbST8Nn2RTJ5Jiip"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"90jnMipR6Nn0LGYlmlnHHZAdpZEomrDB"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"LBcuLdCG239P6VZAPTKe0HO9HzeiXJAy"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"JEFspe0OmusrVMSqOQIUxDEd05RLzpyb"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"wA22PRFKkbbBbmx3r9r877icaGjIdDbu"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"ZoLO1VHXjTa0QqbK5JsY7bsw8nXssBdM"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"S6lCCvi22KfjHfw6UTlzpkVEDZgKgZDE"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"dxiJDl5Ajm9RKNyylUyDKkNYrXPYSFKI"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"nQmFicT7w93QmvKrTuyVHnMo1UU9K9VC"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"8jz7NshbkgHoba2OxkOPrPdmjvCqnydD"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"qCUs3NwWC2rUXc5PoEGa0efkuWtjtLjG"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"fg9u744w7mVv0dj8CgG2wr2sg3iWriBL"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"4X989WhMxaCBsPnvV8HYCgOrdXpKSREf"},{"tenant":"go-auth0-dev.eu.auth0.com","client_id":"0l7SK3RVZEAcZkq0T6dOdMjQe60uDF7j"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 582.517208ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/xPkWwI7ROs4DbniMiwKfs5W0dq94tfP6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Test Client Full MyOrgConfig (Mar 31 11:47:35.828)","description":"Client with full my_organization_configuration.","client_id":"xPkWwI7ROs4DbniMiwKfs5W0dq94tfP6","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"my_organization_configuration":{"connection_profile_id":"cop_1cu7hYRotxr9BYXXwLH14g","user_attribute_profile_id":"uap_1cyzEQFSNB3A82BQCargzi","allowed_strategies":["pingfederate","adfs","waad","google-apps","okta","oidc","samlp"],"connection_deletion_behavior":"allow"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 337.167375ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/xPkWwI7ROs4DbniMiwKfs5W0dq94tfP6
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 413.382542ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/user-attribute-profiles/uap_1cyzEQFSNB3A82BQCargzi
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 560.87975ms

--- a/test/data/recordings/TestClient_OrganizationDiscoveryMethods.yaml
+++ b/test/data/recordings/TestClient_OrganizationDiscoveryMethods.yaml
@@ -13,13 +13,13 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test Client (Sep 26 12:14:51.749)","description":"This is a test client with organization discovery methods.","organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email","organization_name"]}
+            {"name":"Test Client (Mar 31 11:47:22.041)","description":"This is a test client with organization discovery methods.","organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email","organization_name"]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.28.0
+                - Go-Auth0/1.36.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"name":"Test Client (Sep 26 12:14:51.749)","description":"This is a test client with organization discovery methods.","client_id":"vd7TGcJWd9JvQxGVohqXfafPAyGFZoml","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email","organization_name"]}'
+        body: '{"name":"Test Client (Mar 31 11:47:22.041)","description":"This is a test client with organization discovery methods.","client_id":"TRgCXOL4VkPri9m95qdwYIxLFIP6ZaOU","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email","organization_name"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 1.036854708s
+        duration: 1.033746167s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -52,8 +52,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.28.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/vd7TGcJWd9JvQxGVohqXfafPAyGFZoml
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/TRgCXOL4VkPri9m95qdwYIxLFIP6ZaOU
         method: GET
       response:
         proto: HTTP/2.0
@@ -63,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Test Client (Sep 26 12:14:51.749)","description":"This is a test client with organization discovery methods.","client_id":"vd7TGcJWd9JvQxGVohqXfafPAyGFZoml","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email","organization_name"]}'
+        body: '{"name":"Test Client (Mar 31 11:47:22.041)","description":"This is a test client with organization discovery methods.","client_id":"TRgCXOL4VkPri9m95qdwYIxLFIP6ZaOU","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email","organization_name"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 226.535541ms
+        duration: 375.249875ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -85,8 +85,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.28.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/vd7TGcJWd9JvQxGVohqXfafPAyGFZoml
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/TRgCXOL4VkPri9m95qdwYIxLFIP6ZaOU
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -102,7 +102,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 304.531833ms
+        duration: 432.098084ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,13 +115,13 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test Client (Sep 26 12:14:53.320)","description":"This is a test client for updating discovery methods.","organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email"]}
+            {"name":"Test Client (Mar 31 11:47:23.885)","description":"This is a test client for updating discovery methods.","organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email"]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.28.0
+                - Go-Auth0/1.36.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
         method: POST
       response:
@@ -132,13 +132,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"name":"Test Client (Sep 26 12:14:53.320)","description":"This is a test client for updating discovery methods.","client_id":"Yar6aO2yYQnAoToGEt4Zzu7RjOvinjZw","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email"]}'
+        body: '{"name":"Test Client (Mar 31 11:47:23.885)","description":"This is a test client for updating discovery methods.","client_id":"TN1hfTjEdxcW8XahAq0t9DTysBuvFIAr","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 426.180167ms
+        duration: 479.500541ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -157,8 +157,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.28.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/Yar6aO2yYQnAoToGEt4Zzu7RjOvinjZw
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/TN1hfTjEdxcW8XahAq0t9DTysBuvFIAr
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -168,13 +168,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Test Client (Sep 26 12:14:53.320)","description":"This is a test client for updating discovery methods.","client_id":"Yar6aO2yYQnAoToGEt4Zzu7RjOvinjZw","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email","organization_name"]}'
+        body: '{"name":"Test Client (Mar 31 11:47:23.885)","description":"This is a test client for updating discovery methods.","client_id":"TN1hfTjEdxcW8XahAq0t9DTysBuvFIAr","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email","organization_name"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 265.760208ms
+        duration: 404.532083ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -190,8 +190,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.28.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/Yar6aO2yYQnAoToGEt4Zzu7RjOvinjZw
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/TN1hfTjEdxcW8XahAq0t9DTysBuvFIAr
         method: GET
       response:
         proto: HTTP/2.0
@@ -201,13 +201,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Test Client (Sep 26 12:14:53.320)","description":"This is a test client for updating discovery methods.","client_id":"Yar6aO2yYQnAoToGEt4Zzu7RjOvinjZw","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email","organization_name"]}'
+        body: '{"name":"Test Client (Mar 31 11:47:23.885)","description":"This is a test client for updating discovery methods.","client_id":"TN1hfTjEdxcW8XahAq0t9DTysBuvFIAr","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email","organization_name"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 273.62875ms
+        duration: 352.915708ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -223,8 +223,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.28.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/Yar6aO2yYQnAoToGEt4Zzu7RjOvinjZw
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/TN1hfTjEdxcW8XahAq0t9DTysBuvFIAr
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -240,4 +240,244 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 362.77225ms
+        duration: 431.502417ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 193
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client (Mar 31 11:47:25.557)","oidc_conformant":true,"organization_usage":"require","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email"]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client (Mar 31 11:47:25.557)","client_id":"JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"require","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 490.960375ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Test Client (Mar 31 11:47:25.557)","client_id":"JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"require","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 361.154958ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 31
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"organization_usage":"allow"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Test Client (Mar 31 11:47:25.557)","client_id":"JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 364.21725ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Test Client (Mar 31 11:47:25.557)","client_id":"JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"pre_login_prompt","organization_discovery_methods":["email"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 366.103834ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 92
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"organization_require_behavior":"post_login_prompt","organization_discovery_methods":null}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Test Client (Mar 31 11:47:25.557)","client_id":"JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"post_login_prompt"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 373.409833ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Test Client (Mar 31 11:47:25.557)","client_id":"JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"organization_usage":"allow","organization_require_behavior":"post_login_prompt"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 343.990708ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.36.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/JckbLAVfDRHFXGTmnadMUGhTZLlMgTh7
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 446.592792ms


### PR DESCRIPTION
This PR adds support for setting `my_organization_configuration` for Auth0 Clients

### 🔧 Changes

Introduced new property `MyOrganizationConfiguration`

### 📚 References

Example:


```go
        strategies := []string{"pingfederate", "oidc", "samlp"}
        client := &Client{
		Name:        auth0.Stringf("Testing Client"),
		Description: auth0.String("Client with my_organization_configuration."),
		MyOrganizationConfiguration: &MyOrganizationConfiguration{
			ConnectionProfileID:        auth0.String("cop_xxxxxxxxxxxxxxxxxxx"),
			UserAttributeProfileID:     auth0.String("uap_xxxxxxxxxxxxxxxxxxx"),
			AllowedStrategies:          &strategies,
			ConnectionDeletionBehavior: auth0.String("allow"),
		   },
	    }
```

### 🔬 Testing
New test cases have been added and recorded.
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
