### PR TITLE
feat: added support for identifiers in branding_theme, country_codes …

### DIFF
--- a/management/branding_theme.go
+++ b/management/branding_theme.go
@@ -15,6 +15,7 @@ type BrandingTheme struct {
 	Fonts          BrandingThemeFonts          `json:"fonts"`
 	PageBackground BrandingThemePageBackground `json:"page_background"`
 	Widget         BrandingThemeWidget         `json:"widget"`
+	Identifiers    *BrandingThemeIdentifiers   `json:"identifiers,omitempty"`
 }
 
 // BrandingThemeBorders contains borders settings for the BrandingTheme.
@@ -88,6 +89,20 @@ type BrandingThemeWidget struct {
 	LogoPosition        string  `json:"logo_position"`
 	LogoURL             string  `json:"logo_url"`
 	SocialButtonsLayout string  `json:"social_buttons_layout"`
+}
+
+// BrandingThemeIdentifiers contains identifier input display settings for the BrandingTheme.
+type BrandingThemeIdentifiers struct {
+	LoginDisplay    string                    `json:"login_display"`
+	OTPAutocomplete bool                      `json:"otp_autocomplete"`
+	PhoneDisplay    BrandingThemePhoneDisplay `json:"phone_display"`
+}
+
+// BrandingThemePhoneDisplay contains phone number display settings
+// for the BrandingThemeIdentifiers.
+type BrandingThemePhoneDisplay struct {
+	Formatting string `json:"formatting"`
+	Masking    string `json:"masking"`
 }
 
 // BrandingThemeManager manages Auth0 BrandingTheme resources.

--- a/management/branding_theme_test.go
+++ b/management/branding_theme_test.go
@@ -309,6 +309,104 @@ func givenABrandingTheme(t *testing.T) *BrandingTheme {
 	return theme
 }
 
