### PR TITLE
feat: support hostnames and CIDRs in NetworkACLRuleMatch

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -10392,6 +10392,22 @@ func (n *NetworkACLRuleMatch) GetAnonymousProxy() bool {
 	return *n.AnonymousProxy
 }
 
+// GetConnectingIPv4Cidrs returns the ConnectingIPv4Cidrs field if it's non-nil, zero value otherwise.
+func (n *NetworkACLRuleMatch) GetConnectingIPv4Cidrs() []string {
+	if n == nil || n.ConnectingIPv4Cidrs == nil {
+		return nil
+	}
+	return *n.ConnectingIPv4Cidrs
+}
+
+// GetConnectingIPv6Cidrs returns the ConnectingIPv6Cidrs field if it's non-nil, zero value otherwise.
+func (n *NetworkACLRuleMatch) GetConnectingIPv6Cidrs() []string {
+	if n == nil || n.ConnectingIPv6Cidrs == nil {
+		return nil
+	}
+	return *n.ConnectingIPv6Cidrs
+}
+
 // GetGeoCountryCodes returns the GeoCountryCodes field if it's non-nil, zero value otherwise.
 func (n *NetworkACLRuleMatch) GetGeoCountryCodes() []string {
 	if n == nil || n.GeoCountryCodes == nil {
@@ -10406,6 +10422,14 @@ func (n *NetworkACLRuleMatch) GetGeoSubdivisionCodes() []string {
 		return nil
 	}
 	return *n.GeoSubdivisionCodes
+}
+
+// GetHostnames returns the Hostnames field if it's non-nil, zero value otherwise.
+func (n *NetworkACLRuleMatch) GetHostnames() []string {
+	if n == nil || n.Hostnames == nil {
+		return nil
+	}
+	return *n.Hostnames
 }
 
 // GetIPv4Cidrs returns the IPv4Cidrs field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -12997,6 +12997,26 @@ func TestNetworkACLRuleMatch_GetAnonymousProxy(tt *testing.T) {
 	n.GetAnonymousProxy()
 }
 
+func TestNetworkACLRuleMatch_GetConnectingIPv4Cidrs(tt *testing.T) {
+	var zeroValue []string
+	n := &NetworkACLRuleMatch{ConnectingIPv4Cidrs: &zeroValue}
+	n.GetConnectingIPv4Cidrs()
+	n = &NetworkACLRuleMatch{}
+	n.GetConnectingIPv4Cidrs()
+	n = nil
+	n.GetConnectingIPv4Cidrs()
+}
+
+func TestNetworkACLRuleMatch_GetConnectingIPv6Cidrs(tt *testing.T) {
+	var zeroValue []string
+	n := &NetworkACLRuleMatch{ConnectingIPv6Cidrs: &zeroValue}
+	n.GetConnectingIPv6Cidrs()
+	n = &NetworkACLRuleMatch{}
+	n.GetConnectingIPv6Cidrs()
+	n = nil
+	n.GetConnectingIPv6Cidrs()
+}
+
 func TestNetworkACLRuleMatch_GetGeoCountryCodes(tt *testing.T) {
 	var zeroValue []string
 	n := &NetworkACLRuleMatch{GeoCountryCodes: &zeroValue}
@@ -13015,6 +13035,16 @@ func TestNetworkACLRuleMatch_GetGeoSubdivisionCodes(tt *testing.T) {
 	n.GetGeoSubdivisionCodes()
 	n = nil
 	n.GetGeoSubdivisionCodes()
+}
+
+func TestNetworkACLRuleMatch_GetHostnames(tt *testing.T) {
+	var zeroValue []string
+	n := &NetworkACLRuleMatch{Hostnames: &zeroValue}
+	n.GetHostnames()
+	n = &NetworkACLRuleMatch{}
+	n.GetHostnames()
+	n = nil
+	n.GetHostnames()
 }
 
 func TestNetworkACLRuleMatch_GetIPv4Cidrs(tt *testing.T) {

--- a/management/network_acl.go
+++ b/management/network_acl.go
@@ -69,6 +69,12 @@ type NetworkACLRuleMatch struct {
 	Ja4Fingerprints *[]string `json:"ja4_fingerprints,omitempty"`
 	// User Agents
 	UserAgents *[]string `json:"user_agents,omitempty"`
+	// Hostnames
+	Hostnames *[]string `json:"hostnames,omitempty"`
+	// Connecting IPv4 CIDRs
+	ConnectingIPv4Cidrs *[]string `json:"connecting_ipv4_cidrs,omitempty"`
+	// Connecting IPv6 CIDRs
+	ConnectingIPv6Cidrs *[]string `json:"connecting_ipv6_cidrs,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds three new fields to `NetworkACLRuleMatch` for matching network ACL rules against connecting CIDRs and hostnames:

- `ConnectingIPv4Cidrs` — match against connecting client IPv4 CIDR ranges
- `ConnectingIPv6Cidrs` — match against connecting client IPv6 CIDR ranges
- `Hostnames` — match against hostnames

Includes generated getter methods (`GetConnectingIPv4Cidrs`, `GetConnectingIPv6Cidrs`, `GetHostnames`) and corresponding unit tests.

### 📚 References

- API Docs: https://auth0.com/docs/api/management/v2/network-acls/post-network-acls
- https://github.com/auth0/terraform-provider-auth0/pull/1581

### 🔬 Testing

- Unit tests added for all three new getter methods covering nil receiver, nil field, and valid field cases
- Run tests: `go test ./management/ -run TestNetworkACLRuleMatch`

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
