### PR TITLE
ci: add automated beta SDK release track

### DIFF
--- a/.github/actions/compute-next-version/action.yml
+++ b/.github/actions/compute-next-version/action.yml
@@ -1,0 +1,63 @@
+name: Compute the next version for a release track
+
+#
+# Computes the next version for either the stable or beta track from the
+# existing git tags, which are treated as the single source of truth.
+#
+#   - stable: next minor after the latest stable tag (vX.Y.0 -> vX.(Y+1).0)
+#   - beta:   vX.(Y+1).0-beta.N, where the base is the next minor after the
+#             latest stable tag and N auto-increments from existing beta tags.
+#
+# Because the beta base is always derived from the latest stable tag, the
+# moment a stable release is tagged the next beta computation rolls forward
+# automatically. No shared state file is needed.
+#
+
+inputs:
+  track:
+    description: 'Release track: "stable" or "beta".'
+    required: true
+
+outputs:
+  version:
+    value: ${{ steps.compute.outputs.VERSION }}
+
+runs:
+  using: composite
+
+  steps:
+    - id: compute
+      shell: bash
+      run: |
+        set -euo pipefail
+        git fetch --tags --quiet
+
+        # Only consider clean stable tags on the current major line (v2.MINOR.PATCH).
+        # The strict anchored regex excludes other majors (v1.*), any prerelease
+        # suffix (-beta/-alpha/-rc/...), and stray non-release tags. `sort -V`
+        # orders by semver so double-digit minors (v2.10.0 > v2.9.0) sort right.
+        LATEST_STABLE=$(git tag --list | grep -E '^v2\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+        if [ -z "${LATEST_STABLE}" ]; then
+          echo "::error::No stable v2.MINOR.PATCH tag found; cannot compute next version." >&2
+          exit 1
+        fi
+
+        BASE=$(echo "${LATEST_STABLE}" | awk -F. '{printf "%s.%d.0", $1, $2+1}')
+
+        if [ "${TRACK}" = "stable" ]; then
+          VERSION="${BASE}"
+          echo "::notice::compute-next-version (stable): latest_stable=${LATEST_STABLE} -> ${VERSION}"
+        elif [ "${TRACK}" = "beta" ]; then
+          # Only beta tags whose base is exactly BASE, with a numeric suffix.
+          LAST_N=$(git tag --list | grep -E "^${BASE}-beta\.[0-9]+$" | sed -E 's/.*-beta\.//' | sort -n | tail -1)
+          N=$(( ${LAST_N:-0} + 1 ))
+          VERSION="${BASE}-beta.${N}"
+          echo "::notice::compute-next-version (beta): latest_stable=${LATEST_STABLE} base=${BASE} last_beta_n=${LAST_N:-<none>} -> ${VERSION}"
+        else
+          echo "::error::Unknown track '${TRACK}'. Expected 'stable' or 'beta'." >&2
+          exit 1
+        fi
+
+        echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+      env:
+        TRACK: ${{ inputs.track }}

--- a/.github/workflows/beta-autorelease.yml
+++ b/.github/workflows/beta-autorelease.yml
@@ -1,0 +1,238 @@
+name: Beta Auto-Release
+
+#
+# Publishes a beta prerelease whenever a PR is merged into the `beta` branch
+# (every fern-bot regeneration PR or human PR). The version is computed from
+# the existing tags by the compute-next-version action, the version files are
+# stamped, a CHANGELOG.md entry is generated from the merged squash-commit
+# message, the commit is tagged, and a GitHub prerelease is created.
+#
+# Triggering on `pull_request: closed` (merged) rather than `push` means:
+#   - the bot's own "Release ..." commit cannot re-trigger the workflow, so no
+#     infinite-loop guard is needed (a PR merges exactly once);
+#   - two PRs merging in quick succession each get their own run with their own
+#     computed version, instead of racing on the same `push` event.
+# All inflow to `beta` goes through PRs, so nothing is missed.
+#
+# This runs on the `beta` branch, so CHANGELOG.md here is the beta track's
+# own changelog and never collides with the stable changelog on `main`.
+#
+# `workflow_dispatch` is kept only as a manual backup; it is not used in the
+# normal hands-off flow.
+#
+# Security notes:
+#   - This uses `pull_request` (NOT `pull_request_target`). PRs from forks run
+#     with a read-only token and no access to secrets, so a malicious fork PR
+#     cannot reach the release credentials. All real inflow (fern-bot, org
+#     members) comes from same-repo branches, which do have the needed access.
+#   - The workflow never executes checked-out PR code; it only reads the merge
+#     commit message and stamps files. Untrusted text is handled via shell
+#     variables/`env:`, never interpolated into `run:` via `${{ }}`.
+#   - Permissions default to none and are granted minimally at the job level.
+#
+
+on:
+  pull_request:
+    branches: [beta]
+    types: [closed]
+  workflow_dispatch:
+
+# Serialize releases so concurrent merges cut versions one at a time and the
+# push-back to `beta` never races.
+concurrency:
+  group: beta-release
+  cancel-in-progress: false
+
+# Least privilege: grant nothing by default; the job opts into exactly what it
+# needs (pushing the release commit/tag and creating the GitHub release).
+permissions: {}
+
+jobs:
+  beta-release:
+    # Run for a genuinely merged PR into beta, or a manual dispatch on beta.
+    if: >-
+      github.repository == 'auth0/go-auth0' &&
+      (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+
+    steps:
+      # Checkout the code
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: beta
+
+      # Compute the next beta version from the existing tags
+      - id: get_version
+        uses: ./.github/actions/compute-next-version
+        with:
+          track: beta
+
+      # Defense in depth: refuse to proceed if the computed tag already exists,
+      # so a re-run can never overwrite a published release or create a
+      # duplicate release commit. Mirrors the stable pipeline's guard.
+      - id: tag_exists
+        uses: ./.github/actions/tag-exists
+        with:
+          tag: ${{ steps.get_version.outputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: steps.tag_exists.outputs.exists == 'true'
+        shell: bash
+        run: |
+          echo "::error::Tag ${{ steps.get_version.outputs.version }} already exists; aborting to avoid overwriting a published release."
+          exit 1
+
+      # Build the release notes from the structured squash-commit message of
+      # the merged regeneration PR. The combined beta PR mixes stable-mirrored
+      # and beta-only changes in one squash commit, which cannot be told apart
+      # from code or paths, so the author marks them at merge time:
+      #
+      #   <!-- BETA -->
+      #   - feat: add Sandbox preview API (Beta)
+      #   <!-- /BETA -->
+      #   <!-- STABLE -->
+      #   - feat: add tenant security headers
+      #   <!-- /STABLE -->
+      #
+      # We render a self-contained entry with a "Beta" section and a
+      # "Stable (from main)" section. If the markers are absent we fall back to
+      # the raw commit subject so the release never produces empty notes.
+      - id: notes
+        name: Generate release notes
+        shell: bash
+        run: |
+          MSG=$(git log -1 --pretty='%B' HEAD)
+
+          extract() { # $1=open marker  $2=close marker
+            printf '%s\n' "${MSG}" | awk -v o="$1" -v c="$2" '
+              $0 ~ o {grab=1; next}
+              $0 ~ c {grab=0}
+              grab {print}
+            ' | sed '/^[[:space:]]*$/d'
+          }
+
+          BETA_SECTION=$(extract '<!-- BETA -->' '<!-- /BETA -->')
+          STABLE_SECTION=$(extract '<!-- STABLE -->' '<!-- /STABLE -->')
+
+          # Use an unpredictable heredoc delimiter so untrusted commit-message
+          # content cannot forge the terminator and inject extra step outputs.
+          DELIM="RELEASE_NOTES_$(openssl rand -hex 16)"
+          {
+            echo "RELEASE_NOTES<<${DELIM}"
+            if [ -z "${BETA_SECTION}" ] && [ -z "${STABLE_SECTION}" ]; then
+              # No structured markers: fall back to the commit subject line.
+              echo "**Beta**"
+              echo "- $(printf '%s\n' "${MSG}" | head -1)"
+            else
+              echo "**Beta**"
+              if [ -n "${BETA_SECTION}" ]; then
+                echo "${BETA_SECTION}"
+              else
+                echo "- No beta-only changes in this release."
+              fi
+              echo ""
+              echo "**Stable (from main)**"
+              if [ -n "${STABLE_SECTION}" ]; then
+                echo "${STABLE_SECTION}"
+              else
+                echo "- No stable changes in this release."
+              fi
+            fi
+            echo "${DELIM}"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+
+      # Stamp the version into .version and meta.go and prepend the CHANGELOG.md
+      # entry. This only edits files on disk; the commit is created separately
+      # through the GitHub API (next step) so GitHub signs it server-side.
+      - name: Stamp version files and changelog
+        shell: bash
+        run: |
+          echo "${VERSION}" > .version
+          sed -i -E 's/Version = ".*"/Version = "'"${VERSION}"'"/' meta.go
+
+          DATE=$(date -u +%Y-%m-%d)
+          [ -f CHANGELOG.md ] || printf '# Change Log\n\n' > CHANGELOG.md
+          {
+            head -2 CHANGELOG.md
+            echo "## [${VERSION}](https://github.com/auth0/go-auth0/tree/${VERSION}) (${DATE})"
+            echo ""
+            echo "${RELEASE_NOTES}"
+            echo ""
+            tail -n +3 CHANGELOG.md
+          } > CHANGELOG.md.tmp
+          mv CHANGELOG.md.tmp CHANGELOG.md
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.RELEASE_NOTES }}
+
+      # Create the release commit through the GitHub API. Commits created via
+      # the API are signed by GitHub's web-flow key server-side, so the release
+      # commit shows as "Verified" (matching how stable releases are signed),
+      # with no GPG key to manage. The commit is built from blobs/tree/commit
+      # and the `beta` ref is fast-forwarded to it.
+      - id: stamp
+        name: Create signed release commit
+        uses: actions/github-script@v7
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const branch = 'beta';
+            const version = process.env.VERSION;
+            const files = ['.version', 'meta.go', 'CHANGELOG.md'];
+
+            // Current tip of beta = parent of the new commit.
+            const ref = await github.rest.git.getRef({
+              owner, repo, ref: `heads/${branch}`,
+            });
+            const parentSha = ref.data.object.sha;
+            const parentCommit = await github.rest.git.getCommit({
+              owner, repo, commit_sha: parentSha,
+            });
+
+            // Upload each changed file as a blob and assemble a tree.
+            const tree = [];
+            for (const path of files) {
+              const blob = await github.rest.git.createBlob({
+                owner, repo,
+                content: fs.readFileSync(path, 'utf8'),
+                encoding: 'utf-8',
+              });
+              tree.push({ path, mode: '100644', type: 'blob', sha: blob.data.sha });
+            }
+            const newTree = await github.rest.git.createTree({
+              owner, repo, base_tree: parentCommit.data.tree.sha, tree,
+            });
+
+            // Create the commit (GitHub signs this) and move beta to it.
+            const commit = await github.rest.git.createCommit({
+              owner, repo,
+              message: `Release ${version}`,
+              tree: newTree.data.sha,
+              parents: [parentSha],
+            });
+            await github.rest.git.updateRef({
+              owner, repo, ref: `heads/${branch}`, sha: commit.data.sha,
+            });
+
+            core.setOutput('SHA', commit.data.sha);
+            core.notice(`Created signed release commit ${commit.data.sha} for ${version}`);
+
+      # Create the GitHub prerelease. action-gh-release creates the tag at the
+      # signed commit, so the tag points at the verified release commit.
+      - uses: ./.github/actions/release-create
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ steps.get_version.outputs.version }}
+          body: ${{ steps.notes.outputs.RELEASE_NOTES }}
+          tag: ${{ steps.get_version.outputs.version }}
+          commit: ${{ steps.stamp.outputs.SHA }}
+          prerelease: true

--- a/.github/workflows/beta-autorelease.yml
+++ b/.github/workflows/beta-autorelease.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       # Checkout the code
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: beta
@@ -178,7 +178,7 @@ jobs:
       # and the `beta` ref is fast-forwarded to it.
       - id: stamp
         name: Create signed release commit
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           VERSION: ${{ steps.get_version.outputs.version }}
         with:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -6,7 +6,7 @@ on:
       - opened
       - synchronize
   push:
-    branches: [main, v2]
+    branches: [main, v2, beta]
   schedule:
     - cron: "30 0 1,15 * *"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Main Workflow
 
 on:
   push:
-    branches: [main, v2]
+    branches: [main, v2, beta]
   pull_request:
 
 jobs:

--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -2,9 +2,9 @@ name: SCA
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "beta"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "beta"]
 
 jobs:
   snyk-cli:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,50 @@ make test-record   # Record new HTTP interactions
 make test-e2e      # Run tests against real Auth0 tenant
 ```
 
+## Beta Track Releases
+
+> Applies only when working on the `beta` branch.
+
+This SDK ships two tracks from one module path (`github.com/auth0/go-auth0/v2`):
+
+- **Stable** (`main`): EA/GA endpoints only. Released by a maintainer via a `release/*` branch.
+- **Beta** (`beta`): a superset of stable plus beta-only endpoints. Released automatically when a PR is merged into `beta`.
+
+The `beta` branch is **regenerated** from the stable spec plus the beta-only spec files; it is never produced by merging `main` into `beta`. It receives one combined regeneration PR (stable + beta) as a single squash commit. The beta-only versus stable-mirrored split cannot be detected from code or file paths, so it must be recorded in the squash commit message.
+
+### Versioning
+
+Beta = the next stable minor + `-beta.N`, derived from git tags. Latest stable `v2.13.0` -> beta `v2.14.0-beta.N`; `-beta.N` auto-increments; once stable `v2.14.0` ships, beta rolls to `v2.15.0-beta.1`. No state file.
+
+### When merging a beta regeneration PR
+
+Squash and merge with a commit message that marks each group:
+
+```
+Regenerate SDK (stable + beta) (#<pr-number>)
+
+<!-- BETA -->
+- feat: add `Management.Sandbox` preview API (Beta)
+<!-- /BETA -->
+
+<!-- STABLE -->
+- feat: add tenant security headers configuration
+<!-- /STABLE -->
+```
+
+- Beta-only changes go inside the `BETA` markers; stable-mirrored changes go inside the `STABLE` markers.
+- The `<!-- ... -->` markers are HTML comments and stay invisible in GitHub's rendered view.
+- Omitting a section renders a "No ... changes in this release." note; omitting both falls back to the raw commit subject. Always prefer the structured form.
+- Everything reaches `beta` through a PR. Never push directly to `beta` (a direct push will not trigger a release).
+
+### Do not hand-edit release files on `beta`
+
+The Beta Auto-Release workflow (`.github/workflows/beta-autorelease.yml`) owns versioning. When a PR is merged into `beta` it computes the next `vX.Y.0-beta.N`, aborts if that tag already exists, stamps `.version` and `meta.go`, prepends a `CHANGELOG.md` entry with separate **Beta** and **Stable (from main)** sections, creates the release commit **through the GitHub API** (so it is signed/Verified, no GPG key), tags it, and publishes a prerelease. Never manually bump `.version`, `meta.go`, or `CHANGELOG.md` on `beta`.
+
+### Hand-written code
+
+The `authentication/` package is hand-written and is **not** regenerated on `beta`. A fix on `main` does not reach `beta` automatically, so hand-written changes must be PR'd to **both** `main` and `beta`.
+
 ## Important Notes for Agents
 
 - **Never modify auto-generated code** in the `management/` package unless explicitly asked
@@ -175,3 +219,4 @@ make test-e2e      # Run tests against real Auth0 tenant
 - The SDK uses pointer fields extensively - use safe getters to avoid nil panics
 - Authentication package is hand-written and can be modified carefully
 - Follow existing code patterns, especially in the authentication package
+- On the `beta` branch, never hand-edit `.version`, `meta.go`, or `CHANGELOG.md`; mark beta vs. stable changes in the squash commit message (see "Beta Track Releases")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,105 @@ This SDK is auto-generated from Auth0's OpenAPI specifications. Most of the mana
 
 **Manual modifications are only allowed in the `authentication` package**, which contains hand-written code for authentication flows.
 
+## Beta Track Releases
+
+> This section applies only on the `beta` branch.
+
+The SDK ships two parallel tracks from one Go module path
+(`github.com/auth0/go-auth0/v2`):
+
+- **Stable** (`main` branch): EA/GA endpoints only. Released the usual way, by a maintainer, through a `release/*` branch.
+- **Beta** (`beta` branch): a superset that contains everything in stable **plus** beta-only endpoints. Released automatically whenever a PR is merged into `beta`.
+
+Consumers opt into beta explicitly; a plain `go get` never selects it:
+
+```sh
+# Stable (default): always resolves to the latest stable release.
+go get github.com/auth0/go-auth0/v2
+
+# Beta: explicit prerelease pin.
+go get github.com/auth0/go-auth0/v2@v2.14.0-beta.1
+```
+
+### How beta stays a superset of stable
+
+The `beta` branch is **regenerated** from the stable spec plus the beta-only
+spec files. It is never produced by `git merge main -> beta`. When endpoints
+change upstream, fern-bot opens a regeneration PR into `beta` (combined stable +
+beta) and a separate PR into `main` (stable only). Do **not** merge `main` into
+`beta`.
+
+**Hand-written code** (the `authentication/` package) is not regenerated, so a
+fix made on `main` does not reach `beta` automatically. Hand-written changes must
+be opened as separate PRs to **both** `main` and `beta`.
+
+### How beta versions are numbered
+
+Beta always carries the **next** stable minor with a `-beta.N` suffix, derived
+entirely from the git tags (no state file):
+
+- Latest stable `v2.13.0` -> beta is `v2.14.0-beta.N`.
+- `-beta.N` auto-increments on each beta release.
+- The moment stable `v2.14.0` is tagged, the next beta automatically becomes
+  `v2.15.0-beta.1`.
+
+Because `v2.14.0-beta.3` sorts before `v2.14.0` in semver, beta is never picked
+up by `go get` unless pinned.
+
+### Merging a beta regeneration PR
+
+The combined regeneration PR lands as a **single squash commit**, and the
+beta-only versus stable-mirrored split cannot be recovered from the code or file
+paths. The person merging records the split in the squash commit message, and
+the Beta Auto-Release workflow parses it into the changelog and release notes.
+
+When you squash and merge a beta PR, format the commit message like this:
+
+```
+Regenerate SDK (stable + beta) (#<pr-number>)
+
+<!-- BETA -->
+- feat: add `Management.Sandbox` preview API (Beta)
+- feat: add device-flow polling endpoint (Beta)
+<!-- /BETA -->
+
+<!-- STABLE -->
+- feat: add tenant security headers configuration
+- feat: add minute-based session lifetime fields
+<!-- /STABLE -->
+```
+
+Guidelines:
+
+- Put **beta-only** changes inside the `BETA` markers and **stable-mirrored** changes inside the `STABLE` markers.
+- The `<!-- ... -->` markers are HTML comments, so they stay invisible in GitHub's rendered view while remaining easy to parse.
+- If a release has no beta-only changes, leave the `BETA` section empty or omit it. The workflow records "No beta-only changes in this release." (and likewise for a missing `STABLE` section).
+- If you omit both sections entirely, the workflow falls back to the raw commit subject so the release is never empty. Always prefer the structured form.
+- All changes must reach `beta` through a PR. Do not push commits directly to `beta`; a direct push will not trigger a release.
+
+### What happens automatically after merge
+
+Do **not** hand-edit `.version`, `meta.go`, or `CHANGELOG.md` on the `beta`
+branch. When a PR is merged into `beta`, the Beta Auto-Release workflow
+(`.github/workflows/beta-autorelease.yml`):
+
+1. Computes the next beta version from the existing tags (`vX.Y.0-beta.N`).
+2. Aborts if that tag already exists, so a re-run can never overwrite a published release.
+3. Builds the release notes by parsing the `BETA` / `STABLE` sections of the merge commit message.
+4. Stamps `.version` and `meta.go`, and prepends a self-contained `CHANGELOG.md` entry with a **Beta** section and a **Stable (from main)** section.
+5. Creates the `Release vX.Y.0-beta.N` commit **through the GitHub API**, so the commit is signed by GitHub and shows as **Verified** (the same way stable releases are signed). No GPG key is involved.
+6. Tags that commit and publishes a GitHub release marked as a prerelease.
+
+The release fires on PR merge (not on raw pushes), so the workflow's own release
+commit cannot re-trigger it, and concurrent merges are serialized and each get
+their own version.
+
+### CI on the beta branch
+
+Beta is gated by the same checks as `main`: the build/lint/test workflow
+(`main.yml`), Go vulnerability scanning (`govulncheck.yml`), and the SCA scan
+(`sca_scan.yml`) all run on `beta` pushes and PRs.
+
 ## Safe Getters
 
 The SDK offers safe getters to access pointer fields and avoid panics on nil pointers.


### PR DESCRIPTION
### 🔧 Changes

Adds the repo-side automation for a second, parallel **beta** SDK release track alongside the existing stable track, shipped from one Go module path (`github.com/auth0/go-auth0/v2`). Stable stays on `main` exactly as today; beta lives on a new `beta` branch and carries everything stable has plus beta-only endpoints. Consumers opt into beta explicitly with a prerelease pin, and a plain `go get` never selects it because `vX.Y.Z-beta.N` sorts before `vX.Y.Z` in semver.

This PR is **infrastructure only**. It changes nothing on `main` today and stays inert until the `beta` branch is created and the upstream Fern beta generation target is wired (see References).

New:

- **`.github/actions/compute-next-version`** — composite action that derives the next version from the git tags (the single source of truth). Stable resolves to the next minor of the latest stable tag; beta resolves to `vX.(Y+1).0-beta.N` with an auto-incrementing counter. A strict `^v2\.[0-9]+\.[0-9]+$` tag filter ensures it only ever anchors to the current `v2` stable line, so `v1.*` releases and prerelease/`-rc` tags are never picked up.
- **`.github/workflows/beta-autorelease.yml`** — publishes a beta prerelease when a PR is merged into `beta`. It computes the version, aborts if the tag already exists, builds release notes by parsing `<!-- BETA -->` / `<!-- STABLE -->` sections from the merge commit, stamps `.version`/`meta.go`/`CHANGELOG.md`, creates the `Release …` commit through the GitHub API so it is signed and shows as **Verified**, then tags it and publishes a GitHub prerelease.

Changed:

- **`main.yml`**, **`govulncheck.yml`**, **`sca_scan.yml`** — add `beta` to their triggers so the new branch gets the same build/lint/test, Go vulnerability, and SCA coverage as `main`.
- **`CONTRIBUTING.md`**, **`AGENTS.md`** — document the beta track: how it stays a superset (regenerated, never merged), versioning, the squash-commit marker convention used at merge time, the hand-written `authentication/` two-branch rule, and the fact that release files are owned by automation and must not be hand-edited.

### 📚 References

- Requires a corresponding upstream Fern beta generation target that opens a combined (stable + beta) regeneration PR into the `beta` branch. Until that and the `beta` branch exist, the new workflow does not fire.

### 🔬 Testing

- The version-computation logic was validated locally against a realistic tag set (mixed `v1.*` and `v2.*` lines, double-digit minors, existing `-beta`/`-alpha`/`-rc` tags): stable resolved to the next `v2` minor and beta to the next `vX.Y.0-beta.N`, never selecting a `v1` or prerelease tag.
- All new and changed workflow/action YAML was validated as parseable.
- No runtime behavior on `main` changes; the beta workflow only triggers on PR merges into the `beta` branch, which does not exist yet.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A) — N/A; CI/release automation, validated as described above
- [x] I have added documentation for all new/changed functionality (or N/A) — `CONTRIBUTING.md` and `AGENTS.md` updated
