### PR TITLE
feat: add Cross-App Access resource application support

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -260,6 +260,15 @@ type Client struct {
 
 	// FedCMLogin holds the Federated Credential Management login configuration.
 	FedCMLogin *FedCMLogin `json:"fedcm_login,omitempty"`
+
+	// IdentityAssertionAuthorizationGrant enables the Identity Assertion Authorization Grant (ID-JAG) exchange for the client, used for Cross-App Access.
+	IdentityAssertionAuthorizationGrant *IdentityAssertionAuthorizationGrant `json:"identity_assertion_authorization_grant,omitempty"`
+}
+
+// IdentityAssertionAuthorizationGrant enables the Identity Assertion Authorization Grant (ID-JAG) exchange for the client, used for Cross-App Access.
+type IdentityAssertionAuthorizationGrant struct {
+	// Active controls whether the client can exchange ID-JAGs for access tokens.
+	Active *bool `json:"active,omitempty"`
 }
 
 // ExpressConfiguration represents the OIN Express Configuration settings for a client.

--- a/management/connection.go
+++ b/management/connection.go
@@ -165,11 +165,20 @@ type Connection struct {
 
 	// ConnectedAccounts is used for configuring the purpose of a connection to be used for connected accounts and Token Vault.
 	ConnectedAccounts *ConnectedAccounts `json:"connected_accounts,omitempty"`
+
+	// CrossAppAccessResourceApp is used for configuring the purpose of a connection to be used as a Cross-App Access resource application authorization server.
+	CrossAppAccessResourceApp *CrossAppAccessResourceApp `json:"cross_app_access_resource_app,omitempty"`
 }
 
 // Authentication is used for configuring the purpose of a Connection for login with Universal Login and displaying the connection.
 type Authentication struct {
 	Active *bool `json:"active,omitempty"`
+}
+
+// CrossAppAccessResourceApp is used for configuring the purpose of a connection to be used as a Cross-App Access resource application authorization server.
+type CrossAppAccessResourceApp struct {
+	// Status controls whether the connection acts as a Cross-App Access resource application. One of "enabled" or "disabled".
+	Status *string `json:"status,omitempty"`
 }
 
 // ConnectedAccounts is used for configuring the purpose of a connection to be used for connected accounts and Token Vault.
@@ -1743,6 +1752,11 @@ type ConnectionOptionsSAML struct {
 	UpstreamParams              map[string]interface{} `json:"upstream_params,omitempty"`
 	GlobalTokenRevocationJWTIss *string                `json:"global_token_revocation_jwt_iss,omitempty"`
 	GlobalTokenRevocationJWTSub *string                `json:"global_token_revocation_jwt_sub,omitempty"`
+
+	// DiscoveryURL is the OIDC discovery URL used to auto-populate OIDCMetadata. Honoured for SAML connections acting as a Cross-App Access resource application.
+	DiscoveryURL *string `json:"discovery_url,omitempty"`
+	// OIDCMetadata is the OIDC discovery document. Auto-populated from DiscoveryURL when absent, or preserved as uploaded. Honoured for SAML connections acting as a Cross-App Access resource application.
+	OIDCMetadata map[string]interface{} `json:"oidc_metadata,omitempty"`
 }
 
 // ConnectionOptionsSAMLIdpInitiated is used to configure the

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1937,6 +1937,14 @@ func (c *Client) GetGrantTypes() []string {
 	return *c.GrantTypes
 }
 
