### PR TITLE
feat: add FedCMLogin configuration and related methods to client

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -257,6 +257,9 @@ type Client struct {
 	// Values: "allow_always" or "open_redirect_protection".
 	// Only applies when is_first_party is false and third_party_security_mode is strict.
 	RedirectionPolicy *string `json:"redirection_policy,omitempty"`
+
+	// FedCMLogin holds the Federated Credential Management login configuration.
+	FedCMLogin *FedCMLogin `json:"fedcm_login,omitempty"`
 }
 
 // ExpressConfiguration represents the OIN Express Configuration settings for a client.
@@ -568,6 +571,18 @@ type SessionTransfer struct {
 	AllowRefreshToken             *bool     `json:"allow_refresh_token,omitempty"`
 	EnforceOnlineRefreshTokens    *bool     `json:"enforce_online_refresh_tokens,omitempty"`
 	EnforceCascadeRevocation      *bool     `json:"enforce_cascade_revocation,omitempty"`
+}
+
+// FedCMLogin defines the Federated Credential Management login configuration.
+type FedCMLogin struct {
+	// Google holds the Google FedCM configuration.
+	Google *FedCMLoginGoogle `json:"google,omitempty"`
+}
+
+// FedCMLoginGoogle defines the Google FedCM configuration.
+type FedCMLoginGoogle struct {
+	// IsEnabled shows the Google FedCM prompt on New Universal Login when true.
+	IsEnabled *bool `json:"is_enabled,omitempty"`
 }
 
 // ClientAddons defines the `addons` settings for a Client.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1895,6 +1895,14 @@ func (c *Client) GetExternalMetadataType() string {
 	return *c.ExternalMetadataType
 }
 
+// GetFedCMLogin returns the FedCMLogin field.
+func (c *Client) GetFedCMLogin() *FedCMLogin {
+	if c == nil {
+		return nil
+	}
+	return c.FedCMLogin
+}
+
 // GetFormTemplate returns the FormTemplate field if it's non-nil, zero value otherwise.
 func (c *Client) GetFormTemplate() string {
 	if c == nil || c.FormTemplate == nil {
@@ -8683,6 +8691,32 @@ func (e *ExpressConfiguration) GetUserAttributeProfileID() string {
 // String returns a string representation of ExpressConfiguration.
 func (e *ExpressConfiguration) String() string {
 	return Stringify(e)
+}
+
+// GetGoogle returns the Google field.
+func (f *FedCMLogin) GetGoogle() *FedCMLoginGoogle {
+	if f == nil {
+		return nil
+	}
+	return f.Google
+}
+
+// String returns a string representation of FedCMLogin.
+func (f *FedCMLogin) String() string {
+	return Stringify(f)
+}
+
+// GetIsEnabled returns the IsEnabled field if it's non-nil, zero value otherwise.
+func (f *FedCMLoginGoogle) GetIsEnabled() bool {
+	if f == nil || f.IsEnabled == nil {
+		return false
+	}
+	return *f.IsEnabled
+}
+
+// String returns a string representation of FedCMLoginGoogle.
+func (f *FedCMLoginGoogle) String() string {
+	return Stringify(f)
 }
 
 // GetClientEmail returns the ClientEmail field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2401,6 +2401,13 @@ func TestClient_GetExternalMetadataType(tt *testing.T) {
 	c.GetExternalMetadataType()
 }
 
+func TestClient_GetFedCMLogin(tt *testing.T) {
+	c := &Client{}
+	c.GetFedCMLogin()
+	c = nil
+	c.GetFedCMLogin()
+}
+
 func TestClient_GetFormTemplate(tt *testing.T) {
 	var zeroValue string
 	c := &Client{FormTemplate: &zeroValue}
@@ -10803,6 +10810,39 @@ func TestExpressConfiguration_GetUserAttributeProfileID(tt *testing.T) {
 func TestExpressConfiguration_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ExpressConfiguration{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestFedCMLogin_GetGoogle(tt *testing.T) {
+	f := &FedCMLogin{}
+	f.GetGoogle()
+	f = nil
+	f.GetGoogle()
+}
+
+func TestFedCMLogin_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &FedCMLogin{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestFedCMLoginGoogle_GetIsEnabled(tt *testing.T) {
+	var zeroValue bool
+	f := &FedCMLoginGoogle{IsEnabled: &zeroValue}
+	f.GetIsEnabled()
+	f = &FedCMLoginGoogle{}
+	f.GetIsEnabled()
+	f = nil
+	f.GetIsEnabled()
+}
+
+func TestFedCMLoginGoogle_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &FedCMLoginGoogle{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds support for Federated Credential Management (FedCM) login configuration on clients, enabling the Google FedCM prompt (Google One Tap) on the New Universal Login experience.

**New types:**
- `FedCMLogin` — holds the FedCM login configuration for a client.
- `FedCMLoginGoogle` — Google-specific FedCM settings, with `IsEnabled` to toggle the Google FedCM prompt on New Universal Login.

**Client struct:**
- Adds the `FedCMLogin` field, serialized as `fedcm_login`.

**New accessor methods:**
- `Client.GetFedCMLogin()`
- `FedCMLogin.GetGoogle()`, `FedCMLogin.String()`
- `FedCMLoginGoogle.GetIsEnabled()`, `FedCMLoginGoogle.String()`

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- API Docs: https://auth0.com/docs/api/management/v2/clients/post-clients#body-fedcm-login

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

Unit tests cover the generated accessor and `String` methods for the new types (`TestClient_GetFedCMLogin`, `TestFedCMLogin_GetGoogle`, `TestFedCMLogin_String`, `TestFedCMLoginGoogle_GetIsEnabled`, `TestFedCMLoginGoogle_String`), including nil-receiver and zero-value cases.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
