### PR TITLE
feat: add FederatedConnectionsAccessTokens support for OIDC connections

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -1287,6 +1287,17 @@ type ConnectionOptionsOIDC struct {
 	// TokenEndpointJwtcaAudFormat specifies the aud claim format in the JWT for client authentication
 	// at the token endpoint. Possible values: "issuer", "token_endpoint".
 	TokenEndpointJwtcaAudFormat *string `json:"token_endpoint_jwtca_aud_format,omitempty"`
+	// FederatedConnectionsAccessTokens enables refresh tokens and access tokens collection for federated connections
+	FederatedConnectionsAccessTokens *ConnectionOptionsOIDCFederatedConnectionsAccessTokens `json:"federated_connections_access_tokens,omitempty"`
+}
+
+// ConnectionOptionsOIDCFederatedConnectionsAccessTokens is used by OIDC Connections to
+// configure the collection of access tokens and refresh tokens for federated connections.
+// When enabled, Auth0 will collect and store access tokens and refresh tokens
+// obtained from federated connections during authentication.
+type ConnectionOptionsOIDCFederatedConnectionsAccessTokens struct {
+	// Enables refresh tokens and access tokens collection for federated connections
+	Active *bool `json:"active,omitempty"`
 }
 
 // ConnectionOptionsOIDCConnectionSettings contains PKCE configuration for the connection.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5674,6 +5674,14 @@ func (c *ConnectionOptionsOIDC) GetDPoPSigningAlg() string {
 	return *c.DPoPSigningAlg
 }
 
+// GetFederatedConnectionsAccessTokens returns the FederatedConnectionsAccessTokens field.
+func (c *ConnectionOptionsOIDC) GetFederatedConnectionsAccessTokens() *ConnectionOptionsOIDCFederatedConnectionsAccessTokens {
+	if c == nil {
+		return nil
+	}
+	return c.FederatedConnectionsAccessTokens
+}
+
 // GetIDTokenSignedResponseAlgs returns the IDTokenSignedResponseAlgs field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsOIDC) GetIDTokenSignedResponseAlgs() []string {
 	if c == nil || c.IDTokenSignedResponseAlgs == nil {
@@ -5854,6 +5862,19 @@ func (c *ConnectionOptionsOIDCConnectionSettings) GetPKCE() string {
 
 // String returns a string representation of ConnectionOptionsOIDCConnectionSettings.
 func (c *ConnectionOptionsOIDCConnectionSettings) String() string {
+	return Stringify(c)
+}
+
+// GetActive returns the Active field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDCFederatedConnectionsAccessTokens) GetActive() bool {
+	if c == nil || c.Active == nil {
+		return false
+	}
+	return *c.Active
+}
+
+// String returns a string representation of ConnectionOptionsOIDCFederatedConnectionsAccessTokens.
+func (c *ConnectionOptionsOIDCFederatedConnectionsAccessTokens) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -7006,6 +7006,13 @@ func TestConnectionOptionsOIDC_GetDPoPSigningAlg(tt *testing.T) {
 	c.GetDPoPSigningAlg()
 }
 
+func TestConnectionOptionsOIDC_GetFederatedConnectionsAccessTokens(tt *testing.T) {
+	c := &ConnectionOptionsOIDC{}
+	c.GetFederatedConnectionsAccessTokens()
+	c = nil
+	c.GetFederatedConnectionsAccessTokens()
+}
+
 func TestConnectionOptionsOIDC_GetIDTokenSignedResponseAlgs(tt *testing.T) {
 	var zeroValue []string
 	c := &ConnectionOptionsOIDC{IDTokenSignedResponseAlgs: &zeroValue}
@@ -7235,6 +7242,24 @@ func TestConnectionOptionsOIDCConnectionSettings_GetPKCE(tt *testing.T) {
 func TestConnectionOptionsOIDCConnectionSettings_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ConnectionOptionsOIDCConnectionSettings{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsOIDCFederatedConnectionsAccessTokens_GetActive(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsOIDCFederatedConnectionsAccessTokens{Active: &zeroValue}
+	c.GetActive()
+	c = &ConnectionOptionsOIDCFederatedConnectionsAccessTokens{}
+	c.GetActive()
+	c = nil
+	c.GetActive()
+}
+
+func TestConnectionOptionsOIDCFederatedConnectionsAccessTokens_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsOIDCFederatedConnectionsAccessTokens{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}


### PR DESCRIPTION

### 🔧 Changes

FederatedConnectionsAccessTokens is used by OIDC Connections to configure the collection of access tokens and refresh tokens for federated connections. When enabled, Auth0 will collect and store access tokens and refresh tokens obtained from federated connections during authentication. Added support to configure this field. 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
