### PR TITLE
feat: added support for id_token_session_expiry_supported flag on con…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [Unreleased]
+
+### Added
+- Add `IDTokenSessionExpirySupported` field to `ConnectionOptionsOkta` and `ConnectionOptionsOIDC` to control session expiry via ID token claims.
+
 ## [v1.43.0](https://github.com/auth0/go-auth0/tree/v1.43.0) (2026-06-17)
 [Full Changelog](https://github.com/auth0/go-auth0/compare/v1.42.1...v1.43.0)
 

--- a/management/connection.go
+++ b/management/connection.go
@@ -785,6 +785,8 @@ type ConnectionOptionsOkta struct {
 	// TokenEndpointJwtcaAudFormat specifies the aud claim format in the JWT for client authentication
 	// at the token endpoint. Possible values: "issuer", "token_endpoint".
 	TokenEndpointJwtcaAudFormat *string `json:"token_endpoint_jwtca_aud_format,omitempty"`
+	// IDTokenSessionExpirySupported indicates whether the connection supports session expiry via ID token claims.
+	IDTokenSessionExpirySupported *bool `json:"id_token_session_expiry_supported,omitempty"`
 }
 
 // Scopes returns the scopes for ConnectionOptionsOkta.
@@ -1296,6 +1298,8 @@ type ConnectionOptionsOIDC struct {
 	TokenEndpointJwtcaAudFormat *string `json:"token_endpoint_jwtca_aud_format,omitempty"`
 	// FederatedConnectionsAccessTokens enables refresh tokens and access tokens collection for federated connections
 	FederatedConnectionsAccessTokens *ConnectionOptionsOIDCFederatedConnectionsAccessTokens `json:"federated_connections_access_tokens,omitempty"`
+	// IDTokenSessionExpirySupported indicates whether the connection supports session expiry via ID token claims.
+	IDTokenSessionExpirySupported *bool `json:"id_token_session_expiry_supported,omitempty"`
 }
 
 // ConnectionOptionsOIDCFederatedConnectionsAccessTokens is used by OIDC Connections to

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -1982,3 +1982,136 @@ func TestConnectionManager_TokenEndpointJwtcaAudFormatForOktaAndOIDC(t *testing.
 	assert.Equal(t, "issuer", oktaOpts.GetTokenEndpointJwtcaAudFormat())
 	assert.Equal(t, "token_endpoint", oidcOpts.GetTokenEndpointJwtcaAudFormat())
 }
+
+func TestConnectionManager_IDTokenSessionExpirySupportedForOktaAndOIDC(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	// Case 1: setting true — API echoes true.
+	t.Run("It sets id_token_session_expiry_supported to true for Okta and OIDC", func(t *testing.T) {
+		oktaConnection := givenAConnection(t, connectionTestCase{
+			connection: Connection{
+				Name:     auth0.Stringf("Test-Okta-Connection-%d", time.Now().Unix()),
+				Strategy: auth0.String("okta"),
+			},
+			options: &ConnectionOptionsOkta{
+				ClientID:                      auth0.String("4ef8d976-71bd-4473-a7ce-087d3f0fafd8"),
+				ClientSecret:                  auth0.String("mySecret"),
+				Scope:                         auth0.String("openid"),
+				Domain:                        auth0.String("domain.okta.com"),
+				Issuer:                        auth0.String("https://example.com"),
+				AuthorizationEndpoint:         auth0.String("https://example.com"),
+				JWKSURI:                       auth0.String("https://example.com/jwks"),
+				IDTokenSessionExpirySupported: auth0.Bool(true),
+			},
+		})
+
+		oidcConnection := givenAConnection(t, connectionTestCase{
+			connection: Connection{
+				Name:     auth0.Stringf("Test-OIDC-Connection-%d", time.Now().Unix()),
+				Strategy: auth0.String("oidc"),
+			},
+			options: &ConnectionOptionsOIDC{
+				ClientID:                      auth0.String("4ef8d976-71bd-4473-a7ce-087d3f0fafd8"),
+				ClientSecret:                  auth0.String("mySecret"),
+				Scope:                         auth0.String("openid"),
+				TenantDomain:                  auth0.String("domain.okta.com"),
+				Issuer:                        auth0.String("https://example.com"),
+				AuthorizationEndpoint:         auth0.String("https://example.com"),
+				JWKSURI:                       auth0.String("https://example.com/jwks"),
+				IDTokenSessionExpirySupported: auth0.Bool(true),
+			},
+		})
+
+		oktaOpts := oktaConnection.Options.(*ConnectionOptionsOkta)
+		oidcOpts := oidcConnection.Options.(*ConnectionOptionsOIDC)
+
+		assert.Equal(t, true, oktaOpts.GetIDTokenSessionExpirySupported())
+		assert.Equal(t, true, oidcOpts.GetIDTokenSessionExpirySupported())
+	})
+
+	// Case 2: setting false — API echoes false explicitly (does not omit the field).
+	t.Run("It sets id_token_session_expiry_supported to false for Okta and OIDC", func(t *testing.T) {
+		oktaConnection := givenAConnection(t, connectionTestCase{
+			connection: Connection{
+				Name:     auth0.Stringf("Test-Okta-Connection-%d", time.Now().Unix()),
+				Strategy: auth0.String("okta"),
+			},
+			options: &ConnectionOptionsOkta{
+				ClientID:                      auth0.String("4ef8d976-71bd-4473-a7ce-087d3f0fafd8"),
+				ClientSecret:                  auth0.String("mySecret"),
+				Scope:                         auth0.String("openid"),
+				Domain:                        auth0.String("domain.okta.com"),
+				Issuer:                        auth0.String("https://example.com"),
+				AuthorizationEndpoint:         auth0.String("https://example.com"),
+				JWKSURI:                       auth0.String("https://example.com/jwks"),
+				IDTokenSessionExpirySupported: auth0.Bool(false),
+			},
+		})
+
+		oidcConnection := givenAConnection(t, connectionTestCase{
+			connection: Connection{
+				Name:     auth0.Stringf("Test-OIDC-Connection-%d", time.Now().Unix()),
+				Strategy: auth0.String("oidc"),
+			},
+			options: &ConnectionOptionsOIDC{
+				ClientID:                      auth0.String("4ef8d976-71bd-4473-a7ce-087d3f0fafd8"),
+				ClientSecret:                  auth0.String("mySecret"),
+				Scope:                         auth0.String("openid"),
+				TenantDomain:                  auth0.String("domain.okta.com"),
+				Issuer:                        auth0.String("https://example.com"),
+				AuthorizationEndpoint:         auth0.String("https://example.com"),
+				JWKSURI:                       auth0.String("https://example.com/jwks"),
+				IDTokenSessionExpirySupported: auth0.Bool(false),
+			},
+		})
+
+		oktaOpts := oktaConnection.Options.(*ConnectionOptionsOkta)
+		oidcOpts := oidcConnection.Options.(*ConnectionOptionsOIDC)
+
+		assert.Equal(t, false, oktaOpts.GetIDTokenSessionExpirySupported())
+		assert.Equal(t, false, oidcOpts.GetIDTokenSessionExpirySupported())
+	})
+
+	// Case 3: clearing the field (nil / omitted) — omitempty means field is absent from the
+	// PATCH body, which causes the API to clear its stored value. The returned options must
+	// not carry the field (getter returns zero value false).
+	t.Run("It clears id_token_session_expiry_supported when set to nil for Okta and OIDC", func(t *testing.T) {
+		oktaConnection := givenAConnection(t, connectionTestCase{
+			connection: Connection{
+				Name:     auth0.Stringf("Test-Okta-Connection-%d", time.Now().Unix()),
+				Strategy: auth0.String("okta"),
+			},
+			options: &ConnectionOptionsOkta{
+				ClientID:              auth0.String("4ef8d976-71bd-4473-a7ce-087d3f0fafd8"),
+				ClientSecret:          auth0.String("mySecret"),
+				Scope:                 auth0.String("openid"),
+				Domain:                auth0.String("domain.okta.com"),
+				Issuer:                auth0.String("https://example.com"),
+				AuthorizationEndpoint: auth0.String("https://example.com"),
+				JWKSURI:               auth0.String("https://example.com/jwks"),
+			},
+		})
+
+		oidcConnection := givenAConnection(t, connectionTestCase{
+			connection: Connection{
+				Name:     auth0.Stringf("Test-OIDC-Connection-%d", time.Now().Unix()),
+				Strategy: auth0.String("oidc"),
+			},
+			options: &ConnectionOptionsOIDC{
+				ClientID:              auth0.String("4ef8d976-71bd-4473-a7ce-087d3f0fafd8"),
+				ClientSecret:          auth0.String("mySecret"),
+				Scope:                 auth0.String("openid"),
+				TenantDomain:          auth0.String("domain.okta.com"),
+				Issuer:                auth0.String("https://example.com"),
+				AuthorizationEndpoint: auth0.String("https://example.com"),
+				JWKSURI:               auth0.String("https://example.com/jwks"),
+			},
+		})
+
+		oktaOpts := oktaConnection.Options.(*ConnectionOptionsOkta)
+		oidcOpts := oidcConnection.Options.(*ConnectionOptionsOIDC)
+
+		assert.Nil(t, oktaOpts.IDTokenSessionExpirySupported)
+		assert.Nil(t, oidcOpts.IDTokenSessionExpirySupported)
+	})
+}

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -5690,6 +5690,14 @@ func (c *ConnectionOptionsOIDC) GetFederatedConnectionsAccessTokens() *Connectio
 	return c.FederatedConnectionsAccessTokens
 }
 
