### PR TITLE
feat: add delegation configuration and access methods to client session-transfer

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -565,12 +565,24 @@ type BackChannelLogoutInitiators struct {
 
 // SessionTransfer Transfer defines the setting to allow Native to Web SSO session transfer.
 type SessionTransfer struct {
-	CanCreateSessionTransferToken *bool     `json:"can_create_session_transfer_token,omitempty"`
-	AllowedAuthenticationMethods  *[]string `json:"allowed_authentication_methods,omitempty"`
-	EnforceDeviceBinding          *string   `json:"enforce_device_binding,omitempty"`
-	AllowRefreshToken             *bool     `json:"allow_refresh_token,omitempty"`
-	EnforceOnlineRefreshTokens    *bool     `json:"enforce_online_refresh_tokens,omitempty"`
-	EnforceCascadeRevocation      *bool     `json:"enforce_cascade_revocation,omitempty"`
+	CanCreateSessionTransferToken *bool                      `json:"can_create_session_transfer_token,omitempty"`
+	AllowedAuthenticationMethods  *[]string                  `json:"allowed_authentication_methods,omitempty"`
+	EnforceDeviceBinding          *string                    `json:"enforce_device_binding,omitempty"`
+	AllowRefreshToken             *bool                      `json:"allow_refresh_token,omitempty"`
+	EnforceOnlineRefreshTokens    *bool                      `json:"enforce_online_refresh_tokens,omitempty"`
+	EnforceCascadeRevocation      *bool                      `json:"enforce_cascade_revocation,omitempty"`
+	Delegation                    *SessionTransferDelegation `json:"delegation,omitempty"`
+}
+
+// SessionTransferDelegation holds configuration for delegation (impersonation) access using Session Transfer Tokens
+type SessionTransferDelegation struct {
+	// AllowDelegatedAccess indicates whether delegation (impersonation) access is allowed using Session Transfer Tokens.
+	// Default value is false.
+	AllowDelegatedAccess *bool `json:"allow_delegated_access,omitempty"`
+	// EnforceDeviceBinding indicates the device binding enforcement for delegation (impersonation) access. 
+	// If set to 'ip', device binding is enforced by IP. If set to 'asn', device binding is enforced by ASN. 
+	// Default value is ip.
+	EnforceDeviceBinding *string `json:"enforce_device_binding,omitempty"`
 }
 
 // FedCMLogin defines the Federated Credential Management login configuration.

--- a/management/client.go
+++ b/management/client.go
@@ -574,13 +574,13 @@ type SessionTransfer struct {
 	Delegation                    *SessionTransferDelegation `json:"delegation,omitempty"`
 }
 
-// SessionTransferDelegation holds configuration for delegation (impersonation) access using Session Transfer Tokens
+// SessionTransferDelegation holds configuration for delegation (impersonation) access using Session Transfer Tokens.
 type SessionTransferDelegation struct {
 	// AllowDelegatedAccess indicates whether delegation (impersonation) access is allowed using Session Transfer Tokens.
 	// Default value is false.
 	AllowDelegatedAccess *bool `json:"allow_delegated_access,omitempty"`
-	// EnforceDeviceBinding indicates the device binding enforcement for delegation (impersonation) access. 
-	// If set to 'ip', device binding is enforced by IP. If set to 'asn', device binding is enforced by ASN. 
+	// EnforceDeviceBinding indicates the device binding enforcement for delegation (impersonation) access.
+	// If set to 'ip', device binding is enforced by IP. If set to 'asn', device binding is enforced by ASN.
 	// Default value is ip.
 	EnforceDeviceBinding *string `json:"enforce_device_binding,omitempty"`
 }

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -13368,6 +13368,14 @@ func (s *SessionTransfer) GetCanCreateSessionTransferToken() bool {
 	return *s.CanCreateSessionTransferToken
 }
 
+// GetDelegation returns the Delegation field.
+func (s *SessionTransfer) GetDelegation() *SessionTransferDelegation {
+	if s == nil {
+		return nil
+	}
+	return s.Delegation
+}
+
 // GetEnforceCascadeRevocation returns the EnforceCascadeRevocation field if it's non-nil, zero value otherwise.
 func (s *SessionTransfer) GetEnforceCascadeRevocation() bool {
 	if s == nil || s.EnforceCascadeRevocation == nil {
@@ -13394,6 +13402,27 @@ func (s *SessionTransfer) GetEnforceOnlineRefreshTokens() bool {
 
 // String returns a string representation of SessionTransfer.
 func (s *SessionTransfer) String() string {
+	return Stringify(s)
+}
+
+// GetAllowDelegatedAccess returns the AllowDelegatedAccess field if it's non-nil, zero value otherwise.
+func (s *SessionTransferDelegation) GetAllowDelegatedAccess() bool {
+	if s == nil || s.AllowDelegatedAccess == nil {
+		return false
+	}
+	return *s.AllowDelegatedAccess
+}
+
+// GetEnforceDeviceBinding returns the EnforceDeviceBinding field if it's non-nil, zero value otherwise.
+func (s *SessionTransferDelegation) GetEnforceDeviceBinding() string {
+	if s == nil || s.EnforceDeviceBinding == nil {
+		return ""
+	}
+	return *s.EnforceDeviceBinding
+}
+
+// String returns a string representation of SessionTransferDelegation.
+func (s *SessionTransferDelegation) String() string {
 	return Stringify(s)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -16783,6 +16783,13 @@ func TestSessionTransfer_GetCanCreateSessionTransferToken(tt *testing.T) {
 	s.GetCanCreateSessionTransferToken()
 }
 
+func TestSessionTransfer_GetDelegation(tt *testing.T) {
+	s := &SessionTransfer{}
+	s.GetDelegation()
+	s = nil
+	s.GetDelegation()
+}
+
 func TestSessionTransfer_GetEnforceCascadeRevocation(tt *testing.T) {
 	var zeroValue bool
 	s := &SessionTransfer{EnforceCascadeRevocation: &zeroValue}
@@ -16816,6 +16823,34 @@ func TestSessionTransfer_GetEnforceOnlineRefreshTokens(tt *testing.T) {
 func TestSessionTransfer_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &SessionTransfer{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestSessionTransferDelegation_GetAllowDelegatedAccess(tt *testing.T) {
+	var zeroValue bool
+	s := &SessionTransferDelegation{AllowDelegatedAccess: &zeroValue}
+	s.GetAllowDelegatedAccess()
+	s = &SessionTransferDelegation{}
+	s.GetAllowDelegatedAccess()
+	s = nil
+	s.GetAllowDelegatedAccess()
+}
+
+func TestSessionTransferDelegation_GetEnforceDeviceBinding(tt *testing.T) {
+	var zeroValue string
+	s := &SessionTransferDelegation{EnforceDeviceBinding: &zeroValue}
+	s.GetEnforceDeviceBinding()
+	s = &SessionTransferDelegation{}
+	s.GetEnforceDeviceBinding()
+	s = nil
+	s.GetEnforceDeviceBinding()
+}
+
+func TestSessionTransferDelegation_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &SessionTransferDelegation{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds support for delegation (impersonation) access via Session Transfer Tokens on the `Client` resource.

- Adds a `Delegation` field to the `SessionTransfer` struct.
- Adds a new `SessionTransferDelegation` struct with two fields:
  - `AllowDelegatedAccess` (`*bool`) — enables delegated (impersonation) access using Session Transfer Tokens. Defaults to `false`.
  - `EnforceDeviceBinding` (`*string`) — controls device binding enforcement for delegated access (`ip` or `asn`). Defaults to `ip`.
- Adds generated getters: `SessionTransfer.GetDelegation()`, `SessionTransferDelegation.GetAllowDelegatedAccess()`, and `SessionTransferDelegation.GetEnforceDeviceBinding()`.

This lets API consumers configure impersonation access settings when managing a client's session transfer configuration.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

API Docs: https://auth0.com/docs/api/management/v2/clients/post-clients#body-session-transfer-one-of-0-delegation-one-of-0

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Updated `management.gen_test.go` with unit tests covering the new getters for `Delegation`, `AllowDelegatedAccess`, and `EnforceDeviceBinding`, including nil-receiver and nil-field cases.
- Run `go test ./management/...` to validate.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
