### PR TITLE
feat: Add support for `authorization_policy` in Resource Servers

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -11437,6 +11437,14 @@ func (r *ResourceServer) GetAuthorizationDetails() []ResourceServerAuthorization
 	return *r.AuthorizationDetails
 }
 
+// GetAuthorizationPolicy returns the AuthorizationPolicy field.
+func (r *ResourceServer) GetAuthorizationPolicy() *ResourceServerAuthorizationPolicy {
+	if r == nil {
+		return nil
+	}
+	return r.AuthorizationPolicy
+}
+
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
 func (r *ResourceServer) GetClientID() string {
 	if r == nil || r.ClientID == nil {
@@ -11604,6 +11612,19 @@ func (r *ResourceServerAuthorizationDetails) GetType() string {
 
 // String returns a string representation of ResourceServerAuthorizationDetails.
 func (r *ResourceServerAuthorizationDetails) String() string {
+	return Stringify(r)
+}
+
+// GetPolicyID returns the PolicyID field if it's non-nil, zero value otherwise.
+func (r *ResourceServerAuthorizationPolicy) GetPolicyID() string {
+	if r == nil || r.PolicyID == nil {
+		return ""
+	}
+	return *r.PolicyID
+}
+
+// String returns a string representation of ResourceServerAuthorizationPolicy.
+func (r *ResourceServerAuthorizationPolicy) String() string {
 	return Stringify(r)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -14345,6 +14345,13 @@ func TestResourceServer_GetAuthorizationDetails(tt *testing.T) {
 	r.GetAuthorizationDetails()
 }
 
+func TestResourceServer_GetAuthorizationPolicy(tt *testing.T) {
+	r := &ResourceServer{}
+	r.GetAuthorizationPolicy()
+	r = nil
+	r.GetAuthorizationPolicy()
+}
+
 func TestResourceServer_GetClientID(tt *testing.T) {
 	var zeroValue string
 	r := &ResourceServer{ClientID: &zeroValue}
@@ -14547,6 +14554,24 @@ func TestResourceServerAuthorizationDetails_GetType(tt *testing.T) {
 func TestResourceServerAuthorizationDetails_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ResourceServerAuthorizationDetails{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestResourceServerAuthorizationPolicy_GetPolicyID(tt *testing.T) {
+	var zeroValue string
+	r := &ResourceServerAuthorizationPolicy{PolicyID: &zeroValue}
+	r.GetPolicyID()
+	r = &ResourceServerAuthorizationPolicy{}
+	r.GetPolicyID()
+	r = nil
+	r.GetPolicyID()
+}
+
+func TestResourceServerAuthorizationPolicy_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ResourceServerAuthorizationPolicy{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/management/resource_server.go
+++ b/management/resource_server.go
@@ -123,6 +123,14 @@ type ResourceServer struct {
 
 	// SubjectTypeAuthorization defines the authorization policies for user and client flows.
 	SubjectTypeAuthorization *ResourceServerSubjectTypeAuthorization `json:"subject_type_authorization,omitempty"`
+
+	// AuthorizationPolicy specifies the authorization policy for the resource server.
+	AuthorizationPolicy *ResourceServerAuthorizationPolicy `json:"authorization_policy,omitempty"`
+}
+
+// ResourceServerAuthorizationPolicy specifies the authorization policy for the resource server.
+type ResourceServerAuthorizationPolicy struct {
+	PolicyID *string `json:"policy_id,omitempty"`
 }
 
 // ResourceServerSubjectTypeAuthorization defines the authorization policies for user and client flows.

--- a/management/resource_server_test.go
+++ b/management/resource_server_test.go
@@ -3,6 +3,7 @@ package management
 import (
 	"context"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -422,5 +423,26 @@ func TestResourceServer_ExpressConfiguration(t *testing.T) {
 		}
 
 		assert.True(t, foundExpressConfig, "urn:auth0:express-configure should exist in resource server list")
+	})
+}
+
+func TestResourceServer_ACR(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	expectedResourceServer := &ResourceServer{
+		Name:       auth0.Stringf("Test Resource Server (%s)", time.Now().Format(time.StampMilli)),
+		Identifier: auth0.String("https://" + os.Getenv("AUTH0_DOMAIN") + "/me/"),
+		AuthorizationPolicy: &ResourceServerAuthorizationPolicy{
+			PolicyID: auth0.String("019b76da-a800-73c9-b656-b349ae415c17"),
+		},
+	}
+
+	err := api.ResourceServer.Create(context.Background(), expectedResourceServer)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResourceServer.GetName(), "Auth0 My Account API")
+	assert.NotEmpty(t, expectedResourceServer.GetID())
+
+	t.Cleanup(func() {
+		cleanupResourceServer(t, expectedResourceServer.GetID())
 	})
 }

--- a/test/data/recordings/TestResourceServer_ACR.yaml
+++ b/test/data/recordings/TestResourceServer_ACR.yaml
@@ -1,0 +1,72 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 180
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Resource Server (Apr 27 12:17:07.056)","identifier":"https://go-auth0-dev.eu.auth0.com.us.auth0.com/me/","authorization_policy":{"policy_id":"019b76da-a800-73c9-b656-b349ae415c17"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.38.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/resource-servers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 780
+        uncompressed: false
+        body: '{"id":"69ef066bd334660159726096","name":"Auth0 My Account API","identifier":"https://go-auth0-dev.eu.auth0.com.us.auth0.com/me/","scopes":[{"value":"create:me:connected_accounts","description":"Create Connected Accounts"},{"value":"read:me:connected_accounts","description":"Read Connected Accounts"},{"value":"delete:me:connected_accounts","description":"Delete Connected Accounts"}],"signing_alg":"RS256","allow_offline_access":true,"token_lifetime":600,"token_lifetime_for_web":600,"skip_consent_for_verifiable_first_party_clients":true,"is_system":true,"proof_of_possession":{"mechanism":"dpop","required":false},"subject_type_authorization":{"user":{"policy":"require_client_grant"},"client":{"policy":"deny_all"}},"authorization_policy":{"policy_id":"019b76da-a800-73c9-b656-b349ae415c17"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 972.28325ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.38.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/resource-servers/69ef066bd334660159726096
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 341.630125ms


### PR DESCRIPTION

### 🔧 Changes

This PR adds support to configure `authorization_policy` for Auth0 My Account API.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

```go
expectedResourceServer := &ResourceServer{
		Name:       auth0.Stringf("Auth0 My Account API"), # Constant name for this resource server
		Identifier: auth0.String("https://" + os.Getenv("AUTH0_DOMAIN") + "/me/"),
		AuthorizationPolicy: &ResourceServerAuthorizationPolicy{
			PolicyID: auth0.String("019b76da-a800-73c9-b656-b349ae415c17"),
		},
	}

	err := api.ResourceServer.Create(context.Background(), expectedResourceServer)
```

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Relevant test case added and recorded

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