+// GetIDTokenSessionExpirySupported returns the IDTokenSessionExpirySupported field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetIDTokenSessionExpirySupported() bool {
+	if c == nil || c.IDTokenSessionExpirySupported == nil {
+		return false
+	}
+	return *c.IDTokenSessionExpirySupported
+}
+
 // GetIDTokenSignedResponseAlgs returns the IDTokenSignedResponseAlgs field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsOIDC) GetIDTokenSignedResponseAlgs() []string {
 	if c == nil || c.IDTokenSignedResponseAlgs == nil {
@@ -5948,6 +5956,14 @@ func (c *ConnectionOptionsOkta) GetDPoPSigningAlg() string {
 		return ""
 	}
 	return *c.DPoPSigningAlg
+}
+
+// GetIDTokenSessionExpirySupported returns the IDTokenSessionExpirySupported field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOkta) GetIDTokenSessionExpirySupported() bool {
+	if c == nil || c.IDTokenSessionExpirySupported == nil {
+		return false
+	}
+	return *c.IDTokenSessionExpirySupported
 }
 
 // GetIDTokenSignedResponseAlgs returns the IDTokenSignedResponseAlgs field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -7020,6 +7020,16 @@ func TestConnectionOptionsOIDC_GetFederatedConnectionsAccessTokens(tt *testing.T
 	c.GetFederatedConnectionsAccessTokens()
 }
 
