### PR TITLE
feat: add online access and ephemeral session fields to ResourceServer, Client, and Tenant

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -11646,6 +11646,22 @@ func (r *ResourceServer) GetAllowOfflineAccess() bool {
 	return *r.AllowOfflineAccess
 }
 
+// GetAllowOnlineAccess returns the AllowOnlineAccess field if it's non-nil, zero value otherwise.
+func (r *ResourceServer) GetAllowOnlineAccess() bool {
+	if r == nil || r.AllowOnlineAccess == nil {
+		return false
+	}
+	return *r.AllowOnlineAccess
+}
+
+// GetAllowOnlineAccessWithEphemeralSessions returns the AllowOnlineAccessWithEphemeralSessions field if it's non-nil, zero value otherwise.
+func (r *ResourceServer) GetAllowOnlineAccessWithEphemeralSessions() bool {
+	if r == nil || r.AllowOnlineAccessWithEphemeralSessions == nil {
+		return false
+	}
+	return *r.AllowOnlineAccessWithEphemeralSessions
+}
+
 // GetAuthorizationDetails returns the AuthorizationDetails field if it's non-nil, zero value otherwise.
 func (r *ResourceServer) GetAuthorizationDetails() []ResourceServerAuthorizationDetails {
 	if r == nil || r.AuthorizationDetails == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -14600,6 +14600,26 @@ func TestResourceServer_GetAllowOfflineAccess(tt *testing.T) {
 	r.GetAllowOfflineAccess()
 }
 
+func TestResourceServer_GetAllowOnlineAccess(tt *testing.T) {
+	var zeroValue bool
+	r := &ResourceServer{AllowOnlineAccess: &zeroValue}
+	r.GetAllowOnlineAccess()
+	r = &ResourceServer{}
+	r.GetAllowOnlineAccess()
+	r = nil
+	r.GetAllowOnlineAccess()
+}
+
+func TestResourceServer_GetAllowOnlineAccessWithEphemeralSessions(tt *testing.T) {
+	var zeroValue bool
+	r := &ResourceServer{AllowOnlineAccessWithEphemeralSessions: &zeroValue}
+	r.GetAllowOnlineAccessWithEphemeralSessions()
+	r = &ResourceServer{}
+	r.GetAllowOnlineAccessWithEphemeralSessions()
+	r = nil
+	r.GetAllowOnlineAccessWithEphemeralSessions()
+}
+
 func TestResourceServer_GetAuthorizationDetails(tt *testing.T) {
 	var zeroValue []ResourceServerAuthorizationDetails
 	r := &ResourceServer{AuthorizationDetails: &zeroValue}

--- a/management/resource_server.go
+++ b/management/resource_server.go
@@ -31,6 +31,12 @@ type ResourceServer struct {
 	// Allows issuance of refresh tokens for this entity.
 	AllowOfflineAccess *bool `json:"allow_offline_access,omitempty"`
 
+	// Whether Online Refresh Tokens can be issued for this resource server.
+	AllowOnlineAccess *bool `json:"allow_online_access,omitempty"`
+
+	// Whether Online Refresh Tokens can be issued even when sessions are configured as ephemeral.
+	AllowOnlineAccessWithEphemeralSessions *bool `json:"allow_online_access_with_ephemeral_sessions,omitempty"`
+
 	// The amount of time in seconds that the token will be valid after being
 	// issued.
 	TokenLifetime *int `json:"token_lifetime,omitempty"`


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds Online Access support to the `ResourceServer` struct, enabling configuration of Online Refresh Tokens via the Management API.

**New fields on `ResourceServer`:**
- `AllowOnlineAccess` (`*bool`) — controls whether Online Refresh Tokens can be issued for this resource server
- `AllowOnlineAccessWithEphemeralSessions` (`*bool`) — controls whether Online Refresh Tokens can be issued even when sessions are configured as ephemeral

**New getter methods:**
- `GetAllowOnlineAccess()` — returns the field value or `false` if nil
- `GetAllowOnlineAccessWithEphemeralSessions()` — returns the field value or `false` if nil

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- Required for https://github.com/auth0/terraform-provider-auth0/pull/1576
- API: https://auth0.com/docs/api/management/v2/resource-servers/post-resource-servers

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Unit tests added for both getter methods covering three scenarios each: non-nil value, empty struct, and nil receiver
- Run tests: `go test ./management/ -run "TestResourceServer_GetAllowOnlineAccess"`

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
