### PR TITLE
Add EnableGroupsAPI field to ConnectionOptionsGoogleApps

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -1770,6 +1770,7 @@ type ConnectionOptionsGoogleApps struct {
 	IsSuspended               *bool                  `json:"ext_is_suspended,omitempty" scope:"ext_is_suspended"`
 	AgreedTerms               *bool                  `json:"ext_agreed_terms,omitempty" scope:"ext_agreed_terms"`
 	EnableUsersAPI            *bool                  `json:"api_enable_users,omitempty"`
+	EnableGroupsAPI           *bool                  `json:"api_enable_groups,omitempty"`
 	SetUserAttributes         *string                `json:"set_user_root_attributes,omitempty"`
 	MapUserIDtoID             *bool                  `json:"map_user_id_to_id,omitempty"`
 	HandleLoginFromSocial     *bool                  `json:"handle_login_from_social,omitempty"`

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -4913,6 +4913,14 @@ func (c *ConnectionOptionsGoogleApps) GetDomainAliases() []string {
 	return *c.DomainAliases
 }
 
+// GetEnableGroupsAPI returns the EnableGroupsAPI field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetEnableGroupsAPI() bool {
+	if c == nil || c.EnableGroupsAPI == nil {
+		return false
+	}
+	return *c.EnableGroupsAPI
+}
+
 // GetEnableUsersAPI returns the EnableUsersAPI field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsGoogleApps) GetEnableUsersAPI() bool {
 	if c == nil || c.EnableUsersAPI == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -6052,6 +6052,16 @@ func TestConnectionOptionsGoogleApps_GetDomainAliases(tt *testing.T) {
 	c.GetDomainAliases()
 }
 
+func TestConnectionOptionsGoogleApps_GetEnableGroupsAPI(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsGoogleApps{EnableGroupsAPI: &zeroValue}
+	c.GetEnableGroupsAPI()
+	c = &ConnectionOptionsGoogleApps{}
+	c.GetEnableGroupsAPI()
+	c = nil
+	c.GetEnableGroupsAPI()
+}
+
 func TestConnectionOptionsGoogleApps_GetEnableUsersAPI(tt *testing.T) {
 	var zeroValue bool
 	c := &ConnectionOptionsGoogleApps{EnableUsersAPI: &zeroValue}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds `EnableGroupsAPI` field to `ConnectionOptionsGoogleApps` struct, allowing configuration of the Google Workspace Groups API for Google Apps connections.

- New field: `EnableGroupsAPI *bool` with JSON tag `api_enable_groups`
- New getter: `GetEnableGroupsAPI()` on `ConnectionOptionsGoogleApps`

### 📚 References
- https://github.com/auth0/terraform-provider-auth0/pull/1561
<!-- Related to enabling Google Workspace Directory API (Groups) for Google Apps connections -->

### 🔬 Testing

- Unit tests added for `GetEnableGroupsAPI` covering non-nil value, zero-value struct, and nil receiver cases
- Run locally: `go test ./management/ -run TestConnectionOptionsGoogleApps_GetEnableGroupsAPI`

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
