### PR TITLE
feat: add DestinationUrl and RecipientURL fields to SAML ConnectionOptions

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -1702,6 +1702,8 @@ type ConnectionOptionsSAML struct {
 	TenantDomain       *string                             `json:"tenant_domain,omitempty"`
 	DomainAliases      *[]string                           `json:"domain_aliases,omitempty"`
 	SignInEndpoint     *string                             `json:"signInEndpoint,omitempty"`
+	DestinationURL     *string                             `json:"destinationUrl,omitempty"`
+	RecipientURL       *string                             `json:"recipientUrl,omitempty"`
 	SignOutEndpoint    *string                             `json:"signOutEndpoint,omitempty"`
 	DisableSignOut     *bool                               `json:"disableSignout,omitempty"`
 	SignatureAlgorithm *string                             `json:"signatureAlgorithm,omitempty"`

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -6535,6 +6535,14 @@ func (c *ConnectionOptionsSAML) GetDecryptionKey() *ConnectionOptionsSAMLDecrypt
 	return c.DecryptionKey
 }
 
+// GetDestinationURL returns the DestinationURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetDestinationURL() string {
+	if c == nil || c.DestinationURL == nil {
+		return ""
+	}
+	return *c.DestinationURL
+}
+
 // GetDigestAglorithm returns the DigestAglorithm field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSAML) GetDigestAglorithm() string {
 	if c == nil || c.DigestAglorithm == nil {
@@ -6661,6 +6669,14 @@ func (c *ConnectionOptionsSAML) GetProtocolBinding() string {
 		return ""
 	}
 	return *c.ProtocolBinding
+}
+
+// GetRecipientURL returns the RecipientURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetRecipientURL() string {
+	if c == nil || c.RecipientURL == nil {
+		return ""
+	}
+	return *c.RecipientURL
 }
 
 // GetRequestTemplate returns the RequestTemplate field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -8071,6 +8071,16 @@ func TestConnectionOptionsSAML_GetDecryptionKey(tt *testing.T) {
 	c.GetDecryptionKey()
 }
 
+func TestConnectionOptionsSAML_GetDestinationURL(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsSAML{DestinationURL: &zeroValue}
+	c.GetDestinationURL()
+	c = &ConnectionOptionsSAML{}
+	c.GetDestinationURL()
+	c = nil
+	c.GetDestinationURL()
+}
+
 func TestConnectionOptionsSAML_GetDigestAglorithm(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsSAML{DigestAglorithm: &zeroValue}
@@ -8226,6 +8236,16 @@ func TestConnectionOptionsSAML_GetProtocolBinding(tt *testing.T) {
 	c.GetProtocolBinding()
 	c = nil
 	c.GetProtocolBinding()
+}
+
+func TestConnectionOptionsSAML_GetRecipientURL(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsSAML{RecipientURL: &zeroValue}
+	c.GetRecipientURL()
+	c = &ConnectionOptionsSAML{}
+	c.GetRecipientURL()
+	c = nil
+	c.GetRecipientURL()
 }
 
 func TestConnectionOptionsSAML_GetRequestTemplate(tt *testing.T) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes


* Added `DestinationURL` and `RecipientURL` fields to the `ConnectionOptionsSAML` struct to support additional SAML endpoint configuration.


<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

- https://auth0.com/docs/api/management/v2/connections/post-connections
- https://auth0.com/docs/api/management/v2/connections/patch-connections-by-id

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

- Added  getter methods and corresponding unit tests. 

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
