### PR TITLE
feat: add third_party_client_access field in organization

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -10701,6 +10701,14 @@ func (o *Organization) GetName() string {
 	return *o.Name
 }
 
+// GetThirdPartyClientAccess returns the ThirdPartyClientAccess field if it's non-nil, zero value otherwise.
+func (o *Organization) GetThirdPartyClientAccess() string {
+	if o == nil || o.ThirdPartyClientAccess == nil {
+		return ""
+	}
+	return *o.ThirdPartyClientAccess
+}
+
 // GetTokenQuota returns the TokenQuota field.
 func (o *Organization) GetTokenQuota() *TokenQuota {
 	if o == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -13381,6 +13381,16 @@ func TestOrganization_GetName(tt *testing.T) {
 	o.GetName()
 }
 
+func TestOrganization_GetThirdPartyClientAccess(tt *testing.T) {
+	var zeroValue string
+	o := &Organization{ThirdPartyClientAccess: &zeroValue}
+	o.GetThirdPartyClientAccess()
+	o = &Organization{}
+	o.GetThirdPartyClientAccess()
+	o = nil
+	o.GetThirdPartyClientAccess()
+}
+
 func TestOrganization_GetTokenQuota(tt *testing.T) {
 	o := &Organization{}
 	o.GetTokenQuota()

--- a/management/organization.go
+++ b/management/organization.go
@@ -20,6 +20,9 @@ type Organization struct {
 	// DisplayName of this organization.
 	DisplayName *string `json:"display_name,omitempty"`
 
+	// ThirdPartyClientAccess controls whether this organization can be used in user flows with third-party clients.
+	ThirdPartyClientAccess *string `json:"third_party_client_access,omitempty"`
+
 	// Branding defines how to style the login pages
 	Branding *OrganizationBranding `json:"branding,omitempty"`
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds support for the `third_party_client_access` field on organizations.

- Adds the `ThirdPartyClientAccess` field to the `Organization` struct, serialized as `third_party_client_access`.
- Controls whether an organization can be used in user flows with third-party clients.
- Generates the `GetThirdPartyClientAccess` accessor for safe nil-tolerant reads.

Usage:

```go
org := &management.Organization{
	Name:                   auth0.String("my-org"),
	ThirdPartyClientAccess: auth0.String("enabled"),
}
```

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- API Docs: https://auth0.com/docs/api/management/v2/organizations/post-organizations#body-third-party-client-access

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Generated accessor test `TestOrganization_GetThirdPartyClientAccess` covers the set, unset, and nil-receiver cases.
- The field is a standard optional string on an existing struct; existing organization create/update flows exercise its (de)serialization.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
