### PR TITLE
feat: Add InvitationLandingClientID in MyOrganizationConfiguration

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -310,6 +310,10 @@ type MyOrganizationConfiguration struct {
 	// associated with organizations for this client.
 	// Possible values: "allow", "allow_if_empty".
 	ConnectionDeletionBehavior *string `json:"connection_deletion_behavior,omitempty"`
+
+	// InvitationLandingClientID is the client ID used as the invitation landing page
+	// when creating invitations through the My Organization API.
+	InvitationLandingClientID *string `json:"invitation_landing_client_id,omitempty"`
 }
 
 // ClientTokenExchange allows configuration for token exchange.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -10244,6 +10244,14 @@ func (m *MyOrganizationConfiguration) GetConnectionProfileID() string {
 	return *m.ConnectionProfileID
 }
 
+// GetInvitationLandingClientID returns the InvitationLandingClientID field if it's non-nil, zero value otherwise.
+func (m *MyOrganizationConfiguration) GetInvitationLandingClientID() string {
+	if m == nil || m.InvitationLandingClientID == nil {
+		return ""
+	}
+	return *m.InvitationLandingClientID
+}
+
 // GetUserAttributeProfileID returns the UserAttributeProfileID field if it's non-nil, zero value otherwise.
 func (m *MyOrganizationConfiguration) GetUserAttributeProfileID() string {
 	if m == nil || m.UserAttributeProfileID == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -12817,6 +12817,16 @@ func TestMyOrganizationConfiguration_GetConnectionProfileID(tt *testing.T) {
 	m.GetConnectionProfileID()
 }
 
+func TestMyOrganizationConfiguration_GetInvitationLandingClientID(tt *testing.T) {
+	var zeroValue string
+	m := &MyOrganizationConfiguration{InvitationLandingClientID: &zeroValue}
+	m.GetInvitationLandingClientID()
+	m = &MyOrganizationConfiguration{}
+	m.GetInvitationLandingClientID()
+	m = nil
+	m.GetInvitationLandingClientID()
+}
+
 func TestMyOrganizationConfiguration_GetUserAttributeProfileID(tt *testing.T) {
 	var zeroValue string
 	m := &MyOrganizationConfiguration{UserAttributeProfileID: &zeroValue}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds the `InvitationLandingClientID` field to the `MyOrganizationConfiguration` struct.

This field sets the client ID used for the invitation landing page when creating invitations through the My Organization API, giving callers control over where invitees are directed.

- **New field:** `MyOrganizationConfiguration.InvitationLandingClientID` (`*string`, JSON `invitation_landing_client_id`)
- **New getter:** `GetInvitationLandingClientID()` returns the value or the zero value when unset

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- API Docs: https://auth0.com/docs/api/management/v2/clients/post-clients#body-my-organization-configuration-invitation-landing-client-id
- Terraform Impl: https://github.com/auth0/terraform-provider-auth0/pull/1609

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Added unit test `TestMyOrganizationConfiguration_GetInvitationLandingClientID` covering the getter for set, unset, and nil-receiver cases.

Run tests locally:

```bash
go test ./management/ -run TestMyOrganizationConfiguration_GetInvitationLandingClientID
```

- **Live Management API validation.** The field was manually tested directly against `POST/GET/PATCH /api/v2/clients` on a real tenant (27 cases). Summary of what was confirmed:

| Area | Result |
| --- | --- |
| Create | Field persists and is echoed in the `201` body; optional (absent when omitted). |
| Read | Returned on `GET /{id}`, in the list response per-item, and selectable via `fields=`; absent when unset. |
| Update | PATCH adds/changes it and echoes it; a PATCH of unrelated fields preserves it. |
| Removal | `my_organization_configuration: null` removes the whole object. PATCH replaces the object **wholesale** — an omitted field is dropped (the provider always re-sends the full object, so this is safe). |
| Type validation | `null` / number / array / empty-string all rejected with `400 invalid_body`. |
| Entitlement gate | Without `my_org_member_management`, the field alone returns `403 operation_not_supported` (other four fields unaffected). |
| Reference checks | Nonexistent client → `404`; client with `organization_usage = deny` → `400 "...does not allow organizations"`. |

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