+func TestBrandingThemeManager_Update_Identifiers(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	expectedTheme := givenABrandingTheme(t)
+
+	actualTheme := &BrandingTheme{
+		Borders: BrandingThemeBorders{
+			ButtonBorderRadius: 2,
+			ButtonBorderWeight: 2,
+			ButtonsStyle:       "pill",
+			InputBorderRadius:  2,
+			InputBorderWeight:  2,
+			InputsStyle:        "pill",
+			ShowWidgetShadow:   true,
+			WidgetBorderWeight: 2,
+			WidgetCornerRadius: 2,
+		},
+		Colors: BrandingThemeColors{
+			BodyText:                "#00FF00",
+			Error:                   "#00FF00",
+			CaptchaWidgetTheme:      "auto",
+			Header:                  "#00FF00",
+			Icons:                   "#00FF00",
+			InputBackground:         "#00FF00",
+			InputBorder:             "#00FF00",
+			InputFilledText:         "#00FF00",
+			InputLabelsPlaceholders: "#00FF00",
+			LinksFocusedComponents:  "#00FF00",
+			PrimaryButton:           "#00FF00",
+			PrimaryButtonLabel:      "#00FF00",
+			SecondaryButtonBorder:   "#00FF00",
+			SecondaryButtonLabel:    "#00FF00",
+			Success:                 "#00FF00",
+			WidgetBackground:        "#00FF00",
+			WidgetBorder:            "#00FF00",
+		},
+		Fonts: BrandingThemeFonts{
+			BodyText: BrandingThemeText{
+				Bold: true,
+				Size: 100,
+			},
+			ButtonsText: BrandingThemeText{
+				Bold: true,
+				Size: 100,
+			},
+			FontURL: "https://google.com/font.woff",
+			InputLabels: BrandingThemeText{
+				Bold: true,
+				Size: 100,
+			},
+			Links: BrandingThemeText{
+				Bold: true,
+				Size: 100,
+			},
+			LinksStyle:        "normal",
+			ReferenceTextSize: 12,
+			Subtitle: BrandingThemeText{
+				Bold: true,
+				Size: 100,
+			},
+			Title: BrandingThemeText{
+				Bold: true,
+				Size: 100,
+			},
+		},
+		PageBackground: BrandingThemePageBackground{
+			BackgroundColor:    "#000000",
+			BackgroundImageURL: "https://google.com/background.png",
+			PageLayout:         "center",
+		},
+		Widget: BrandingThemeWidget{
+			HeaderTextAlignment: "center",
+			LogoHeight:          55,
+			LogoPosition:        "center",
+			LogoURL:             "https://google.com/logo.png",
+			SocialButtonsLayout: "top",
+		},
+		Identifiers: &BrandingThemeIdentifiers{
+			LoginDisplay:    "unified",
+			OTPAutocomplete: true,
+			PhoneDisplay: BrandingThemePhoneDisplay{
+				Formatting: "international",
+				Masking:    "mask_digits",
+			},
+		},
+	}
+
+	err := api.BrandingTheme.Update(context.Background(), expectedTheme.GetID(), actualTheme)
+	assert.NoError(t, err)
+
+	updatedTheme, err := api.BrandingTheme.Read(context.Background(), expectedTheme.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, "unified", updatedTheme.GetIdentifiers().LoginDisplay)
+	assert.True(t, updatedTheme.GetIdentifiers().OTPAutocomplete)
+	assert.Equal(t, "international", updatedTheme.GetIdentifiers().PhoneDisplay.Formatting)
+	assert.Equal(t, "mask_digits", updatedTheme.GetIdentifiers().PhoneDisplay.Masking)
+}
+
 func cleanupBrandingTheme(t *testing.T, themeID string) {
 	t.Helper()
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1399,6 +1399,14 @@ func (b *BrandingTheme) GetID() string {
 	return *b.ID
 }
 
+// GetIdentifiers returns the Identifiers field.
+func (b *BrandingTheme) GetIdentifiers() *BrandingThemeIdentifiers {
+	if b == nil {
+		return nil
+	}
+	return b.Identifiers
+}
+
 // String returns a string representation of BrandingTheme.
 func (b *BrandingTheme) String() string {
 	return Stringify(b)
@@ -1435,8 +1443,18 @@ func (b *BrandingThemeFonts) String() string {
 	return Stringify(b)
 }
 
+// String returns a string representation of BrandingThemeIdentifiers.
+func (b *BrandingThemeIdentifiers) String() string {
+	return Stringify(b)
+}
+
 // String returns a string representation of BrandingThemePageBackground.
 func (b *BrandingThemePageBackground) String() string {
+	return Stringify(b)
+}
+
+// String returns a string representation of BrandingThemePhoneDisplay.
+func (b *BrandingThemePhoneDisplay) String() string {
 	return Stringify(b)
 }
 
@@ -13796,6 +13814,14 @@ func (t *Tenant) GetClientIDMetadataDocumentSupported() bool {
 	return *t.ClientIDMetadataDocumentSupported
 }
 
+// GetCountryCodes returns the CountryCodes field.
+func (t *Tenant) GetCountryCodes() *TenantCountryCodes {
+	if t == nil {
+		return nil
+	}
+	return t.CountryCodes
+}
+
 // GetCustomizeMFAInPostLoginAction returns the CustomizeMFAInPostLoginAction field if it's non-nil, zero value otherwise.
 func (t *Tenant) GetCustomizeMFAInPostLoginAction() bool {
 	if t == nil || t.CustomizeMFAInPostLoginAction == nil {
@@ -14059,6 +14085,11 @@ func (t *TenantChangePassword) GetHTML() string {
 
 // String returns a string representation of TenantChangePassword.
 func (t *TenantChangePassword) String() string {
+	return Stringify(t)
+}
+
+// String returns a string representation of TenantCountryCodes.
+func (t *TenantCountryCodes) String() string {
 	return Stringify(t)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -1774,6 +1774,13 @@ func TestBrandingTheme_GetID(tt *testing.T) {
 	b.GetID()
 }
 
+func TestBrandingTheme_GetIdentifiers(tt *testing.T) {
+	b := &BrandingTheme{}
+	b.GetIdentifiers()
+	b = nil
+	b.GetIdentifiers()
+}
+
 func TestBrandingTheme_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &BrandingTheme{}
@@ -1826,9 +1833,25 @@ func TestBrandingThemeFonts_String(t *testing.T) {
 	}
 }
 
+func TestBrandingThemeIdentifiers_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &BrandingThemeIdentifiers{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestBrandingThemePageBackground_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &BrandingThemePageBackground{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestBrandingThemePhoneDisplay_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &BrandingThemePhoneDisplay{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
@@ -17321,6 +17344,13 @@ func TestTenant_GetClientIDMetadataDocumentSupported(tt *testing.T) {
 	t.GetClientIDMetadataDocumentSupported()
 }
 
+func TestTenant_GetCountryCodes(tt *testing.T) {
+	t := &Tenant{}
+	t.GetCountryCodes()
+	t = nil
+	t.GetCountryCodes()
+}
+
 func TestTenant_GetCustomizeMFAInPostLoginAction(tt *testing.T) {
 	var zeroValue bool
 	t := &Tenant{CustomizeMFAInPostLoginAction: &zeroValue}
@@ -17622,6 +17652,14 @@ func TestTenantChangePassword_GetHTML(tt *testing.T) {
 func TestTenantChangePassword_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &TenantChangePassword{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestTenantCountryCodes_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &TenantCountryCodes{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/management/tenant.go
+++ b/management/tenant.go
@@ -170,6 +170,19 @@ type Tenant struct {
 	// "permissive" can only be configured by customers with pre-existing third-party client usage before April 2026.
 	// See https://auth0.com/docs/get-started/applications/third-party-applications/permissive-mode#who-can-use-permissive-mode for more details.
 	DynamicClientRegistrationSecurityMode *string `json:"dynamic_client_registration_security_mode,omitempty"`
+
+	// CountryCodes configures phone identifier country code filtering for the tenant.
+	//
+	// To unset values (set to null), use a PATCH request like this:
+	//
+	// PATCH /api/v2/tenants/settings
+	// {
+	//   "country_codes": null
+	// }
+	//
+	// For more details on making custom requests, refer to the Auth0 Go SDK examples:
+	// https://github.com/auth0/go-auth0/blob/main/EXAMPLES.md#providing-a-custom-user-struct
+	CountryCodes *TenantCountryCodes `json:"country_codes,omitempty"`
 }
 
 // TenantDefaultTokenQuota holds settings for the default token quota.
@@ -202,6 +215,15 @@ type TokenQuotaClientCredentials struct {
 type TenantMTLSConfiguration struct {
 	// If true, enables mTLS endpoint aliases
 	EnableEndpointAliases *bool `json:"enable_endpoint_aliases,omitempty"`
+}
+
+// TenantCountryCodes holds settings for phone identifier country code filtering.
+type TenantCountryCodes struct {
+	// List of ISO 3166-1 alpha-2 country codes.
+	List []string `json:"list"`
+
+	// Mode determines whether List is used as an allow-list or deny-list. Values: "allow" or "deny".
+	Mode string `json:"mode"`
 }
 
 // MarshalJSON is a custom serializer for the Tenant type.

--- a/management/tenant_test.go
+++ b/management/tenant_test.go
@@ -199,6 +199,63 @@ func TestTenantManager_NullableFields(t *testing.T) {
 	assert.Nil(t, actualTenantSettings.GetDefaultTokenQuota())
 }
 
+func TestTenantManager_CountryCodes(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	initialSettings, err := api.Tenant.Read(context.Background())
+	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		initialSettings.SandboxVersionAvailable = nil
+		initialSettings.UniversalLogin = nil
+		initialSettings.Flags = nil
+		err := api.Tenant.Update(context.Background(), initialSettings)
+		require.NoError(t, err)
+	})
+
+	newTenantSettings := &Tenant{
+		CountryCodes: &TenantCountryCodes{
+			List: []string{"US", "GB"},
+			Mode: "allow",
+		},
+	}
+	err = api.Tenant.Update(context.Background(), newTenantSettings)
+	assert.NoError(t, err)
+
+	actualTenantSettings, err := api.Tenant.Read(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "allow", actualTenantSettings.GetCountryCodes().Mode)
+	assert.ElementsMatch(t, []string{"US", "GB"}, actualTenantSettings.GetCountryCodes().List)
+
+	// Update to deny-list.
+	updatedTenantSettings := &Tenant{
+		CountryCodes: &TenantCountryCodes{
+			List: []string{"FR"},
+			Mode: "deny",
+		},
+	}
+	err = api.Tenant.Update(context.Background(), updatedTenantSettings)
+	assert.NoError(t, err)
+
+	actualTenantSettings, err = api.Tenant.Read(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "deny", actualTenantSettings.GetCountryCodes().Mode)
+	assert.ElementsMatch(t, []string{"FR"}, actualTenantSettings.GetCountryCodes().List)
+
+	// Clear country_codes explicitly via nullable field mechanism.
+	type CustomTenant struct {
+		CountryCodes *TenantCountryCodes `json:"country_codes"`
+	}
+
+	nullableTenantSettings := &CustomTenant{CountryCodes: nil}
+	err = api.Request(context.Background(), http.MethodPatch, api.URI("tenants", "settings"), nullableTenantSettings)
+	assert.NoError(t, err)
+
+	actualTenantSettings, err = api.Tenant.Read(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, actualTenantSettings.GetCountryCodes())
+}
+
 func TestTenantManager_CIMDAndResourceParameterProfile(t *testing.T) {
 	configureHTTPTestRecordings(t)
 

--- a/test/data/recordings/TestBrandingThemeManager_Update_Identifiers.yaml
+++ b/test/data/recordings/TestBrandingThemeManager_Update_Identifiers.yaml
@@ -1,0 +1,141 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1324
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"borders":{"button_border_radius":2,"button_border_weight":2,"buttons_style":"pill","input_border_radius":2,"input_border_weight":2,"inputs_style":"pill","show_widget_shadow":true,"widget_border_weight":2,"widget_corner_radius":2},"colors":{"body_text":"#00FF00","captcha_widget_theme":"auto","error":"#00FF00","header":"#00FF00","icons":"#00FF00","input_background":"#00FF00","input_border":"#00FF00","input_filled_text":"#00FF00","input_labels_placeholders":"#00FF00","links_focused_components":"#00FF00","primary_button":"#00FF00","primary_button_label":"#00FF00","secondary_button_border":"#00FF00","secondary_button_label":"#00FF00","success":"#00FF00","widget_background":"#00FF00","widget_border":"#00FF00"},"fonts":{"body_text":{"bold":true,"size":100},"buttons_text":{"bold":true,"size":100},"font_url":"https://google.com/font.woff","input_labels":{"bold":true,"size":100},"links":{"bold":true,"size":100},"links_style":"normal","reference_text_size":12,"subtitle":{"bold":true,"size":100},"title":{"bold":true,"size":100}},"page_background":{"background_color":"#000000","background_image_url":"https://google.com/background.png","page_layout":"center"},"widget":{"header_text_alignment":"center","logo_height":55,"logo_position":"center","logo_url":"https://google.com/logo.png","social_buttons_layout":"top"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/themes
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"borders":{"button_border_radius":2,"button_border_weight":2,"buttons_style":"pill","input_border_radius":2,"input_border_weight":2,"inputs_style":"pill","show_widget_shadow":true,"widget_border_weight":2,"widget_corner_radius":2},"colors":{"body_text":"#00FF00","captcha_widget_theme":"auto","error":"#00FF00","header":"#00FF00","icons":"#00FF00","input_background":"#00FF00","input_border":"#00FF00","input_filled_text":"#00FF00","input_labels_placeholders":"#00FF00","links_focused_components":"#00FF00","primary_button":"#00FF00","primary_button_label":"#00FF00","secondary_button_border":"#00FF00","secondary_button_label":"#00FF00","success":"#00FF00","widget_background":"#00FF00","widget_border":"#00FF00"},"fonts":{"body_text":{"bold":true,"size":100},"buttons_text":{"bold":true,"size":100},"font_url":"https://google.com/font.woff","input_labels":{"bold":true,"size":100},"links":{"bold":true,"size":100},"links_style":"normal","reference_text_size":12,"subtitle":{"bold":true,"size":100},"title":{"bold":true,"size":100}},"page_background":{"background_color":"#000000","background_image_url":"https://google.com/background.png","page_layout":"center"},"widget":{"header_text_alignment":"center","logo_height":55,"logo_position":"center","logo_url":"https://google.com/logo.png","social_buttons_layout":"top"},"identifiers":{"login_display":"unified","otp_autocomplete":true,"phone_display":{"masking":"mask_digits","formatting":"international"}},"themeId":"4MUApBcQVjmmDVZNEjxd5btBiXMvxmWq"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 973.355916ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1461
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"borders":{"button_border_radius":2,"button_border_weight":2,"buttons_style":"pill","input_border_radius":2,"input_border_weight":2,"inputs_style":"pill","show_widget_shadow":true,"widget_border_weight":2,"widget_corner_radius":2},"colors":{"body_text":"#00FF00","captcha_widget_theme":"auto","error":"#00FF00","header":"#00FF00","icons":"#00FF00","input_background":"#00FF00","input_border":"#00FF00","input_filled_text":"#00FF00","input_labels_placeholders":"#00FF00","links_focused_components":"#00FF00","primary_button":"#00FF00","primary_button_label":"#00FF00","secondary_button_border":"#00FF00","secondary_button_label":"#00FF00","success":"#00FF00","widget_background":"#00FF00","widget_border":"#00FF00"},"fonts":{"body_text":{"bold":true,"size":100},"buttons_text":{"bold":true,"size":100},"font_url":"https://google.com/font.woff","input_labels":{"bold":true,"size":100},"links":{"bold":true,"size":100},"links_style":"normal","reference_text_size":12,"subtitle":{"bold":true,"size":100},"title":{"bold":true,"size":100}},"page_background":{"background_color":"#000000","background_image_url":"https://google.com/background.png","page_layout":"center"},"widget":{"header_text_alignment":"center","logo_height":55,"logo_position":"center","logo_url":"https://google.com/logo.png","social_buttons_layout":"top"},"identifiers":{"login_display":"unified","otp_autocomplete":true,"phone_display":{"formatting":"international","masking":"mask_digits"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/themes/4MUApBcQVjmmDVZNEjxd5btBiXMvxmWq
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"borders":{"button_border_radius":2,"button_border_weight":2,"buttons_style":"pill","input_border_radius":2,"input_border_weight":2,"inputs_style":"pill","show_widget_shadow":true,"widget_border_weight":2,"widget_corner_radius":2},"colors":{"body_text":"#00FF00","captcha_widget_theme":"auto","error":"#00FF00","header":"#00FF00","icons":"#00FF00","input_background":"#00FF00","input_border":"#00FF00","input_filled_text":"#00FF00","input_labels_placeholders":"#00FF00","links_focused_components":"#00FF00","primary_button":"#00FF00","primary_button_label":"#00FF00","secondary_button_border":"#00FF00","secondary_button_label":"#00FF00","success":"#00FF00","widget_background":"#00FF00","widget_border":"#00FF00"},"fonts":{"body_text":{"bold":true,"size":100},"buttons_text":{"bold":true,"size":100},"font_url":"https://google.com/font.woff","input_labels":{"bold":true,"size":100},"links":{"bold":true,"size":100},"links_style":"normal","reference_text_size":12,"subtitle":{"bold":true,"size":100},"title":{"bold":true,"size":100}},"page_background":{"background_color":"#000000","background_image_url":"https://google.com/background.png","page_layout":"center"},"widget":{"header_text_alignment":"center","logo_height":55,"logo_position":"center","logo_url":"https://google.com/logo.png","social_buttons_layout":"top"},"identifiers":{"login_display":"unified","otp_autocomplete":true,"phone_display":{"formatting":"international","masking":"mask_digits"}},"themeId":"4MUApBcQVjmmDVZNEjxd5btBiXMvxmWq"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 311.491833ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/themes/4MUApBcQVjmmDVZNEjxd5btBiXMvxmWq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"borders":{"button_border_radius":2,"button_border_weight":2,"buttons_style":"pill","input_border_radius":2,"input_border_weight":2,"inputs_style":"pill","show_widget_shadow":true,"widget_border_weight":2,"widget_corner_radius":2},"colors":{"body_text":"#00FF00","captcha_widget_theme":"auto","error":"#00FF00","header":"#00FF00","icons":"#00FF00","input_background":"#00FF00","input_border":"#00FF00","input_filled_text":"#00FF00","input_labels_placeholders":"#00FF00","links_focused_components":"#00FF00","primary_button":"#00FF00","primary_button_label":"#00FF00","secondary_button_border":"#00FF00","secondary_button_label":"#00FF00","success":"#00FF00","widget_background":"#00FF00","widget_border":"#00FF00"},"fonts":{"body_text":{"bold":true,"size":100},"buttons_text":{"bold":true,"size":100},"font_url":"https://google.com/font.woff","input_labels":{"bold":true,"size":100},"links":{"bold":true,"size":100},"links_style":"normal","reference_text_size":12,"subtitle":{"bold":true,"size":100},"title":{"bold":true,"size":100}},"page_background":{"background_color":"#000000","background_image_url":"https://google.com/background.png","page_layout":"center"},"widget":{"header_text_alignment":"center","logo_height":55,"logo_position":"center","logo_url":"https://google.com/logo.png","social_buttons_layout":"top"},"identifiers":{"login_display":"unified","otp_autocomplete":true,"phone_display":{"formatting":"international","masking":"mask_digits"}},"themeId":"4MUApBcQVjmmDVZNEjxd5btBiXMvxmWq"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 332.5945ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/branding/themes/4MUApBcQVjmmDVZNEjxd5btBiXMvxmWq
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 376.894584ms

--- a/test/data/recordings/TestTenantManager_CountryCodes.yaml
+++ b/test/data/recordings/TestTenantManager_CountryCodes.yaml
@@ -1,0 +1,279 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"country_codes":{"list":["US","GB"],"mode":"allow"},"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 293.917333ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 54
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"country_codes":{"list":["US","GB"],"mode":"allow"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":false},"phone_consolidated_experience":false,"country_codes":{"list":["US","GB"],"mode":"allow"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 546.67675ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"country_codes":{"list":["US","GB"],"mode":"allow"},"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 306.193667ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 48
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"country_codes":{"list":["FR"],"mode":"deny"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":false},"phone_consolidated_experience":false,"country_codes":{"list":["FR"],"mode":"deny"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 409.895959ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"country_codes":{"list":["FR"],"mode":"deny"},"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 299.68925ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 23
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"country_codes":null}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":false},"phone_consolidated_experience":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 338.125834ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 297.996667ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 382
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","enabled_locales":["en"],"oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"resource_parameter_profile":"audience","country_codes":{"list":["US","GB"],"mode":"allow"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":false},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["US","GB"],"mode":"allow"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 314.479042ms


### PR DESCRIPTION

# Add support for identifiers in BrandingTheme and CountryCodes in Tenant

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- Added `Identifiers` field (type `*BrandingThemeIdentifiers`) to the `BrandingTheme` struct, exposing identifier input display settings for the login experience.
  - `BrandingThemeIdentifiers`: `LoginDisplay`, `OTPAutocomplete`, `PhoneDisplay`.
  - `BrandingThemePhoneDisplay`: `Formatting`, `Masking` — controls how phone numbers are formatted/masked.
  - Added `GetIdentifiers()` on `BrandingTheme`, and `String()` on `BrandingThemeIdentifiers` and `BrandingThemePhoneDisplay`.
- Added `CountryCodes` field (type `*TenantCountryCodes`) to the `Tenant` struct, enabling phone identifier country code filtering at the tenant level.
  - `TenantCountryCodes`: `List` (ISO 3166-1 alpha-2 country codes) and `Mode` (`"allow"` or `"deny"`).
  - Added `GetCountryCodes()` on `Tenant`, and `String()` on `TenantCountryCodes`.
  - As with other nullable `Tenant` fields, `country_codes` can be unset via a `PATCH` with `"country_codes": null`.


### 🔬 Testing

- Added `TestBrandingThemeManager_Update_Identifiers`, which updates a branding theme with `Identifiers` set and asserts the values round-trip correctly, backed by an HTTP recording fixture.
- Added `TestTenantManager_CountryCodes`, which updates tenant settings with an allow-list and then a deny-list of country codes and asserts the change persists, backed by an HTTP recording fixture.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
