### PR TITLE
feat: added XAA feature support

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -165,6 +165,9 @@ type Connection struct {
 
 	// ConnectedAccounts is used for configuring the purpose of a connection to be used for connected accounts and Token Vault.
 	ConnectedAccounts *ConnectedAccounts `json:"connected_accounts,omitempty"`
+
+	// CrossAppAccessRequestingApp is used for configuring the purpose of a connection to be used as a Cross-App Access requesting application authorization server.
+	CrossAppAccessRequestingApp *CrossAppAccessRequestingApp `json:"cross_app_access_requesting_app,omitempty"`
 }
 
 // Authentication is used for configuring the purpose of a Connection for login with Universal Login and displaying the connection.
@@ -174,6 +177,11 @@ type Authentication struct {
 
 // ConnectedAccounts is used for configuring the purpose of a connection to be used for connected accounts and Token Vault.
 type ConnectedAccounts struct {
+	Active *bool `json:"active,omitempty"`
+}
+
+// CrossAppAccessRequestingApp is used for configuring the purpose of a connection to be used as a Cross-App Access requesting application authorization server.
+type CrossAppAccessRequestingApp struct {
 	Active *bool `json:"active,omitempty"`
 }
 

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -432,6 +432,9 @@ ZsUkLw2I7zI/dNlWdB8Xp7v+3w9sX5N3J/WuJ1KOO5m26kRlHQo7EzT3974g
 		connection: Connection{
 			Name:     auth0.Stringf("Test-OIDC-Connection-%d", time.Now().Unix()),
 			Strategy: auth0.String("oidc"),
+			CrossAppAccessRequestingApp: &CrossAppAccessRequestingApp{
+				Active: auth0.Bool(true),
+			},
 		},
 		options: &ConnectionOptionsOIDC{
 			ClientID:                  auth0.String("4ef8d976-71bd-4473-a7ce-087d3f0fafd8"),
@@ -574,6 +577,14 @@ func TestConnectionManager_Create(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotEmpty(t, expectedConnection.GetID())
 			assert.IsType(t, testCase.options, expectedConnection.Options)
+
+			if testCase.connection.CrossAppAccessRequestingApp != nil {
+				assert.Equal(
+					t,
+					testCase.connection.GetCrossAppAccessRequestingApp().GetActive(),
+					expectedConnection.GetCrossAppAccessRequestingApp().GetActive(),
+				)
+			}
 
 			t.Cleanup(func() {
 				cleanupConnection(t, expectedConnection.GetID())

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2885,6 +2885,14 @@ func (c *Connection) GetConnectedAccounts() *ConnectedAccounts {
 	return c.ConnectedAccounts
 }
 
+// GetCrossAppAccessRequestingApp returns the CrossAppAccessRequestingApp field.
+func (c *Connection) GetCrossAppAccessRequestingApp() *CrossAppAccessRequestingApp {
+	if c == nil {
+		return nil
+	}
+	return c.CrossAppAccessRequestingApp
+}
+
 // GetDisplayName returns the DisplayName field if it's non-nil, zero value otherwise.
 func (c *Connection) GetDisplayName() string {
 	if c == nil || c.DisplayName == nil {
@@ -7435,6 +7443,19 @@ func (c *Credential) GetUpdatedAt() time.Time {
 
 // String returns a string representation of Credential.
 func (c *Credential) String() string {
+	return Stringify(c)
+}
+
+// GetActive returns the Active field if it's non-nil, zero value otherwise.
+func (c *CrossAppAccessRequestingApp) GetActive() bool {
+	if c == nil || c.Active == nil {
+		return false
+	}
+	return *c.Active
+}
+
+// String returns a string representation of CrossAppAccessRequestingApp.
+func (c *CrossAppAccessRequestingApp) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -3521,6 +3521,13 @@ func TestConnection_GetConnectedAccounts(tt *testing.T) {
 	c.GetConnectedAccounts()
 }
 
+func TestConnection_GetCrossAppAccessRequestingApp(tt *testing.T) {
+	c := &Connection{}
+	c.GetCrossAppAccessRequestingApp()
+	c = nil
+	c.GetCrossAppAccessRequestingApp()
+}
+
 func TestConnection_GetDisplayName(tt *testing.T) {
 	var zeroValue string
 	c := &Connection{DisplayName: &zeroValue}
@@ -9187,6 +9194,24 @@ func TestCredential_GetUpdatedAt(tt *testing.T) {
 func TestCredential_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &Credential{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestCrossAppAccessRequestingApp_GetActive(tt *testing.T) {
+	var zeroValue bool
+	c := &CrossAppAccessRequestingApp{Active: &zeroValue}
+	c.GetActive()
+	c = &CrossAppAccessRequestingApp{}
+	c.GetActive()
+	c = nil
+	c.GetActive()
+}
+
+func TestCrossAppAccessRequestingApp_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &CrossAppAccessRequestingApp{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/test/data/recordings/TestConnectionManager_Create/It_can_successfully_create_a_OIDC_Connection.yaml
+++ b/test/data/recordings/TestConnectionManager_Create/It_can_successfully_create_a_OIDC_Connection.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1190
+        content_length: 1290
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-OIDC-Connection-1757700857","strategy":"oidc","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","discovery_url":"https://example.com/.well-known/openid-configuration","authorization_endpoint":"https://example.com/authorize","issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","type":"front_channel","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid profile email","upstream_params":{"screen_name":{"alias":"login_hint"}},"oidc_metadata":{"authorization_endpoint":"https://example.com/authorize","claims_supported":["sub","iss","aud","exp","iat","name","email"],"grant_types_supported":["authorization_code","implicit","refresh_token"],"id_token_signing_alg_values_supported":["RS256"],"issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","response_types_supported":["code","id_token","token","code id_token"],"scopes_supported":["openid","profile","email"],"subject_types_supported":["public"],"token_endpoint":"https://example.com/oauth/token","token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],"userinfo_endpoint":"https://example.com/userinfo"}}}
+            {"name":"Test-OIDC-Connection-1784053651","strategy":"oidc","cross_app_access_requesting_app":{"active":true},"options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","discovery_url":"https://example.com/.well-known/openid-configuration","authorization_endpoint":"https://example.com/authorize","issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","type":"front_channel","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid profile email","upstream_params":{"screen_name":{"alias":"login_hint"}},"id_token_signed_response_algs":["RS256","PS256"],"oidc_metadata":{"authorization_endpoint":"https://example.com/authorize","claims_supported":["sub","iss","aud","exp","iat","name","email"],"grant_types_supported":["authorization_code","implicit","refresh_token"],"id_token_signing_alg_values_supported":["RS256"],"issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","response_types_supported":["code","id_token","token","code id_token"],"scopes_supported":["openid","profile","email"],"subject_types_supported":["public"],"token_endpoint":"https://example.com/oauth/token","token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],"userinfo_endpoint":"https://example.com/userinfo"}}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.28.0
+                - Go-Auth0/1.44.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"id":"con_nj8LSqLDn1wsDuNh","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","discovery_url":"https://example.com/.well-known/openid-configuration","authorization_endpoint":"https://example.com/authorize","issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","type":"front_channel","userinfo_endpoint":"https://example.com/userinfo","token_endpoint":"https://example.com/oauth/token","scope":"openid profile email","upstream_params":{"screen_name":{"alias":"login_hint"}},"oidc_metadata":{"authorization_endpoint":"https://example.com/authorize","claims_supported":["sub","iss","aud","exp","iat","name","email"],"grant_types_supported":["authorization_code","implicit","refresh_token"],"id_token_signing_alg_values_supported":["RS256"],"issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","response_types_supported":["code","id_token","token","code id_token"],"scopes_supported":["openid","profile","email"],"subject_types_supported":["public"],"token_endpoint":"https://example.com/oauth/token","token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],"userinfo_endpoint":"https://example.com/userinfo","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false},"schema_version":"oidc-V4","attribute_map":{"mapping_mode":"bind_all"},"connection_settings":{"pkce":"auto"}},"strategy":"oidc","name":"Test-OIDC-Connection-1757700857","is_domain_connection":false,"show_as_button":false,"display_name":"Test-OIDC-Connection-1757700857","enabled_clients":[],"realms":["Test-OIDC-Connection-1757700857"]}'
+        body: '{"id":"con_N9F4Xe32OeGTYKSU","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","discovery_url":"https://example.com/.well-known/openid-configuration","authorization_endpoint":"https://example.com/authorize","issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","type":"front_channel","userinfo_endpoint":"https://example.com/userinfo","token_endpoint":"https://example.com/oauth/token","scope":"openid profile email","upstream_params":{"screen_name":{"alias":"login_hint"}},"id_token_signed_response_algs":["RS256","PS256"],"oidc_metadata":{"authorization_endpoint":"https://example.com/authorize","claims_supported":["sub","iss","aud","exp","iat","name","email"],"grant_types_supported":["authorization_code","implicit","refresh_token"],"id_token_signing_alg_values_supported":["RS256"],"issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","response_types_supported":["code","id_token","token","code id_token"],"scopes_supported":["openid","profile","email"],"subject_types_supported":["public"],"token_endpoint":"https://example.com/oauth/token","token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],"userinfo_endpoint":"https://example.com/userinfo","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false},"schema_version":"oidc-V4","attribute_map":{"mapping_mode":"bind_all"},"connection_settings":{"pkce":"auto"}},"strategy":"oidc","name":"Test-OIDC-Connection-1784053651","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"cross_app_access_requesting_app":{"active":true},"display_name":"Test-OIDC-Connection-1784053651","enabled_clients":[],"realms":["Test-OIDC-Connection-1784053651"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 1.14842275s
+        duration: 908.821ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -52,8 +52,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.28.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_nj8LSqLDn1wsDuNh
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_N9F4Xe32OeGTYKSU
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -63,10 +63,10 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2025-09-12T18:14:19.837Z"}'
+        body: '{"deleted_at":"2026-07-14T18:27:33.185Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 872.658417ms
+        duration: 887.751208ms

--- a/test/data/recordings/TestConnectionManager_Read/It_can_successfully_read_a_OIDC_Connection.yaml
+++ b/test/data/recordings/TestConnectionManager_Read/It_can_successfully_read_a_OIDC_Connection.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1190
+        content_length: 1290
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test-OIDC-Connection-1757700921","strategy":"oidc","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","discovery_url":"https://example.com/.well-known/openid-configuration","authorization_endpoint":"https://example.com/authorize","issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","type":"front_channel","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid profile email","upstream_params":{"screen_name":{"alias":"login_hint"}},"oidc_metadata":{"authorization_endpoint":"https://example.com/authorize","claims_supported":["sub","iss","aud","exp","iat","name","email"],"grant_types_supported":["authorization_code","implicit","refresh_token"],"id_token_signing_alg_values_supported":["RS256"],"issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","response_types_supported":["code","id_token","token","code id_token"],"scopes_supported":["openid","profile","email"],"subject_types_supported":["public"],"token_endpoint":"https://example.com/oauth/token","token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],"userinfo_endpoint":"https://example.com/userinfo"}}}
+            {"name":"Test-OIDC-Connection-1784053679","strategy":"oidc","cross_app_access_requesting_app":{"active":true},"options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","discovery_url":"https://example.com/.well-known/openid-configuration","authorization_endpoint":"https://example.com/authorize","issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","type":"front_channel","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid profile email","upstream_params":{"screen_name":{"alias":"login_hint"}},"id_token_signed_response_algs":["RS256","PS256"],"oidc_metadata":{"authorization_endpoint":"https://example.com/authorize","claims_supported":["sub","iss","aud","exp","iat","name","email"],"grant_types_supported":["authorization_code","implicit","refresh_token"],"id_token_signing_alg_values_supported":["RS256"],"issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","response_types_supported":["code","id_token","token","code id_token"],"scopes_supported":["openid","profile","email"],"subject_types_supported":["public"],"token_endpoint":"https://example.com/oauth/token","token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],"userinfo_endpoint":"https://example.com/userinfo"}}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.28.0
+                - Go-Auth0/1.44.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"id":"con_S6e3XARphqilWTZJ","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","discovery_url":"https://example.com/.well-known/openid-configuration","authorization_endpoint":"https://example.com/authorize","issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","type":"front_channel","userinfo_endpoint":"https://example.com/userinfo","token_endpoint":"https://example.com/oauth/token","scope":"openid profile email","upstream_params":{"screen_name":{"alias":"login_hint"}},"oidc_metadata":{"authorization_endpoint":"https://example.com/authorize","claims_supported":["sub","iss","aud","exp","iat","name","email"],"grant_types_supported":["authorization_code","implicit","refresh_token"],"id_token_signing_alg_values_supported":["RS256"],"issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","response_types_supported":["code","id_token","token","code id_token"],"scopes_supported":["openid","profile","email"],"subject_types_supported":["public"],"token_endpoint":"https://example.com/oauth/token","token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],"userinfo_endpoint":"https://example.com/userinfo","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false},"schema_version":"oidc-V4","attribute_map":{"mapping_mode":"bind_all"},"connection_settings":{"pkce":"auto"}},"strategy":"oidc","name":"Test-OIDC-Connection-1757700921","is_domain_connection":false,"show_as_button":false,"display_name":"Test-OIDC-Connection-1757700921","enabled_clients":[],"realms":["Test-OIDC-Connection-1757700921"]}'
+        body: '{"id":"con_TXbqvSVEpHu4l5ZY","options":{"client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","discovery_url":"https://example.com/.well-known/openid-configuration","authorization_endpoint":"https://example.com/authorize","issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","type":"front_channel","userinfo_endpoint":"https://example.com/userinfo","token_endpoint":"https://example.com/oauth/token","scope":"openid profile email","upstream_params":{"screen_name":{"alias":"login_hint"}},"id_token_signed_response_algs":["RS256","PS256"],"oidc_metadata":{"authorization_endpoint":"https://example.com/authorize","claims_supported":["sub","iss","aud","exp","iat","name","email"],"grant_types_supported":["authorization_code","implicit","refresh_token"],"id_token_signing_alg_values_supported":["RS256"],"issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","response_types_supported":["code","id_token","token","code id_token"],"scopes_supported":["openid","profile","email"],"subject_types_supported":["public"],"token_endpoint":"https://example.com/oauth/token","token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],"userinfo_endpoint":"https://example.com/userinfo","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false},"schema_version":"oidc-V4","attribute_map":{"mapping_mode":"bind_all"},"connection_settings":{"pkce":"auto"}},"strategy":"oidc","name":"Test-OIDC-Connection-1784053679","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"cross_app_access_requesting_app":{"active":true},"display_name":"Test-OIDC-Connection-1784053679","enabled_clients":[],"realms":["Test-OIDC-Connection-1784053679"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 932.781ms
+        duration: 1.114904666s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -52,8 +52,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.28.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_S6e3XARphqilWTZJ
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_TXbqvSVEpHu4l5ZY
         method: GET
       response:
         proto: HTTP/2.0
@@ -63,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_S6e3XARphqilWTZJ","options":{"type":"front_channel","scope":"openid profile email","issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","attribute_map":{"mapping_mode":"bind_all"},"discovery_url":"https://example.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","token_endpoint":"https://example.com/oauth/token","claims_supported":["sub","iss","aud","exp","iat","name","email"],"scopes_supported":["openid","profile","email"],"userinfo_endpoint":"https://example.com/userinfo","grant_types_supported":["authorization_code","implicit","refresh_token"],"authorization_endpoint":"https://example.com/authorize","subject_types_supported":["public"],"response_types_supported":["code","id_token","token","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://example.com/oauth/token","upstream_params":{"screen_name":{"alias":"login_hint"}},"userinfo_endpoint":"https://example.com/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.com/authorize"},"strategy":"oidc","name":"Test-OIDC-Connection-1757700921","is_domain_connection":false,"show_as_button":false,"display_name":"Test-OIDC-Connection-1757700921","enabled_clients":[],"realms":["Test-OIDC-Connection-1757700921"]}'
+        body: '{"id":"con_TXbqvSVEpHu4l5ZY","options":{"type":"front_channel","scope":"openid profile email","issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","client_id":"4ef8d976-71bd-4473-a7ce-087d3f0fafd8","attribute_map":{"mapping_mode":"bind_all"},"discovery_url":"https://example.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://example.com","jwks_uri":"https://example.com/.well-known/jwks.json","token_endpoint":"https://example.com/oauth/token","claims_supported":["sub","iss","aud","exp","iat","name","email"],"scopes_supported":["openid","profile","email"],"userinfo_endpoint":"https://example.com/userinfo","grant_types_supported":["authorization_code","implicit","refresh_token"],"authorization_endpoint":"https://example.com/authorize","subject_types_supported":["public"],"response_types_supported":["code","id_token","token","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://example.com/oauth/token","upstream_params":{"screen_name":{"alias":"login_hint"}},"userinfo_endpoint":"https://example.com/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.com/authorize","id_token_signed_response_algs":["RS256","PS256"]},"strategy":"oidc","name":"Test-OIDC-Connection-1784053679","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"cross_app_access_requesting_app":{"active":true},"display_name":"Test-OIDC-Connection-1784053679","enabled_clients":[],"realms":["Test-OIDC-Connection-1784053679"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 406.237209ms
+        duration: 314.780042ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -85,8 +85,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.28.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_S6e3XARphqilWTZJ
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_TXbqvSVEpHu4l5ZY
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -96,13 +96,13 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2025-09-12T18:15:23.175Z"}'
+        body: '{"deleted_at":"2026-07-14T18:28:01.088Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 360.573791ms
+        duration: 765.079792ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -118,8 +118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.28.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_S6e3XARphqilWTZJ
+                - Go-Auth0/1.44.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/connections/con_TXbqvSVEpHu4l5ZY
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -127,12 +127,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
+        content_length: 41
         uncompressed: false
-        body: ""
+        body: '{"deleted_at":"2026-07-14T18:28:01.088Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 345.058333ms
+        status: 202 Accepted
+        code: 202
+        duration: 285.7535ms


### PR DESCRIPTION

# Add Cross-App Access (XAA) support to Connection

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This adds support for configuring a connection as a Cross-App Access (XAA) requesting application authorization server.

- Added `CrossAppAccessRequestingApp` field to the `Connection` struct, serialized as `cross_app_access_requesting_app`.
- Added the `CrossAppAccessRequestingApp` struct with an `Active *bool` field (`active`) to toggle the behavior.
- Generated accessors: `Connection.GetCrossAppAccessRequestingApp()`, `CrossAppAccessRequestingApp.GetActive()`, and a `String()` method.

Usage:

```go
conn := &management.Connection{
    Name:     auth0.String("my-oidc-connection"),
    Strategy: auth0.String("oidc"),
    CrossAppAccessRequestingApp: &management.CrossAppAccessRequestingApp{
        Active: auth0.Bool(true),
    },
    // ... options
}
```

### 🔬 Testing

- Extended the OIDC connection lifecycle tests to set and assert `CrossAppAccessRequestingApp.Active`, backed by refreshed HTTP recordings for create/read of OIDC connections.
- Added generated-accessor unit tests (`TestConnection_GetCrossAppAccessRequestingApp`, `TestCrossAppAccessRequestingApp_GetActive`, `TestCrossAppAccessRequestingApp_String`).

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->