### PR TITLE
feat: add support for missing fields in connected_accounts

### DIFF
--- a/internal/tag/tag.go
+++ b/internal/tag/tag.go
@@ -7,7 +7,7 @@ import (
 // Scopes is used to get the list of scopes.
 func Scopes(v interface{}) (scopes []string) {
 	val := reflect.ValueOf(v)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 
@@ -17,7 +17,7 @@ func Scopes(v interface{}) (scopes []string) {
 		if scope, ok := typ.Field(i).Tag.Lookup("scope"); ok {
 			if scope != "" {
 				field := val.Field(i)
-				if field.Kind() == reflect.Ptr {
+				if field.Kind() == reflect.Pointer {
 					field = field.Elem()
 				}
 
@@ -34,7 +34,7 @@ func Scopes(v interface{}) (scopes []string) {
 // SetScopes is used for setting the scopes.
 func SetScopes(v interface{}, enable bool, scopes ...string) {
 	val := reflect.ValueOf(v)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 
@@ -56,7 +56,7 @@ func SetScopes(v interface{}, enable bool, scopes ...string) {
 				field := val.Field(i)
 				v := reflect.ValueOf(enable)
 
-				if field.Kind() == reflect.Ptr {
+				if field.Kind() == reflect.Pointer {
 					v = reflect.ValueOf(&enable)
 				}
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -15173,6 +15173,14 @@ func (u *UserConnectedAccount) GetConnection() string {
 	return *u.Connection
 }
 
+// GetConnectionID returns the ConnectionID field if it's non-nil, zero value otherwise.
+func (u *UserConnectedAccount) GetConnectionID() string {
+	if u == nil || u.ConnectionID == nil {
+		return ""
+	}
+	return *u.ConnectionID
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (u *UserConnectedAccount) GetCreatedAt() time.Time {
 	if u == nil || u.CreatedAt == nil {
@@ -15197,12 +15205,28 @@ func (u *UserConnectedAccount) GetID() string {
 	return *u.ID
 }
 
+// GetOrganizationID returns the OrganizationID field if it's non-nil, zero value otherwise.
+func (u *UserConnectedAccount) GetOrganizationID() string {
+	if u == nil || u.OrganizationID == nil {
+		return ""
+	}
+	return *u.OrganizationID
+}
+
 // GetScopes returns the Scopes field if it's non-nil, zero value otherwise.
 func (u *UserConnectedAccount) GetScopes() []string {
 	if u == nil || u.Scopes == nil {
 		return nil
 	}
 	return *u.Scopes
+}
+
+// GetStrategy returns the Strategy field if it's non-nil, zero value otherwise.
+func (u *UserConnectedAccount) GetStrategy() string {
+	if u == nil || u.Strategy == nil {
+		return ""
+	}
+	return *u.Strategy
 }
 
 // String returns a string representation of UserConnectedAccount.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -19036,6 +19036,16 @@ func TestUserConnectedAccount_GetConnection(tt *testing.T) {
 	u.GetConnection()
 }
 
+func TestUserConnectedAccount_GetConnectionID(tt *testing.T) {
+	var zeroValue string
+	u := &UserConnectedAccount{ConnectionID: &zeroValue}
+	u.GetConnectionID()
+	u = &UserConnectedAccount{}
+	u.GetConnectionID()
+	u = nil
+	u.GetConnectionID()
+}
+
 func TestUserConnectedAccount_GetCreatedAt(tt *testing.T) {
 	var zeroValue time.Time
 	u := &UserConnectedAccount{CreatedAt: &zeroValue}
@@ -19066,6 +19076,16 @@ func TestUserConnectedAccount_GetID(tt *testing.T) {
 	u.GetID()
 }
 
+func TestUserConnectedAccount_GetOrganizationID(tt *testing.T) {
+	var zeroValue string
+	u := &UserConnectedAccount{OrganizationID: &zeroValue}
+	u.GetOrganizationID()
+	u = &UserConnectedAccount{}
+	u.GetOrganizationID()
+	u = nil
+	u.GetOrganizationID()
+}
+
 func TestUserConnectedAccount_GetScopes(tt *testing.T) {
 	var zeroValue []string
 	u := &UserConnectedAccount{Scopes: &zeroValue}
@@ -19074,6 +19094,16 @@ func TestUserConnectedAccount_GetScopes(tt *testing.T) {
 	u.GetScopes()
 	u = nil
 	u.GetScopes()
+}
+
+func TestUserConnectedAccount_GetStrategy(tt *testing.T) {
+	var zeroValue string
+	u := &UserConnectedAccount{Strategy: &zeroValue}
+	u.GetStrategy()
+	u = &UserConnectedAccount{}
+	u.GetStrategy()
+	u = nil
+	u.GetStrategy()
 }
 
 func TestUserConnectedAccount_String(t *testing.T) {

--- a/management/user.go
+++ b/management/user.go
@@ -504,33 +504,6 @@ type UserConnectedAccount struct {
 	OrganizationID *string `json:"organization_id,omitempty"`
 }
 
-// GetConnectionID returns the ConnectionID field if set, otherwise an empty string.
-func (u *UserConnectedAccount) GetConnectionID() string {
-	if u == nil || u.ConnectionID == nil {
-		return ""
-	}
-
-	return *u.ConnectionID
-}
-
-// GetStrategy returns the Strategy field if set, otherwise an empty string.
-func (u *UserConnectedAccount) GetStrategy() string {
-	if u == nil || u.Strategy == nil {
-		return ""
-	}
-
-	return *u.Strategy
-}
-
-// GetOrganizationID returns the OrganizationID field if set, otherwise an empty string.
-func (u *UserConnectedAccount) GetOrganizationID() string {
-	if u == nil || u.OrganizationID == nil {
-		return ""
-	}
-
-	return *u.OrganizationID
-}
-
 // UserManager manages Auth0 User resources.
 type UserManager manager
 

--- a/management/user.go
+++ b/management/user.go
@@ -509,6 +509,7 @@ func (u *UserConnectedAccount) GetConnectionID() string {
 	if u == nil || u.ConnectionID == nil {
 		return ""
 	}
+
 	return *u.ConnectionID
 }
 
@@ -517,6 +518,7 @@ func (u *UserConnectedAccount) GetStrategy() string {
 	if u == nil || u.Strategy == nil {
 		return ""
 	}
+
 	return *u.Strategy
 }
 
@@ -525,6 +527,7 @@ func (u *UserConnectedAccount) GetOrganizationID() string {
 	if u == nil || u.OrganizationID == nil {
 		return ""
 	}
+
 	return *u.OrganizationID
 }
 

--- a/management/user.go
+++ b/management/user.go
@@ -488,6 +488,10 @@ type UserConnectedAccount struct {
 	ID *string `json:"id,omitempty"`
 	// Connection is the name of the connection associated with the account.
 	Connection *string `json:"connection,omitempty"`
+	// ConnectionID is the unique identifier of the connection associated with the account.
+	ConnectionID *string `json:"connection_id,omitempty"`
+	// Strategy is the authentication strategy used by the connection.
+	Strategy *string `json:"strategy,omitempty"`
 	// AccessType is the access type for to the connected account.
 	AccessType *UserConnectedAccountAccessType `json:"access_type,omitempty"`
 	// Scopes are the scopes granted for this connected account.
@@ -496,6 +500,32 @@ type UserConnectedAccount struct {
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	// ExpiresAt is the ISO 8601 timestamp when the connected account expires.
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	// OrganizationID is the identifier of the organization associated with the connected account.
+	OrganizationID *string `json:"organization_id,omitempty"`
+}
+
+// GetConnectionID returns the ConnectionID field if set, otherwise an empty string.
+func (u *UserConnectedAccount) GetConnectionID() string {
+	if u == nil || u.ConnectionID == nil {
+		return ""
+	}
+	return *u.ConnectionID
+}
+
+// GetStrategy returns the Strategy field if set, otherwise an empty string.
+func (u *UserConnectedAccount) GetStrategy() string {
+	if u == nil || u.Strategy == nil {
+		return ""
+	}
+	return *u.Strategy
+}
+
+// GetOrganizationID returns the OrganizationID field if set, otherwise an empty string.
+func (u *UserConnectedAccount) GetOrganizationID() string {
+	if u == nil || u.OrganizationID == nil {
+		return ""
+	}
+	return *u.OrganizationID
 }
 
 // UserManager manages Auth0 User resources.

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -612,6 +612,30 @@ func TestUserManager_ListConnectedAccounts(t *testing.T) {
 	assert.Equal(t, len(connectedAccounts.ConnectedAccounts), 0, "Expected no connected accounts for the user")
 }
 
+func TestUserConnectedAccount_UnmarshalNewFields(t *testing.T) {
+	body := `{
+		"connected_accounts": [{
+			"id": "ca_001",
+			"connection": "test-connection",
+			"connection_id": "con_abc123",
+			"strategy": "google-oauth2",
+			"access_type": "offline",
+			"scopes": ["email", "profile"],
+			"created_at": "2025-09-24T12:00:00.000Z",
+			"organization_id": "org_xyz789"
+		}]
+	}`
+
+	var list UserConnectedAccountList
+	require.NoError(t, json.Unmarshal([]byte(body), &list))
+	require.Len(t, list.ConnectedAccounts, 1)
+
+	account := list.ConnectedAccounts[0]
+	assert.Equal(t, "con_abc123", account.GetConnectionID())
+	assert.Equal(t, "google-oauth2", account.GetStrategy())
+	assert.Equal(t, "org_xyz789", account.GetOrganizationID())
+}
+
 func givenAUser(t *testing.T) *User {
 	t.Helper()
 
@@ -664,6 +688,36 @@ func retrieveRefreshTokens(t *testing.T) *RefreshTokenList {
 	require.NoError(t, err)
 
 	return tokens
+}
+
+func TestUserConnectedAccount_GetConnectionID(tt *testing.T) {
+	var zeroValue string
+	u := &UserConnectedAccount{ConnectionID: &zeroValue}
+	u.GetConnectionID()
+	u = &UserConnectedAccount{}
+	u.GetConnectionID()
+	u = nil
+	u.GetConnectionID()
+}
+
+func TestUserConnectedAccount_GetStrategy(tt *testing.T) {
+	var zeroValue string
+	u := &UserConnectedAccount{Strategy: &zeroValue}
+	u.GetStrategy()
+	u = &UserConnectedAccount{}
+	u.GetStrategy()
+	u = nil
+	u.GetStrategy()
+}
+
+func TestUserConnectedAccount_GetOrganizationID(tt *testing.T) {
+	var zeroValue string
+	u := &UserConnectedAccount{OrganizationID: &zeroValue}
+	u.GetOrganizationID()
+	u = &UserConnectedAccount{}
+	u.GetOrganizationID()
+	u = nil
+	u.GetOrganizationID()
 }
 
 func cleanupUser(t *testing.T, userID string) {

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -691,36 +691,6 @@ func retrieveRefreshTokens(t *testing.T) *RefreshTokenList {
 	return tokens
 }
 
-func TestUserConnectedAccount_GetConnectionID(_ *testing.T) {
-	var zeroValue string
-	u := &UserConnectedAccount{ConnectionID: &zeroValue}
-	u.GetConnectionID()
-	u = &UserConnectedAccount{}
-	u.GetConnectionID()
-	u = nil
-	u.GetConnectionID()
-}
-
-func TestUserConnectedAccount_GetStrategy(_ *testing.T) {
-	var zeroValue string
-	u := &UserConnectedAccount{Strategy: &zeroValue}
-	u.GetStrategy()
-	u = &UserConnectedAccount{}
-	u.GetStrategy()
-	u = nil
-	u.GetStrategy()
-}
-
-func TestUserConnectedAccount_GetOrganizationID(_ *testing.T) {
-	var zeroValue string
-	u := &UserConnectedAccount{OrganizationID: &zeroValue}
-	u.GetOrganizationID()
-	u = &UserConnectedAccount{}
-	u.GetOrganizationID()
-	u = nil
-	u.GetOrganizationID()
-}
-
 func cleanupUser(t *testing.T, userID string) {
 	t.Helper()
 

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -627,6 +627,7 @@ func TestUserConnectedAccount_UnmarshalNewFields(t *testing.T) {
 	}`
 
 	var list UserConnectedAccountList
+
 	require.NoError(t, json.Unmarshal([]byte(body), &list))
 	require.Len(t, list.ConnectedAccounts, 1)
 
@@ -690,7 +691,7 @@ func retrieveRefreshTokens(t *testing.T) *RefreshTokenList {
 	return tokens
 }
 
-func TestUserConnectedAccount_GetConnectionID(tt *testing.T) {
+func TestUserConnectedAccount_GetConnectionID(_ *testing.T) {
 	var zeroValue string
 	u := &UserConnectedAccount{ConnectionID: &zeroValue}
 	u.GetConnectionID()
@@ -700,7 +701,7 @@ func TestUserConnectedAccount_GetConnectionID(tt *testing.T) {
 	u.GetConnectionID()
 }
 
-func TestUserConnectedAccount_GetStrategy(tt *testing.T) {
+func TestUserConnectedAccount_GetStrategy(_ *testing.T) {
 	var zeroValue string
 	u := &UserConnectedAccount{Strategy: &zeroValue}
 	u.GetStrategy()
@@ -710,7 +711,7 @@ func TestUserConnectedAccount_GetStrategy(tt *testing.T) {
 	u.GetStrategy()
 }
 
-func TestUserConnectedAccount_GetOrganizationID(tt *testing.T) {
+func TestUserConnectedAccount_GetOrganizationID(_ *testing.T) {
 	var zeroValue string
 	u := &UserConnectedAccount{OrganizationID: &zeroValue}
 	u.GetOrganizationID()


### PR DESCRIPTION
### 🔧 Changes

**`UserConnectedAccount` — new fields**

Added three new fields to `UserConnectedAccount` in `management/user.go`:

| Field | Type | JSON key | Description |
|-------|------|----------|-------------|
| `ConnectionID` | `*string` | `connection_id` | Unique identifier of the connection associated with the account |
| `Strategy` | `*string` | `strategy` | Authentication strategy used by the connection (e.g. `"google-oauth2"`) |
| `OrganizationID` | `*string` | `organization_id` | Identifier of the organization associated with the connected account |

Generated nil-safe getter methods (`GetConnectionID()`, `GetStrategy()`, `GetOrganizationID()`) are included in `management/management.gen.go`.

**`internal/tag` — use canonical reflect constant** - `gocritic` lint fix

Replaced four uses of `reflect.Ptr` with `reflect.Pointer` in `internal/tag/tag.go`. Both are identical at runtime; `reflect.Pointer` is the canonical name introduced in Go 1.18 and `reflect.Ptr` is its deprecated alias.

This was a `gocritic` lint fix

### 🔬 Testing

- `TestUserConnectedAccount_UnmarshalNewFields` — unmarshals a JSON payload containing all three new fields and asserts the getter return values match expected strings; covers nil-safety via the generated getter tests.
