### PR TITLE
feat: add SendBackChannelNonce and Type fields to connection

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -772,7 +772,7 @@ type ConnectionOptionsOkta struct {
 	//  }
 	OIDCMetadata map[string]interface{} `json:"oidc_metadata,omitempty"`
 
-	Type *string `json:"type"`
+	Type *string `json:"type,omitempty"`
 
 	// When true and type is 'back_channel',
 	// includes a cryptographic nonce in authorization requests to prevent replay attacks.
@@ -1247,7 +1247,7 @@ type ConnectionOptionsOIDC struct {
 	AuthorizationEndpoint *string `json:"authorization_endpoint"`
 	Issuer                *string `json:"issuer"`
 	JWKSURI               *string `json:"jwks_uri"`
-	Type                  *string `json:"type"`
+	Type                  *string `json:"type,omitempty"`
 	UserInfoEndpoint      *string `json:"userinfo_endpoint"`
 	TokenEndpoint         *string `json:"token_endpoint"`
 	Scope                 *string `json:"scope,omitempty"`

--- a/management/connection.go
+++ b/management/connection.go
@@ -772,6 +772,13 @@ type ConnectionOptionsOkta struct {
 	//  }
 	OIDCMetadata map[string]interface{} `json:"oidc_metadata,omitempty"`
 
+	Type *string `json:"type"`
+
+	// When true and type is 'back_channel',
+	// includes a cryptographic nonce in authorization requests to prevent replay attacks.
+	// The identity provider must include this nonce in the ID token for validation.
+	SendBackChannelNonce *bool `json:"send_back_channel_nonce,omitempty"`
+
 	// DPoPSigningAlg is the algorithm used to sign the DPoP proof. Currently allowed values: ES256, Ed25519.
 	DPoPSigningAlg *string `json:"dpop_signing_alg,omitempty"`
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5998,6 +5998,14 @@ func (c *ConnectionOptionsOkta) GetScope() string {
 	return *c.Scope
 }
 
+// GetSendBackChannelNonce returns the SendBackChannelNonce field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOkta) GetSendBackChannelNonce() bool {
+	if c == nil || c.SendBackChannelNonce == nil {
+		return false
+	}
+	return *c.SendBackChannelNonce
+}
+
 // GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsOkta) GetSetUserAttributes() string {
 	if c == nil || c.SetUserAttributes == nil {
@@ -6036,6 +6044,14 @@ func (c *ConnectionOptionsOkta) GetTokenEndpointJwtcaAudFormat() string {
 		return ""
 	}
 	return *c.TokenEndpointJwtcaAudFormat
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOkta) GetType() string {
+	if c == nil || c.Type == nil {
+		return ""
+	}
+	return *c.Type
 }
 
 // GetUpstreamParams returns the UpstreamParams map if it's non-nil, an empty map otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -7409,6 +7409,16 @@ func TestConnectionOptionsOkta_GetScope(tt *testing.T) {
 	c.GetScope()
 }
 
+func TestConnectionOptionsOkta_GetSendBackChannelNonce(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsOkta{SendBackChannelNonce: &zeroValue}
+	c.GetSendBackChannelNonce()
+	c = &ConnectionOptionsOkta{}
+	c.GetSendBackChannelNonce()
+	c = nil
+	c.GetSendBackChannelNonce()
+}
+
 func TestConnectionOptionsOkta_GetSetUserAttributes(tt *testing.T) {
 	var zeroValue string
 	c := &ConnectionOptionsOkta{SetUserAttributes: &zeroValue}
@@ -7457,6 +7467,16 @@ func TestConnectionOptionsOkta_GetTokenEndpointJwtcaAudFormat(tt *testing.T) {
 	c.GetTokenEndpointJwtcaAudFormat()
 	c = nil
 	c.GetTokenEndpointJwtcaAudFormat()
+}
+
+func TestConnectionOptionsOkta_GetType(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsOkta{Type: &zeroValue}
+	c.GetType()
+	c = &ConnectionOptionsOkta{}
+	c.GetType()
+	c = nil
+	c.GetType()
 }
 
 func TestConnectionOptionsOkta_GetUpstreamParams(tt *testing.T) {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds two new fields to `ConnectionOptionsOkta` for Okta enterprise connections:

- `SendBackChannelNonce` (`send_back_channel_nonce`): when enabled and the connection type is `back_channel`, includes a cryptographic nonce in authorization requests to protect against replay attacks. The identity provider must echo this nonce in the ID token for validation.
- `Type` (`type`): specifies the Okta connection type (e.g. `back_channel`).

Generated getter methods `GetSendBackChannelNonce` and `GetType` are added for safe nil-aware access to the new pointer fields.

**`type` uses `json:"type,omitempty"` (both `ConnectionOptionsOkta` and `ConnectionOptionsOIDC`).**

`type` is an enumerated field the API validates whenever the key is present. Okta accepts `[back_channel]`, OIDC accepts `[front_channel, back_channel]`. `null` is not a member of either set. Without `omitempty`, a nil pointer serializes as `"type":null`, so any connection that does not set `type` fails with `400 "options.type" must be ...`. With `omitempty`, an unset `type` is omitted from the payload and only sent when explicitly configured.

This also corrects the existing `ConnectionOptionsOIDC.Type` tag, which carried the same latent bug, the field is optional but not nullable. It went unnoticed because its tests always set `type`.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories
-->

- Helps resolving https://github.com/auth0/terraform-provider-auth0/issues/1610
- Reference PR: https://github.com/auth0/go-auth0/pull/700

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Generated unit tests cover the new getters (`TestConnectionOptionsOkta_GetSendBackChannelNonce`, `TestConnectionOptionsOkta_GetType`) across nil-receiver, nil-field, and set-value cases.
- Run the suite with `make test` (or `go test ./management/...`).

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
