### PR TITLE
feat: add TokenEndpointJwtcaAudFormat support for Okta and OIDC connections

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -708,6 +708,10 @@ type ConnectionOptionsOkta struct {
 
 	// DPoPSigningAlg is the algorithm used to sign the DPoP proof. Currently allowed values: ES256, Ed25519.
 	DPoPSigningAlg *string `json:"dpop_signing_alg,omitempty"`
+
+	// TokenEndpointJwtcaAudFormat specifies the aud claim format in the JWT for client authentication
+	// at the token endpoint. Possible values: "issuer", "token_endpoint".
+	TokenEndpointJwtcaAudFormat *string `json:"token_endpoint_jwtca_aud_format,omitempty"`
 }
 
 // Scopes returns the scopes for ConnectionOptionsOkta.
@@ -1213,6 +1217,10 @@ type ConnectionOptionsOIDC struct {
 
 	// DPoPSigningAlg is the algorithm used to sign the DPoP proof. Currently allowed values: ES256, Ed25519.
 	DPoPSigningAlg *string `json:"dpop_signing_alg,omitempty"`
+
+	// TokenEndpointJwtcaAudFormat specifies the aud claim format in the JWT for client authentication
+	// at the token endpoint. Possible values: "issuer", "token_endpoint".
+	TokenEndpointJwtcaAudFormat *string `json:"token_endpoint_jwtca_aud_format,omitempty"`
 }
 
 // ConnectionOptionsOIDCConnectionSettings contains PKCE configuration for the connection.

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -1780,3 +1780,48 @@ func TestConnectionManager_DpopForOktaAndOIDC(t *testing.T) {
 		cleanupConnection(t, expectedOIDCConnection.GetID())
 	})
 }
+
+func TestConnectionManager_TokenEndpointJwtcaAudFormatForOktaAndOIDC(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	oktaConnection := givenAConnection(t, connectionTestCase{
+		connection: Connection{
+			Name:     auth0.Stringf("Test-Okta-Connection-%d", time.Now().Unix()),
+			Strategy: auth0.String("okta"),
+		},
+		options: &ConnectionOptionsOkta{
+			ClientID:                    auth0.String("4ef8d976-71bd-4473-a7ce-087d3f0fafd8"),
+			ClientSecret:                auth0.String("mySecret"),
+			Scope:                       auth0.String("openid"),
+			Domain:                      auth0.String("domain.okta.com"),
+			Issuer:                      auth0.String("https://example.com"),
+			AuthorizationEndpoint:       auth0.String("https://example.com"),
+			JWKSURI:                     auth0.String("https://example.com/jwks"),
+			TokenEndpointJwtcaAudFormat: auth0.String("issuer"),
+		},
+	})
+
+	oidcConnection := givenAConnection(t, connectionTestCase{
+		connection: Connection{
+			Name:     auth0.Stringf("Test-OIDC-Connection-%d", time.Now().Unix()),
+			Strategy: auth0.String("oidc"),
+		},
+		options: &ConnectionOptionsOIDC{
+			ClientID:                    auth0.String("4ef8d976-71bd-4473-a7ce-087d3f0fafd8"),
+			ClientSecret:                auth0.String("mySecret"),
+			Scope:                       auth0.String("openid"),
+			TenantDomain:                auth0.String("domain.okta.com"),
+			Issuer:                      auth0.String("https://example.com"),
+			AuthorizationEndpoint:       auth0.String("https://example.com"),
+			JWKSURI:                     auth0.String("https://example.com/jwks"),
+			TokenEndpointJwtcaAudFormat: auth0.String("token_endpoint"),
+			Type:                        auth0.String("back_channel"),
+		},
+	})
+
+	oktaOpts := oktaConnection.Options.(*ConnectionOptionsOkta)
+	oidcOpts := oidcConnection.Options.(*ConnectionOptionsOIDC)
+
+	assert.Equal(t, "issuer", oktaOpts.GetTokenEndpointJwtcaAudFormat())
+	assert.Equal(t, "token_endpoint", oidcOpts.GetTokenEndpointJwtcaAudFormat())
+}

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5738,6 +5738,14 @@ func (c *ConnectionOptionsOIDC) GetTokenEndpointAuthSigningAlg() string {
 	return *c.TokenEndpointAuthSigningAlg
 }
 