+func TestConnectionOptionsOIDC_GetIDTokenSessionExpirySupported(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsOIDC{IDTokenSessionExpirySupported: &zeroValue}
+	c.GetIDTokenSessionExpirySupported()
+	c = &ConnectionOptionsOIDC{}
+	c.GetIDTokenSessionExpirySupported()
+	c = nil
+	c.GetIDTokenSessionExpirySupported()
+}
+
 func TestConnectionOptionsOIDC_GetIDTokenSignedResponseAlgs(tt *testing.T) {
 	var zeroValue []string
 	c := &ConnectionOptionsOIDC{IDTokenSignedResponseAlgs: &zeroValue}
@@ -7344,6 +7354,16 @@ func TestConnectionOptionsOkta_GetDPoPSigningAlg(tt *testing.T) {
 	c.GetDPoPSigningAlg()
 	c = nil
 	c.GetDPoPSigningAlg()
+}
+
+func TestConnectionOptionsOkta_GetIDTokenSessionExpirySupported(tt *testing.T) {
+	var zeroValue bool
+	c := &ConnectionOptionsOkta{IDTokenSessionExpirySupported: &zeroValue}
+	c.GetIDTokenSessionExpirySupported()
+	c = &ConnectionOptionsOkta{}
+	c.GetIDTokenSessionExpirySupported()
+	c = nil
+	c.GetIDTokenSessionExpirySupported()
 }
 
 func TestConnectionOptionsOkta_GetIDTokenSignedResponseAlgs(tt *testing.T) {

--- a/test/data/recordings/TestConnectionManager_IDTokenSessionExpirySupportedForOktaAndOIDC.yaml
+++ b/test/data/recordings/TestConnectionManager_IDTokenSessionExpirySupportedForOktaAndOIDC.yaml
@@ -1,0 +1,417 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 399
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Okta-Connection-1782489064","strategy":"okta","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","domain":"domain.okta.com","authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid","id_token_session_expiry_supported":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_wTbqTbXxaKaZOk4U","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","domain":"domain.okta.com","authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":"https://domain.okta.com/oauth2/v1/userinfo","token_endpoint":"https://domain.okta.com/oauth2/v1/token","scope":"openid","id_token_session_expiry_supported":true,"oidc_metadata":{"issuer":"https://domain.okta.com","authorization_endpoint":"https://domain.okta.com/oauth2/v1/authorize","token_endpoint":"https://domain.okta.com/oauth2/v1/token","userinfo_endpoint":"https://domain.okta.com/oauth2/v1/userinfo","registration_endpoint":"https://domain.okta.com/oauth2/v1/clients","jwks_uri":"https://domain.okta.com/oauth2/v1/keys","response_types_supported":["code","id_token","code id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code","urn:openid:params:grant-type:ciba","urn:okta:params:oauth:grant-type:otp","http://auth0.com/oauth/grant-type/mfa-otp","urn:okta:params:oauth:grant-type:oob","http://auth0.com/oauth/grant-type/mfa-oob"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"id_token_encryption_alg_values_supported":["RSA-OAEP-256","RSA-OAEP-384","RSA-OAEP-512"],"id_token_encryption_enc_values_supported":["A256GCM"],"scopes_supported":["openid","email","profile","address","phone","offline_access","groups"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://domain.okta.com/oauth2/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://domain.okta.com/oauth2/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://domain.okta.com/oauth2/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://domain.okta.com/oauth2/v1/device/authorize","pushed_authorization_request_endpoint":"https://domain.okta.com/oauth2/v1/par","backchannel_token_delivery_modes_supported":["poll"],"backchannel_authentication_request_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"dpop_signing_alg_values_supported":["RS256","RS384","RS512","ES256","ES384","ES512"],"claims_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false},"schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Test-Okta-Connection-1782489064","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Test-Okta-Connection-1782489064","enabled_clients":[],"realms":["Test-Okta-Connection-1782489064"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1.223094709s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 427
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-OIDC-Connection-1782489065","strategy":"oidc","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","tenant_domain":"domain.okta.com","discovery_url":null,"authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid","id_token_session_expiry_supported":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 824
+        uncompressed: false
+        body: '{"id":"con_jYydZDxeUqAkjfT4","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","tenant_domain":"domain.okta.com","discovery_url":null,"authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid","id_token_session_expiry_supported":true,"type":"front_channel","schema_version":"oidc-V4","attribute_map":{"mapping_mode":"bind_all"},"connection_settings":{"pkce":"auto"}},"strategy":"oidc","name":"Test-OIDC-Connection-1782489065","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Test-OIDC-Connection-1782489065","enabled_clients":[],"realms":["Test-OIDC-Connection-1782489065"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 550.46025ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_jYydZDxeUqAkjfT4
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-06-26T15:51:06.477Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 303.575125ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_wTbqTbXxaKaZOk4U
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-06-26T15:51:06.803Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 364.934084ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 400
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Okta-Connection-1782489066","strategy":"okta","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","domain":"domain.okta.com","authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid","id_token_session_expiry_supported":false}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_4rDtik2OumJBrj3g","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","domain":"domain.okta.com","authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":"https://domain.okta.com/oauth2/v1/userinfo","token_endpoint":"https://domain.okta.com/oauth2/v1/token","scope":"openid","id_token_session_expiry_supported":false,"oidc_metadata":{"issuer":"https://domain.okta.com","authorization_endpoint":"https://domain.okta.com/oauth2/v1/authorize","token_endpoint":"https://domain.okta.com/oauth2/v1/token","userinfo_endpoint":"https://domain.okta.com/oauth2/v1/userinfo","registration_endpoint":"https://domain.okta.com/oauth2/v1/clients","jwks_uri":"https://domain.okta.com/oauth2/v1/keys","response_types_supported":["code","id_token","code id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code","urn:openid:params:grant-type:ciba","urn:okta:params:oauth:grant-type:otp","http://auth0.com/oauth/grant-type/mfa-otp","urn:okta:params:oauth:grant-type:oob","http://auth0.com/oauth/grant-type/mfa-oob"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"id_token_encryption_alg_values_supported":["RSA-OAEP-256","RSA-OAEP-384","RSA-OAEP-512"],"id_token_encryption_enc_values_supported":["A256GCM"],"scopes_supported":["openid","email","profile","address","phone","offline_access","groups"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://domain.okta.com/oauth2/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://domain.okta.com/oauth2/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://domain.okta.com/oauth2/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://domain.okta.com/oauth2/v1/device/authorize","pushed_authorization_request_endpoint":"https://domain.okta.com/oauth2/v1/par","backchannel_token_delivery_modes_supported":["poll"],"backchannel_authentication_request_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"dpop_signing_alg_values_supported":["RS256","RS384","RS512","ES256","ES384","ES512"],"claims_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false},"schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Test-Okta-Connection-1782489066","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Test-Okta-Connection-1782489066","enabled_clients":[],"realms":["Test-Okta-Connection-1782489066"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 475.085209ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 428
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-OIDC-Connection-1782489067","strategy":"oidc","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","tenant_domain":"domain.okta.com","discovery_url":null,"authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid","id_token_session_expiry_supported":false}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 825
+        uncompressed: false
+        body: '{"id":"con_qlI06X7CBe2AUkXf","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","tenant_domain":"domain.okta.com","discovery_url":null,"authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid","id_token_session_expiry_supported":false,"type":"front_channel","schema_version":"oidc-V4","attribute_map":{"mapping_mode":"bind_all"},"connection_settings":{"pkce":"auto"}},"strategy":"oidc","name":"Test-OIDC-Connection-1782489067","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Test-OIDC-Connection-1782489067","enabled_clients":[],"realms":["Test-OIDC-Connection-1782489067"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 493.514791ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_qlI06X7CBe2AUkXf
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-06-26T15:51:08.129Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 319.096209ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_4rDtik2OumJBrj3g
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-06-26T15:51:08.435Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 306.345208ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 358
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-Okta-Connection-1782489068","strategy":"okta","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","domain":"domain.okta.com","authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_ntdQvK4Nwwmb6H7e","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","domain":"domain.okta.com","authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":"https://domain.okta.com/oauth2/v1/userinfo","token_endpoint":"https://domain.okta.com/oauth2/v1/token","scope":"openid","oidc_metadata":{"issuer":"https://domain.okta.com","authorization_endpoint":"https://domain.okta.com/oauth2/v1/authorize","token_endpoint":"https://domain.okta.com/oauth2/v1/token","userinfo_endpoint":"https://domain.okta.com/oauth2/v1/userinfo","registration_endpoint":"https://domain.okta.com/oauth2/v1/clients","jwks_uri":"https://domain.okta.com/oauth2/v1/keys","response_types_supported":["code","id_token","code id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password","urn:ietf:params:oauth:grant-type:device_code","urn:openid:params:grant-type:ciba","urn:okta:params:oauth:grant-type:otp","http://auth0.com/oauth/grant-type/mfa-otp","urn:okta:params:oauth:grant-type:oob","http://auth0.com/oauth/grant-type/mfa-oob"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"id_token_encryption_alg_values_supported":["RSA-OAEP-256","RSA-OAEP-384","RSA-OAEP-512"],"id_token_encryption_enc_values_supported":["A256GCM"],"scopes_supported":["openid","email","profile","address","phone","offline_access","groups"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://domain.okta.com/oauth2/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://domain.okta.com/oauth2/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://domain.okta.com/oauth2/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"device_authorization_endpoint":"https://domain.okta.com/oauth2/v1/device/authorize","pushed_authorization_request_endpoint":"https://domain.okta.com/oauth2/v1/par","backchannel_token_delivery_modes_supported":["poll"],"backchannel_authentication_request_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"],"dpop_signing_alg_values_supported":["RS256","RS384","RS512","ES256","ES384","ES512"],"claims_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false},"schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Test-Okta-Connection-1782489068","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Test-Okta-Connection-1782489068","enabled_clients":[],"realms":["Test-Okta-Connection-1782489068"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 410.58775ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 386
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test-OIDC-Connection-1782489068","strategy":"oidc","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","tenant_domain":"domain.okta.com","discovery_url":null,"authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 783
+        uncompressed: false
+        body: '{"id":"con_JHr1UQcMaJl04pGg","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","client_secret":"mySecret","tenant_domain":"domain.okta.com","discovery_url":null,"authorization_endpoint":"https://example.com","issuer":"https://example.com","jwks_uri":"https://example.com/jwks","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid","type":"front_channel","schema_version":"oidc-V4","attribute_map":{"mapping_mode":"bind_all"},"connection_settings":{"pkce":"auto"}},"strategy":"oidc","name":"Test-OIDC-Connection-1782489068","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Test-OIDC-Connection-1782489068","enabled_clients":[],"realms":["Test-OIDC-Connection-1782489068"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 330.29375ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_JHr1UQcMaJl04pGg
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-06-26T15:51:09.481Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 349.276833ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_ntdQvK4Nwwmb6H7e
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-06-26T15:51:09.835Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 353.295291ms


### PR DESCRIPTION
# Add `id_token_session_expiry_supported` flag to Okta and OIDC connection options

### 🔧 Changes

- Added `IDTokenSessionExpirySupported *bool` field to `ConnectionOptionsOkta` and `ConnectionOptionsOIDC` structs, allowing callers to opt into session expiry control via ID token claims on Okta and OIDC connections.
- Generated `GetIDTokenSessionExpirySupported()` getter methods for both struct types (nil-safe, returns `false` as zero value).
- Added integration test `TestConnectionManager_IDTokenSessionExpirySupportedForOktaAndOIDC` covering three sub-cases: setting `true`, setting `false`, and clearing the field (nil/omit).
- Added corresponding HTTP cassette recording for the integration test.

### 🔬 Testing

- Integration tests added under `management/connection_test.go` covering `true`, `false`, and nil (cleared) values for both Okta and OIDC connection strategies.
- HTTP recordings captured in `test/data/recordings/TestConnectionManager_IDTokenSessionExpirySupportedForOktaAndOIDC.yaml`, run using `make test FILTER="TestConnectionManager_IDTokenSessionExpirySupportedForOktaAndOIDC"`
- Generated getter unit tests added in `management/management.gen_test.go`.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)