### PR TITLE
fix: add TenantDomain

### DIFF
--- a/management/core/request_option.go
+++ b/management/core/request_option.go
@@ -48,6 +48,10 @@ type RequestOptions struct {
 	// CustomDomainHeader is the custom domain to be sent in the "Auth0-Custom-Domain" header
 	// for whitelisted API endpoints
 	CustomDomainHeader string
+
+	// TenantDomain is the "tenantDomain" server URL variable, substituted into
+	// the base URL template at construction time.
+	TenantDomain string
 }
 
 // NewRequestOptions returns a new *RequestOptions value.
@@ -196,6 +200,15 @@ type WithoutRetriesOption struct{}
 
 func (w *WithoutRetriesOption) applyRequestOptions(opts *RequestOptions) {
 	opts.DisableRetries = true
+}
+
+// TenantDomainOption implements the RequestOption interface.
+type TenantDomainOption struct {
+	TenantDomain string
+}
+
+func (t *TenantDomainOption) applyRequestOptions(opts *RequestOptions) {
+	opts.TenantDomain = t.TenantDomain
 }
 
 // TokenOption implements the RequestOption interface.

--- a/management/core/request_option_test.go
+++ b/management/core/request_option_test.go
@@ -405,3 +405,8 @@ func TestClientCredentialsPrivateKeyJwtAndAudienceOption_TokenURL(t *testing.T) 
 		})
 	}
 }
+
+func TestTenantDomainOption(t *testing.T) {
+	options := NewRequestOptions(&TenantDomainOption{TenantDomain: "acme.us.auth0.com"})
+	assert.Equal(t, "acme.us.auth0.com", options.TenantDomain)
+}

--- a/management/option/request_option.go
+++ b/management/option/request_option.go
@@ -109,6 +109,14 @@ func WithToken(token string) *core.TokenOption {
 	}
 }
 
+// WithTenantDomain sets the "tenantDomain" server URL variable, which is
+// substituted into the base URL template at construction time.
+func WithTenantDomain(tenantDomain string) *core.TenantDomainOption {
+	return &core.TenantDomainOption{
+		TenantDomain: tenantDomain,
+	}
+}
+
 // WithClientCredentials configures OAuth2 client credentials authentication
 // using a client ID and secret. The SDK will automatically fetch and refresh
 // tokens from the Auth0 token endpoint.


### PR DESCRIPTION
### Overview
Manually adds generated code for new tenantDomain server URL var

### 🔧 Changes

Manually adds support for the `tenantDomain` server URL variable so callers can target a specific tenant domain.

- `core.RequestOptions` gains a `TenantDomain` field, substituted into the base URL template at construction time.
- New `option.WithTenantDomain(...)` request option to set it.

### 📚 References

N/A

### 🔬 Testing

Covered by a unit test in `management/core/request_option_test.go`. `go build ./...` passes.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
