### PR TITLE
fix(client): make retry backoff jitter safe for concurrent use

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -157,8 +157,6 @@ func retryErrors(err error) bool {
 
 // backoffDelay implements an exponential backoff with jitter and handles rate limiting.
 func backoffDelay() rehttp.DelayFn {
-	prng := rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec G404: Random generator
-
 	const (
 		minDelay  = 1 * time.Second
 		maxDelay  = 10 * time.Second
@@ -166,9 +164,11 @@ func backoffDelay() rehttp.DelayFn {
 	)
 
 	return func(attempt rehttp.Attempt) time.Duration {
-		// Calculate exponential backoff with jitter
+		// Calculate exponential backoff with jitter. We use the package-global
+		// math/rand source because the returned closure is shared across
+		// concurrent in-flight requests and the global source is lock-protected.
 		expBackoff := time.Duration(float64(baseDelay) * math.Pow(2, float64(attempt.Index)))
-		jitter := time.Duration(prng.Float64() * float64(baseDelay))
+		jitter := time.Duration(rand.Float64() * float64(baseDelay)) // #nosec G404: jitter, not security-sensitive
 		wait := expBackoff + jitter
 
 		// Clamp the delay within min and max bounds

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -633,6 +634,49 @@ func TestRetries(t *testing.T) {
 
 		assert.GreaterOrEqual(t, elapsed, int64(5000), "Expected wait >= 6000ms, got %dms", elapsed)
 		assert.LessOrEqual(t, elapsed, int64(8000), "Expected wait <= 8000ms, got %dms", elapsed)
+	})
+
+	t.Run("Should be safe for concurrent use under -race", func(t *testing.T) {
+		// The retry transport's delay function is shared across in-flight
+		// requests, so the jitter PRNG it uses must be safe for concurrent access.
+		var seen sync.Map
+
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := r.URL.Query().Get("id")
+			if _, loaded := seen.LoadOrStore(id, true); !loaded {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+		})
+
+		s := httptest.NewServer(h)
+		defer s.Close()
+
+		c := WrapWithTokenSource(s.Client(), StaticToken(""), WithRetries(DefaultRetryOptions))
+
+		const concurrency = 25
+
+		var wg sync.WaitGroup
+
+		for i := range concurrency {
+			wg.Add(1)
+
+			go func(i int) {
+				defer wg.Done()
+
+				resp, err := c.Get(fmt.Sprintf("%s/?id=%d", s.URL, i))
+				assert.NoError(t, err)
+
+				if resp != nil {
+					assert.Equal(t, http.StatusOK, resp.StatusCode)
+					_ = resp.Body.Close()
+				}
+			}(i)
+		}
+
+		wg.Wait()
 	})
 }
 


### PR DESCRIPTION
### 🔧 Changes

The retry transport's delay function in `internal/client/client.go` captured a single `*math/rand.Rand` instance and reused it inside the closure returned to `rehttp.Transport`. Because that closure is shared across every in-flight request handled by a single SDK client, two goroutines computing jitter at the same time both read from and wrote to the same unsynchronized PRNG state. The Go race detector flags this consistently when callers fan out parallel management API requests (for example, looping `ConnectionManager.ReadEnabledClients` over many connections concurrently).

This change:

- Drops the per-transport `prng := rand.New(rand.NewSource(...))` and uses the package-global `math/rand` source via `rand.Float64()`. The package-level functions are documented as safe for concurrent use because they are backed by a lock-protected source. Go automatically seeds this source since 1.20, so there is no loss of randomness.
- Keeps the existing exponential backoff envelope, jitter range, minimum and maximum bounds unchanged. There is no behavior change observable to users beyond the disappearance of the race.
- Keeps the `// #nosec G404` annotation since jitter is not security-sensitive.

No public API surface changes.

### 📚 References

https://github.com/auth0/go-auth0/issues/780

### 🔬 Testing

Added a new subtest in `TestRetries`, `Should be safe for concurrent use under -race`, that fans out 25 concurrent requests against an `httptest.NewServer` returning `429` exactly once per request and `200` thereafter. Before the fix this test produces a `DATA RACE` warning at the `prng.Float64` call inside `backoffDelay`. After the fix it passes cleanly.

Verification commands:

```
go test -race -count=1 ./internal/client/...
```

The full client test suite passes under `-race` (around 100 seconds locally). `go vet` and `go build ./...` are clean.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)