+// GetIdentityAssertionAuthorizationGrant returns the IdentityAssertionAuthorizationGrant field.
+func (c *Client) GetIdentityAssertionAuthorizationGrant() *IdentityAssertionAuthorizationGrant {
+	if c == nil {
+		return nil
+	}
+	return c.IdentityAssertionAuthorizationGrant
+}
+
 // GetInitiateLoginURI returns the InitiateLoginURI field if it's non-nil, zero value otherwise.
 func (c *Client) GetInitiateLoginURI() string {
 	if c == nil || c.InitiateLoginURI == nil {
@@ -2883,6 +2891,14 @@ func (c *Connection) GetConnectedAccounts() *ConnectedAccounts {
 		return nil
 	}
 	return c.ConnectedAccounts
+}
+
+// GetCrossAppAccessResourceApp returns the CrossAppAccessResourceApp field.
+func (c *Connection) GetCrossAppAccessResourceApp() *CrossAppAccessResourceApp {
+	if c == nil {
+		return nil
+	}
+	return c.CrossAppAccessResourceApp
 }
 
 // GetDisplayName returns the DisplayName field if it's non-nil, zero value otherwise.
@@ -6617,6 +6633,14 @@ func (c *ConnectionOptionsSAML) GetDisableSignOut() bool {
 	return *c.DisableSignOut
 }
 
+// GetDiscoveryURL returns the DiscoveryURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetDiscoveryURL() string {
+	if c == nil || c.DiscoveryURL == nil {
+		return ""
+	}
+	return *c.DiscoveryURL
+}
+
 // GetDomainAliases returns the DomainAliases field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSAML) GetDomainAliases() []string {
 	if c == nil || c.DomainAliases == nil {
@@ -6719,6 +6743,14 @@ func (c *ConnectionOptionsSAML) GetNonPersistentAttrs() []string {
 		return nil
 	}
 	return *c.NonPersistentAttrs
+}
+
+// GetOIDCMetadata returns the OIDCMetadata map if it's non-nil, an empty map otherwise.
+func (c *ConnectionOptionsSAML) GetOIDCMetadata() map[string]interface{} {
+	if c == nil || c.OIDCMetadata == nil {
+		return map[string]interface{}{}
+	}
+	return c.OIDCMetadata
 }
 
 // GetProtocolBinding returns the ProtocolBinding field if it's non-nil, zero value otherwise.