+// GetTokenEndpointJwtcaAudFormat returns the TokenEndpointJwtcaAudFormat field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetTokenEndpointJwtcaAudFormat() string {
+	if c == nil || c.TokenEndpointJwtcaAudFormat == nil {
+		return ""
+	}
+	return *c.TokenEndpointJwtcaAudFormat
+}
+
 // GetType returns the Type field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsOIDC) GetType() string {
 	if c == nil || c.Type == nil {
@@ -5959,6 +5967,14 @@ func (c *ConnectionOptionsOkta) GetTokenEndpointAuthSigningAlg() string {
 		return ""
 	}
 	return *c.TokenEndpointAuthSigningAlg
+}
+
+// GetTokenEndpointJwtcaAudFormat returns the TokenEndpointJwtcaAudFormat field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOkta) GetTokenEndpointJwtcaAudFormat() string {
+	if c == nil || c.TokenEndpointJwtcaAudFormat == nil {
+		return ""
+	}
+	return *c.TokenEndpointJwtcaAudFormat
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -7089,6 +7089,16 @@ func TestConnectionOptionsOIDC_GetTokenEndpointAuthSigningAlg(tt *testing.T) {
 	c.GetTokenEndpointAuthSigningAlg()
 }
 
+func TestConnectionOptionsOIDC_GetTokenEndpointJwtcaAudFormat(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsOIDC{TokenEndpointJwtcaAudFormat: &zeroValue}
+	c.GetTokenEndpointJwtcaAudFormat()
+	c = &ConnectionOptionsOIDC{}
+	c.GetTokenEndpointJwtcaAudFormat()
+	c = nil
+	c.GetTokenEndpointJwtcaAudFormat()
+}
+
 func TestConnectionOptionsOIDC_GetType(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsOIDC{Type: &zeroValue}
@@ -7365,6 +7375,16 @@ func TestConnectionOptionsOkta_GetTokenEndpointAuthSigningAlg(tt *testing.T) {
 	c.GetTokenEndpointAuthSigningAlg()
 	c = nil
 	c.GetTokenEndpointAuthSigningAlg()
+}
+
+func TestConnectionOptionsOkta_GetTokenEndpointJwtcaAudFormat(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsOkta{TokenEndpointJwtcaAudFormat: &zeroValue}
+	c.GetTokenEndpointJwtcaAudFormat()
+	c = &ConnectionOptionsOkta{}
+	c.GetTokenEndpointJwtcaAudFormat()
+	c = nil
+	c.GetTokenEndpointJwtcaAudFormat()
 }
 
 func TestConnectionOptionsOkta_GetUpstreamParams(tt *testing.T) {

--- a/test/data/recordings/TestConnectionManager_TokenEndpointJwtcaAudFormatForOktaAndOIDC.yaml
+++ b/test/data/recordings/TestConnectionManager_TokenEndpointJwtcaAudFormatForOktaAndOIDC.yaml
@@ -1,0 +1,141 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 401
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Okta-Connection-1777358890","strategy":"okta","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","domain":"domain.okta.com","authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid","token_endpoint_jwtca_aud_format":"issuer"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.38.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_FfeCnSCoDaMKD5rq","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","domain":"domain.okta.com","authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":"https://domain.okta.com/oauth2/v1/userinfo","token_endpoint":"https://domain.okta.com/oauth2/v1/token","scope":"openid","token_endpoint_jwtca_aud_format":"issuer","oidc_metadata":{"issuer":"https://domain.okta.com","authorization_endpoint":"https://domain.okta.com/oauth2/v1/authorize","token_endpoint":"https://domain.okta.com/oauth2/v1/token","userinfo_endpoint":"https://domain.okta.com/oauth2/v1/userinfo","registration_endpoint":"https://domain.okta.com/oauth2/v1/clients","jwks_uri":"https://domain.okta.com/oauth2/v1/keys","response_types_supported":["code","id_token","code id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code","urn:openid:params:grant-type:ciba","urn:okta:params:oauth:grant-type:otp","http://auth0.com/oauth/grant-type/mfa-otp","urn:okta:params:oauth:grant-type:oob","http://auth0.com/oauth/grant-type/mfa-oob"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"id_token_encryption_alg_values_supported":["RSA-OAEP-256","RSA-OAEP-384","RSA-OAEP-512"],"id_token_encryption_enc_values_supported":["A256GCM"],"scopes_supported":["openid","email","profile","address","phone","offline_access","groups"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://domain.okta.com/oauth2/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://domain.okta.com/oauth2/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://domain.okta.com/oauth2/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://domain.okta.com/oauth2/v1/device/authorize","pushed_authorization_request_endpoint":"https://domain.okta.com/oauth2/v1/par","backchannel_token_delivery_modes_supported":["poll"],"backchannel_authentication_request_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"dpop_signing_alg_values_supported":["RS256","RS384","RS512","ES256","ES384","ES512"],"claims_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false},"schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Test-Okta-Connection-1777358890","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Test-Okta-Connection-1777358890","enabled_clients":[],"realms":["Test-Okta-Connection-1777358890"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1.06924575s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 459
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-OIDC-Connection-1777358891","strategy":"oidc","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","tenant_domain":"domain.okta.com","discovery_url":null,"authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","type":"back_channel","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid","token_endpoint_jwtca_aud_format":"token_endpoint"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.38.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 833
+        uncompressed: false
+        body: '{"id":"con_CaoP8wSmvWm9JtZy","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","tenant_domain":"domain.okta.com","discovery_url":null,"authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","type":"back_channel","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid","token_endpoint_jwtca_aud_format":"token_endpoint","schema_version":"oidc-V4","attribute_map":{"mapping_mode":"bind_all"},"connection_settings":{"pkce":"auto"}},"strategy":"oidc","name":"Test-OIDC-Connection-1777358891","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Test-OIDC-Connection-1777358891","enabled_clients":[],"realms":["Test-OIDC-Connection-1777358891"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 371.333416ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.38.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_CaoP8wSmvWm9JtZy
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-04-28T06:48:12.210Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 310.691042ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.38.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_FfeCnSCoDaMKD5rq
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-04-28T06:48:12.518Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 322.209ms


### PR DESCRIPTION


<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR adds support for the token_endpoint_jwtca_aud_format field in OIDC and Okta workforce connection options. This field allows developers to configure the format of the aud (audience) claim in JWT client assertions used for Private Key JWT authentication at the token endpoint


This field is used in conjunction with `token_endpoint_auth_method: "private_key_jwt"` to control how the JWT client assertion's audience claim is formatted:

### Example: OIDC Connection with Token Endpoint Audience Format

```go
conn := &management.Connection{
    Name:     auth0.String("my-oidc-connection"),
    Strategy: auth0.String("oidc"),
    Options: &management.ConnectionOptionsOIDC{
        ClientID:                     auth0.String("client-id"),
        Issuer:                       auth0.String("https://idp.example.com"),
        TokenEndpoint:                auth0.String("https://idp.example.com/oauth/token"),
        TokenEndpointAuthMethod:      auth0.String("private_key_jwt"),
        TokenEndpointAuthSigningAlg:  auth0.String("RS256"),
        TokenEndpointJWTCAAudFormat:  auth0.String("token_endpoint"), // NEW
    },
}

err := api.Connection.Create(context.Background(), conn)
```

### Example: Okta Connection with Issuer Audience Format

```go
conn := &management.Connection{
    Name:     auth0.String("my-okta-connection"),
    Strategy: auth0.String("okta"),
    Options: &management.ConnectionOptionsOkta{
        ClientID:                     auth0.String("client-id"),
        Domain:                       auth0.String("company.okta.com"),
        Issuer:                       auth0.String("https://company.okta.com"),
        TokenEndpointAuthMethod:      auth0.String("private_key_jwt"),
        TokenEndpointAuthSigningAlg:  auth0.String("RS256"),
        TokenEndpointJWTCAAudFormat:  auth0.String("issuer"), // NEW
    },
}

err := api.Connection.Create(context.Background(), conn)
```

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

https://auth0.com/docs/api/management/v2/connections/post-connections
https://auth0.com/docs/api/management/v2/connections/patch-connections-by-id
https://auth0.com/docs/api/management/v2/connections/get-connections-by-id

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

Added testcases in `management/connection_test.go`

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