@@ -7435,6 +7467,19 @@ func (c *Credential) GetUpdatedAt() time.Time {
 
 // String returns a string representation of Credential.
 func (c *Credential) String() string {
+	return Stringify(c)
+}
+
+// GetStatus returns the Status field if it's non-nil, zero value otherwise.
+func (c *CrossAppAccessResourceApp) GetStatus() string {
+	if c == nil || c.Status == nil {
+		return ""
+	}
+	return *c.Status
+}
+
+// String returns a string representation of CrossAppAccessResourceApp.
+func (c *CrossAppAccessResourceApp) String() string {
 	return Stringify(c)
 }
 
@@ -9208,6 +9253,19 @@ func (h *Hook) String() string {
 // String returns a string representation of HookList.
 func (h *HookList) String() string {
 	return Stringify(h)
+}
+
+// GetActive returns the Active field if it's non-nil, zero value otherwise.
+func (i *IdentityAssertionAuthorizationGrant) GetActive() bool {
+	if i == nil || i.Active == nil {
+		return false
+	}
+	return *i.Active
+}
+
+// String returns a string representation of IdentityAssertionAuthorizationGrant.
+func (i *IdentityAssertionAuthorizationGrant) String() string {
+	return Stringify(i)
 }
 
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2451,6 +2451,13 @@ func TestClient_GetGrantTypes(tt *testing.T) {
 	c.GetGrantTypes()
 }
 
+func TestClient_GetIdentityAssertionAuthorizationGrant(tt *testing.T) {
+	c := &Client{}
+	c.GetIdentityAssertionAuthorizationGrant()
+	c = nil
+	c.GetIdentityAssertionAuthorizationGrant()
+}
+
 func TestClient_GetInitiateLoginURI(tt *testing.T) {
 	var zeroValue string
 	c := &Client{InitiateLoginURI: &zeroValue}
@@ -3519,6 +3526,13 @@ func TestConnection_GetConnectedAccounts(tt *testing.T) {
 	c.GetConnectedAccounts()
 	c = nil
 	c.GetConnectedAccounts()
+}
+
+func TestConnection_GetCrossAppAccessResourceApp(tt *testing.T) {
+	c := &Connection{}
+	c.GetCrossAppAccessResourceApp()
+	c = nil
+	c.GetCrossAppAccessResourceApp()
 }
 
 func TestConnection_GetDisplayName(tt *testing.T) {
@@ -8171,6 +8185,16 @@ func TestConnectionOptionsSAML_GetDisableSignOut(tt *testing.T) {
 	c.GetDisableSignOut()
 }
 
+func TestConnectionOptionsSAML_GetDiscoveryURL(tt *testing.T) {
+	var zeroValue string
+	c := &ConnectionOptionsSAML{DiscoveryURL: &zeroValue}
+	c.GetDiscoveryURL()
+	c = &ConnectionOptionsSAML{}
+	c.GetDiscoveryURL()
+	c = nil
+	c.GetDiscoveryURL()
+}
+
 func TestConnectionOptionsSAML_GetDomainAliases(tt *testing.T) {
 	var zeroValue []string
 	c := &ConnectionOptionsSAML{DomainAliases: &zeroValue}
@@ -8296,6 +8320,16 @@ func TestConnectionOptionsSAML_GetNonPersistentAttrs(tt *testing.T) {
 	c.GetNonPersistentAttrs()
 	c = nil
 	c.GetNonPersistentAttrs()
+}
+
+func TestConnectionOptionsSAML_GetOIDCMetadata(tt *testing.T) {
+	zeroValue := map[string]interface{}{}
+	c := &ConnectionOptionsSAML{OIDCMetadata: zeroValue}
+	c.GetOIDCMetadata()
+	c = &ConnectionOptionsSAML{}
+	c.GetOIDCMetadata()
+	c = nil
+	c.GetOIDCMetadata()
 }
 
 func TestConnectionOptionsSAML_GetProtocolBinding(tt *testing.T) {
@@ -9187,6 +9221,24 @@ func TestCredential_GetUpdatedAt(tt *testing.T) {
 func TestCredential_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &Credential{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestCrossAppAccessResourceApp_GetStatus(tt *testing.T) {
+	var zeroValue string
+	c := &CrossAppAccessResourceApp{Status: &zeroValue}
+	c.GetStatus()
+	c = &CrossAppAccessResourceApp{}
+	c.GetStatus()
+	c = nil
+	c.GetStatus()
+}
+
+func TestCrossAppAccessResourceApp_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &CrossAppAccessResourceApp{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
@@ -11474,6 +11526,24 @@ func TestHook_String(t *testing.T) {
 func TestHookList_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &HookList{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestIdentityAssertionAuthorizationGrant_GetActive(tt *testing.T) {
+	var zeroValue bool
+	i := &IdentityAssertionAuthorizationGrant{Active: &zeroValue}
+	i.GetActive()
+	i = &IdentityAssertionAuthorizationGrant{}
+	i.GetActive()
+	i = nil
+	i.GetActive()
+}
+
+func TestIdentityAssertionAuthorizationGrant_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &IdentityAssertionAuthorizationGrant{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds SDK support for configuring Cross-App Access resource applications and the Identity Assertion Authorization Grant (ID-JAG) exchange.

- **`Client`**: adds the `IdentityAssertionAuthorizationGrant` field (new `IdentityAssertionAuthorizationGrant` type with an `Active` flag). When active, the client can exchange ID-JAGs for access tokens.
- **`Connection`**: adds the `CrossAppAccessResourceApp` field (new `CrossAppAccessResourceApp` type with a `Status` of `"enabled"` or `"disabled"`) so a connection can act as a Cross-App Access resource application authorization server.
- **`ConnectionOptionsSAML`**: adds `DiscoveryURL` and `OIDCMetadata`, honoured when a SAML connection acts as a Cross-App Access resource application. `OIDCMetadata` is auto-populated from `DiscoveryURL` when absent, or preserved as uploaded.

Accessor getters and their generated tests were regenerated for the new types and fields.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

API Docs:
- [client.identity_assertion_authorization_grant](https://auth0.com/docs/api/management/v2/clients/post-clients#body-identity-assertion-authorization-grant)
- [connection.cross_app_access_resource_app](https://auth0.com/docs/api/management/v2/connections/post-connections#body-cross-app-access-resource-app)

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Generated getter tests cover the new fields and types (`make generate` produces no diff).
- `go build ./...` and `go vet ./management/` pass.

Run the generated accessor tests locally:

```bash
go test ./management/ -run 'CrossAppAccessResourceApp|IdentityAssertionAuthorizationGrant|ConnectionOptionsSAML_GetDiscoveryURL|ConnectionOptionsSAML_GetOIDCMetadata' -count=1
```

These are struct/serialization additions only; there is no new request logic to exercise against a live tenant.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
