### PR TITLE
feat: Add support for `Token Vault Privileged Access` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+**Added**
+- feat: add `TokenVaultPrivilegedAccess` support to `Client`, letting a client be configured as a Token Vault privileged worker with credentials, an IP allowlist, and per-connection scope grants (Early Access). Note that `Credentials`, `IPAllowlist`, and `Grants` are all required whenever the object is written
+
 ## [v1.46.0](https://github.com/auth0/go-auth0/tree/v1.46.0) (2026-07-31)
 [Full Changelog](https://github.com/auth0/go-auth0/compare/v1.45.0...v1.46.0)
 

--- a/management/client.go
+++ b/management/client.go
@@ -282,18 +282,21 @@ type Client struct {
 
 // ClientTokenVaultPrivilegedAccess configures Token Vault privileged worker access for a client.
 //
-// All three fields are required whenever this object is being written, on both
-// POST /clients and PATCH /clients/{id}. Leaving any one of them nil omits its
-// key and is rejected with a 400, so a caller must always send the full intended
-// state rather than only the sub-fields that changed:
+// All three fields are required on every write, on both POST /clients and
+// PATCH /clients/{id}. Omitting any one of them is rejected with a 400, so a
+// caller must always send the full intended state rather than only the
+// sub-fields that changed.
 //
-//	400 Updating `token_vault_privileged_access` requires `grants` to be present.
+// Writing this object also requires the create:client_token_vault_privileged_access
+// or update:client_token_vault_privileged_access scope, alongside the matching
+// client_credentials scope.
 //
-// Each field is a pointer to a slice so that clearing can be distinguished from
-// omission:
+// Each field is a pointer to a slice so that an empty array can be
+// distinguished from an omitted key:
 //
 //   - &[]T{...} → replaces the stored value.
-//   - &[]T{}    → sends an empty array, clearing that sub-field.
+//   - &[]T{}    → sends an empty array. PATCH clears the value, while POST
+//     rejects an empty IPAllowlist or Grants.
 //   - nil       → omits the key, which is an error (see above).
 //
 // Removing the whole object requires sending a literal `null` for
@@ -301,55 +304,44 @@ type Client struct {
 // because of `omitempty`. Use a custom PATCH request for that, as documented on
 // Client.TokenVaultPrivilegedAccess.
 type ClientTokenVaultPrivilegedAccess struct {
-	// Credentials attached to the privileged worker. Maximum of 2.
+	// Credentials pins the client credentials the privileged worker may
+	// authenticate with. Maximum of 2.
 	//
-	// Required whenever token_vault_privileged_access is being written. Sending an
-	// empty array detaches every credential and disables the worker, so read the
-	// current IDs and echo them on any write that is not meant to change them.
+	// The array is the complete attachment set: writing it replaces which
+	// credentials are attached, and an empty array detaches all of them.
+	// Attaching never creates or deletes a credential record, and a credential
+	// cannot be deleted while it is still attached.
 	//
-	// The accepted shape differs per endpoint:
-	// POST /clients accepts credential material (CredentialType and PEM) and creates
-	// the credentials inline, while PATCH /clients/{id} accepts only references to
-	// previously created credentials (ID).
-	Credentials *[]ClientCredentialID `json:"credentials,omitempty"`
+	// The accepted shape differs per endpoint. POST /clients takes credential
+	// material and creates the credentials inline, where CredentialType and PEM
+	// are required, Name, KeyID, Algorithm and ExpiresAt are optional, and ID is
+	// rejected. PATCH /clients/{id} takes only references to existing
+	// credentials, so ID is the only field accepted there.
+	//
+	// GET /clients/{id} returns just the ID of each attached credential. Use
+	// ClientManager.ListCredentials to read the full metadata.
+	Credentials *[]Credential `json:"credentials,omitempty"`
 
 	// IPAllowlist is the list of permitted IPv4 or IPv6 addresses, or CIDR ranges,
 	// from which the privileged worker may request tokens. Maximum of 10 entries.
 	//
-	// Required whenever token_vault_privileged_access is being written.
+	// Required on every write; POST rejects an empty array.
 	IPAllowlist *[]string `json:"ip_allowlist,omitempty"`
 
 	// Grants pins the connections, and the scopes within them, that the privileged
 	// worker may request tokens for. Maximum of 5 grants, with a maximum of 20
-	// scopes in total across all of them.
+	// scopes in total across all of them, and no repeated connections.
 	//
-	// Required whenever token_vault_privileged_access is being written.
+	// Required on every write; POST rejects an empty array.
 	Grants *[]ClientTokenVaultPrivilegedGrant `json:"grants,omitempty"`
-}
-
-// ClientCredentialID references a client credential used by a Token Vault privileged worker.
-//
-// On PATCH /clients/{id} only ID may be set, referencing a credential created
-// beforehand through ClientManager.CreateCredential. On POST /clients the
-// credential material is supplied instead, through CredentialType and PEM.
-type ClientCredentialID struct {
-	// ID of a previously created client credential.
-	ID *string `json:"id,omitempty"`
-
-	// Name of the credential.
-	Name *string `json:"name,omitempty"`
-
-	// CredentialType of the credential, for example "public_key".
-	CredentialType *string `json:"credential_type,omitempty"`
-
-	// PEM-formatted public key.
-	PEM *string `json:"pem,omitempty"`
 }
 
 // ClientTokenVaultPrivilegedGrant pins the scopes of a single connection that a
 // Token Vault privileged worker is allowed to request tokens for.
 type ClientTokenVaultPrivilegedGrant struct {
-	// Connection is the name of the connection the grant applies to.
+	// Connection is the name of the connection the grant applies to. The
+	// connection does not need to exist when the grant is configured; it is
+	// validated at runtime.
 	Connection *string `json:"connection,omitempty"`
 
 	// Scopes the privileged worker may request on the connection.
@@ -490,12 +482,12 @@ func (c *Client) CleanForPatch() {
 		c.ClientAuthenticationMethods.PrivateKeyJWT.Credentials = &credentials
 	}
 
-	// PATCH /clients/{id} only accepts credential references, so reduce a
-	// read-back credential list to its IDs. Entries without an ID are left
+	// PATCH /clients/{id} rejects any credential field other than `id`, so reduce
+	// a read-back credential list to bare IDs. Entries without an ID are left
 	// untouched rather than dropped: dropping them would silently detach the
 	// worker's credentials, whereas passing them through surfaces the API error.
 	if c.TokenVaultPrivilegedAccess != nil && c.TokenVaultPrivilegedAccess.Credentials != nil {
-		credentials := []ClientCredentialID{}
+		credentials := []Credential{}
 		reducible := true
 
 		for _, cred := range *c.TokenVaultPrivilegedAccess.Credentials {
@@ -504,7 +496,7 @@ func (c *Client) CleanForPatch() {
 				break
 			}
 
-			credentials = append(credentials, ClientCredentialID{ID: cred.ID})
+			credentials = append(credentials, Credential{ID: cred.ID})
 		}
 
 		if reducible {

--- a/management/client.go
+++ b/management/client.go
@@ -263,6 +263,86 @@ type Client struct {
 
 	// IdentityAssertionAuthorizationGrant enables the Identity Assertion Authorization Grant (ID-JAG) exchange for the client, used for Cross-App Access.
 	IdentityAssertionAuthorizationGrant *IdentityAssertionAuthorizationGrant `json:"identity_assertion_authorization_grant,omitempty"`
+
+	// TokenVaultPrivilegedAccess configures the client as a Token Vault privileged worker,
+	// allowing it to request Token Vault tokens on behalf of other users.
+	//
+	// This is an Early Access feature and requires it to be enabled for your tenant.
+	//
+	// To unset values (set to null), use a PATCH request like this:
+	// PATCH /api/v2/clients/{id}
+	// {
+	//	 "token_vault_privileged_access": null
+	// }
+	//
+	// For more details on making custom requests, refer to the Auth0 Go SDK examples:
+	// https://github.com/auth0/go-auth0/blob/main/EXAMPLES.md#providing-a-custom-user-struct
+	TokenVaultPrivilegedAccess *ClientTokenVaultPrivilegedAccess `json:"token_vault_privileged_access,omitempty"`
+}
+
+// ClientTokenVaultPrivilegedAccess configures Token Vault privileged worker access for a client.
+//
+// Each field is a pointer to a slice so that the three write semantics of the
+// Management API can be expressed:
+//
+//   - nil            → the key is omitted, leaving the stored value unchanged.
+//   - &[]T{}         → an empty array is sent, clearing the stored value.
+//   - &[]T{...}      → the stored value is replaced.
+//
+// Note that removing the whole object requires sending a literal `null` for
+// `token_vault_privileged_access`, which a nil pointer on Client cannot express
+// because of `omitempty`. Use a custom PATCH request for that, as documented on
+// Client.TokenVaultPrivilegedAccess.
+type ClientTokenVaultPrivilegedAccess struct {
+	// Credentials attached to the privileged worker. Maximum of 2.
+	//
+	// This property is required whenever token_vault_privileged_access is being
+	// set, on both POST /clients and PATCH /clients/{id}. Sending an empty array
+	// detaches every credential and disables the worker.
+	//
+	// The accepted shape differs per endpoint:
+	// POST /clients expects credential material (CredentialType and PEM), while
+	// PATCH /clients/{id} expects references to previously created credentials (ID).
+	Credentials *[]ClientCredentialID `json:"credentials,omitempty"`
+
+	// IPAllowlist is the list of permitted IPv4 or IPv6 addresses, or CIDR ranges,
+	// from which the privileged worker may request tokens. Maximum of 10 entries.
+	IPAllowlist *[]string `json:"ip_allowlist,omitempty"`
+
+	// Grants pins the connections, and the scopes within them, that the privileged
+	// worker may request tokens for. Maximum of 5 grants, with a maximum of 20
+	// scopes in total across all of them.
+	Grants *[]ClientTokenVaultPrivilegedGrant `json:"grants,omitempty"`
+}
+
+// ClientCredentialID references a client credential used by a Token Vault privileged worker.
+//
+// On PATCH /clients/{id} only ID may be set, referencing a credential created
+// beforehand through ClientManager.CreateCredential. On POST /clients the
+// credential material is supplied instead, through CredentialType and PEM.
+type ClientCredentialID struct {
+	// ID of a previously created client credential.
+	ID *string `json:"id,omitempty"`
+
+	// Name of the credential.
+	Name *string `json:"name,omitempty"`
+
+	// CredentialType of the credential, for example "public_key".
+	CredentialType *string `json:"credential_type,omitempty"`
+
+	// PEM-formatted public key.
+	PEM *string `json:"pem,omitempty"`
+}
+
+// ClientTokenVaultPrivilegedGrant pins the scopes of a single connection that a
+// Token Vault privileged worker is allowed to request tokens for.
+type ClientTokenVaultPrivilegedGrant struct {
+	// Connection is the name of the connection the grant applies to.
+	Connection *string `json:"connection,omitempty"`
+
+	// Scopes the privileged worker may request on the connection.
+	// Must be non-empty and must not contain duplicates.
+	Scopes *[]string `json:"scopes,omitempty"`
 }
 
 // IdentityAssertionAuthorizationGrant enables the Identity Assertion Authorization Grant (ID-JAG) exchange for the client, used for Cross-App Access.
@@ -396,6 +476,28 @@ func (c *Client) CleanForPatch() {
 		}
 
 		c.ClientAuthenticationMethods.PrivateKeyJWT.Credentials = &credentials
+	}
+
+	// PATCH /clients/{id} only accepts credential references, so reduce a
+	// read-back credential list to its IDs. Entries without an ID are left
+	// untouched rather than dropped: dropping them would silently detach the
+	// worker's credentials, whereas passing them through surfaces the API error.
+	if c.TokenVaultPrivilegedAccess != nil && c.TokenVaultPrivilegedAccess.Credentials != nil {
+		credentials := []ClientCredentialID{}
+		reducible := true
+
+		for _, cred := range *c.TokenVaultPrivilegedAccess.Credentials {
+			if cred.ID == nil || *cred.ID == "" {
+				reducible = false
+				break
+			}
+
+			credentials = append(credentials, ClientCredentialID{ID: cred.ID})
+		}
+
+		if reducible {
+			c.TokenVaultPrivilegedAccess.Credentials = &credentials
+		}
 	}
 }
 

--- a/management/client.go
+++ b/management/client.go
@@ -282,36 +282,48 @@ type Client struct {
 
 // ClientTokenVaultPrivilegedAccess configures Token Vault privileged worker access for a client.
 //
-// Each field is a pointer to a slice so that the three write semantics of the
-// Management API can be expressed:
+// All three fields are required whenever this object is being written, on both
+// POST /clients and PATCH /clients/{id}. Leaving any one of them nil omits its
+// key and is rejected with a 400, so a caller must always send the full intended
+// state rather than only the sub-fields that changed:
 //
-//   - nil            → the key is omitted, leaving the stored value unchanged.
-//   - &[]T{}         → an empty array is sent, clearing the stored value.
-//   - &[]T{...}      → the stored value is replaced.
+//	400 Updating `token_vault_privileged_access` requires `grants` to be present.
 //
-// Note that removing the whole object requires sending a literal `null` for
+// Each field is a pointer to a slice so that clearing can be distinguished from
+// omission:
+//
+//   - &[]T{...} → replaces the stored value.
+//   - &[]T{}    → sends an empty array, clearing that sub-field.
+//   - nil       → omits the key, which is an error (see above).
+//
+// Removing the whole object requires sending a literal `null` for
 // `token_vault_privileged_access`, which a nil pointer on Client cannot express
 // because of `omitempty`. Use a custom PATCH request for that, as documented on
 // Client.TokenVaultPrivilegedAccess.
 type ClientTokenVaultPrivilegedAccess struct {
 	// Credentials attached to the privileged worker. Maximum of 2.
 	//
-	// This property is required whenever token_vault_privileged_access is being
-	// set, on both POST /clients and PATCH /clients/{id}. Sending an empty array
-	// detaches every credential and disables the worker.
+	// Required whenever token_vault_privileged_access is being written. Sending an
+	// empty array detaches every credential and disables the worker, so read the
+	// current IDs and echo them on any write that is not meant to change them.
 	//
 	// The accepted shape differs per endpoint:
-	// POST /clients expects credential material (CredentialType and PEM), while
-	// PATCH /clients/{id} expects references to previously created credentials (ID).
+	// POST /clients accepts credential material (CredentialType and PEM) and creates
+	// the credentials inline, while PATCH /clients/{id} accepts only references to
+	// previously created credentials (ID).
 	Credentials *[]ClientCredentialID `json:"credentials,omitempty"`
 
 	// IPAllowlist is the list of permitted IPv4 or IPv6 addresses, or CIDR ranges,
 	// from which the privileged worker may request tokens. Maximum of 10 entries.
+	//
+	// Required whenever token_vault_privileged_access is being written.
 	IPAllowlist *[]string `json:"ip_allowlist,omitempty"`
 
 	// Grants pins the connections, and the scopes within them, that the privileged
 	// worker may request tokens for. Maximum of 5 grants, with a maximum of 20
 	// scopes in total across all of them.
+	//
+	// Required whenever token_vault_privileged_access is being written.
 	Grants *[]ClientTokenVaultPrivilegedGrant `json:"grants,omitempty"`
 }
 

--- a/management/client_test.go
+++ b/management/client_test.go
@@ -1212,6 +1212,23 @@ func cleanupClient(t *testing.T, clientID string) {
 	require.NoError(t, err)
 }
 
+// testTokenVaultPublicKeyPEM is a throwaway public key used to create the
+// credentials a Token Vault privileged worker must have attached.
+const testTokenVaultPublicKeyPEM = `-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo
+0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M
+6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi
+TSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi
+yMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb
+/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw
+++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE
+TjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH
+PPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF
+1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4
+XzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y
+0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==
+-----END PUBLIC KEY-----`
+
 func givenACredential(t *testing.T, client *Client) *Credential {
 	t.Helper()
 
@@ -1386,7 +1403,9 @@ func cleanupCredential(t *testing.T, clientID string, credentialID string) {
 }
 
 func TestClientTokenVaultPrivilegedAccess_MarshalJSON(t *testing.T) {
-	t.Run("Omits sub-fields that are nil, to preserve the stored value", func(t *testing.T) {
+	// The API rejects a write that omits any sub-field, so this asserts the
+	// marshalling behaviour only: a nil pointer emits no key at all.
+	t.Run("Omits sub-fields that are nil", func(t *testing.T) {
 		payload, err := json.Marshal(&Client{
 			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
 				Credentials: &[]ClientCredentialID{{ID: auth0.String("cred_123")}},
@@ -1557,9 +1576,16 @@ func TestClient_TokenVaultPrivilegedAccess(t *testing.T) {
 
 	ctx := context.Background()
 
-	// A privileged worker's credentials must exist before they can be referenced,
-	// and creating them needs a client ID, so the object is attached with a PATCH
-	// rather than being part of the initial POST.
+	// Every write that sets `token_vault_privileged_access` must carry all three
+	// sub-fields. Verified against a tenant with the feature enabled: omitting any
+	// one of them is a 400, so there is no "omit preserves the stored value"
+	// behaviour at the sub-field level. Clearing is done with an empty array, and
+	// removing the whole object with a literal null.
+	//
+	// Credentials are referenced by ID on PATCH, so they must exist first, which
+	// needs a client ID. The object is therefore attached with a PATCH rather than
+	// being part of the initial POST. POST does accept the object with inline
+	// credential material instead; that path is covered separately below.
 	client := &Client{
 		Name:         auth0.Stringf("Test Client TVPA (%s)", time.Now().Format(time.StampMilli)),
 		Description:  auth0.String("This is a test client with Token Vault privileged access."),
@@ -1611,12 +1637,50 @@ func TestClient_TokenVaultPrivilegedAccess(t *testing.T) {
 	assert.Equal(t, "Description updated without touching Token Vault.", preserved.GetDescription())
 	assert.Equal(t, created.GetTokenVaultPrivilegedAccess(), preserved.GetTokenVaultPrivilegedAccess())
 
-	// A populated array replaces the stored value; a nil sub-field is omitted and
-	// leaves its stored value alone.
+	// Omitting any single sub-field is rejected, even though the other two are
+	// present and the object already exists. This is why a caller must always echo
+	// the full intended state rather than sending only what changed.
+	for _, missing := range []struct {
+		name   string
+		access *ClientTokenVaultPrivilegedAccess
+	}{
+		{
+			name: "grants",
+			access: &ClientTokenVaultPrivilegedAccess{
+				Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
+				IPAllowlist: &[]string{"10.0.0.2"},
+			},
+		},
+		{
+			name: "ip_allowlist",
+			access: &ClientTokenVaultPrivilegedAccess{
+				Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
+				Grants:      &[]ClientTokenVaultPrivilegedGrant{},
+			},
+		},
+		{
+			name: "credentials",
+			access: &ClientTokenVaultPrivilegedAccess{
+				IPAllowlist: &[]string{"10.0.0.2"},
+				Grants:      &[]ClientTokenVaultPrivilegedGrant{},
+			},
+		},
+	} {
+		err := api.Client.Update(ctx, client.GetClientID(), &Client{TokenVaultPrivilegedAccess: missing.access})
+		assert.Error(t, err, "omitting %s should be rejected", missing.name)
+	}
+
+	// A populated array replaces the stored value.
 	require.NoError(t, api.Client.Update(ctx, client.GetClientID(), &Client{
 		TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
 			Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
 			IPAllowlist: &[]string{"10.0.0.2"},
+			Grants: &[]ClientTokenVaultPrivilegedGrant{
+				{
+					Connection: auth0.String("Username-Password-Authentication"),
+					Scopes:     &[]string{"openid", "profile"},
+				},
+			},
 		},
 	}))
 
@@ -1625,11 +1689,12 @@ func TestClient_TokenVaultPrivilegedAccess(t *testing.T) {
 	assert.Equal(t, []string{"10.0.0.2"}, replaced.GetTokenVaultPrivilegedAccess().GetIPAllowlist())
 	assert.Len(t, replaced.GetTokenVaultPrivilegedAccess().GetGrants(), 1)
 
-	// An empty array clears the stored value, which is distinct from removing the
-	// whole object.
+	// An empty array clears just that sub-field, which is distinct from removing
+	// the whole object.
 	require.NoError(t, api.Client.Update(ctx, client.GetClientID(), &Client{
 		TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
 			Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
+			IPAllowlist: &[]string{"10.0.0.2"},
 			Grants:      &[]ClientTokenVaultPrivilegedGrant{},
 		},
 	}))
@@ -1652,6 +1717,63 @@ func TestClient_TokenVaultPrivilegedAccess(t *testing.T) {
 	removed, err := api.Client.Read(ctx, client.GetClientID())
 	require.NoError(t, err)
 	assert.Nil(t, removed.GetTokenVaultPrivilegedAccess())
+}
+
+func TestClient_TokenVaultPrivilegedAccessOnCreate(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	ctx := context.Background()
+
+	// POST /clients accepts the object with inline credential material, so a
+	// privileged worker can be created in a single request. This is the one place
+	// CredentialType and PEM are used instead of an ID; PATCH only takes IDs.
+	client := &Client{
+		Name:         auth0.Stringf("Test Client TVPA Create (%s)", time.Now().Format(time.StampMilli)),
+		AppType:      auth0.String("non_interactive"),
+		IsFirstParty: auth0.Bool(true),
+		TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
+			Credentials: &[]ClientCredentialID{
+				{
+					Name:           auth0.String("Test Credential On Create"),
+					CredentialType: auth0.String("public_key"),
+					PEM:            auth0.String(testTokenVaultPublicKeyPEM),
+				},
+			},
+			IPAllowlist: &[]string{"10.0.0.1"},
+			Grants: &[]ClientTokenVaultPrivilegedGrant{
+				{
+					Connection: auth0.String("Username-Password-Authentication"),
+					Scopes:     &[]string{"openid"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, api.Client.Create(ctx, client))
+
+	t.Cleanup(func() {
+		cleanupClient(t, client.GetClientID())
+	})
+
+	// The response echoes the created credential, now carrying a server-assigned ID.
+	access := client.GetTokenVaultPrivilegedAccess()
+	require.NotNil(t, access)
+	require.Len(t, access.GetCredentials(), 1)
+	assert.NotEmpty(t, access.GetCredentials()[0].GetID())
+	assert.Equal(t, "public_key", access.GetCredentials()[0].GetCredentialType())
+	assert.Equal(t, []string{"10.0.0.1"}, access.GetIPAllowlist())
+	require.Len(t, access.GetGrants(), 1)
+	assert.Equal(t, "Username-Password-Authentication", access.GetGrants()[0].GetConnection())
+
+	// Reading back reduces credentials to bare ID references.
+	actual, err := api.Client.Read(ctx, client.GetClientID())
+	require.NoError(t, err)
+	require.Len(t, actual.GetTokenVaultPrivilegedAccess().GetCredentials(), 1)
+	assert.Equal(
+		t,
+		access.GetCredentials()[0].GetID(),
+		actual.GetTokenVaultPrivilegedAccess().GetCredentials()[0].GetID(),
+	)
 }
 
 func TestClient_CIMDFields(t *testing.T) {

--- a/management/client_test.go
+++ b/management/client_test.go
@@ -1403,120 +1403,80 @@ func cleanupCredential(t *testing.T, clientID string, credentialID string) {
 }
 
 func TestClientTokenVaultPrivilegedAccess_MarshalJSON(t *testing.T) {
-	// The API rejects a write that omits any sub-field, so this asserts the
-	// marshalling behaviour only: a nil pointer emits no key at all.
-	t.Run("Omits sub-fields that are nil", func(t *testing.T) {
-		payload, err := json.Marshal(&Client{
-			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
-				Credentials: &[]ClientCredentialID{{ID: auth0.String("cred_123")}},
-			},
-		})
-		require.NoError(t, err)
-		assert.JSONEq(
-			t,
-			`{"token_vault_privileged_access":{"credentials":[{"id":"cred_123"}]}}`,
-			string(payload),
-		)
-	})
-
-	t.Run("Sends empty arrays that clear the stored value", func(t *testing.T) {
-		payload, err := json.Marshal(&Client{
-			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
-				Credentials: &[]ClientCredentialID{{ID: auth0.String("cred_123")}},
-				IPAllowlist: &[]string{},
-				Grants:      &[]ClientTokenVaultPrivilegedGrant{},
-			},
-		})
-		require.NoError(t, err)
-		assert.JSONEq(
-			t,
-			`{"token_vault_privileged_access":{"credentials":[{"id":"cred_123"}],"ip_allowlist":[],"grants":[]}}`,
-			string(payload),
-		)
-	})
-
-	t.Run("Sends populated arrays that replace the stored value", func(t *testing.T) {
-		payload, err := json.Marshal(&Client{
-			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
-				Credentials: &[]ClientCredentialID{{ID: auth0.String("cred_123")}},
-				IPAllowlist: &[]string{"10.0.0.1", "192.168.1.0/24"},
-				Grants: &[]ClientTokenVaultPrivilegedGrant{
-					{
-						Connection: auth0.String("google-oauth2"),
-						Scopes:     &[]string{"https://www.googleapis.com/auth/calendar.readonly"},
-					},
+	// Each field is a pointer to a slice so that a nil field can be omitted while
+	// an empty one is still sent, which is what distinguishes "leave alone" from
+	// "clear" on PATCH.
+	for access, expected := range map[*ClientTokenVaultPrivilegedAccess]string{
+		{}: `{}`,
+		{
+			Credentials: &[]Credential{{ID: auth0.String("cred_123")}},
+		}: `{"credentials":[{"id":"cred_123"}]}`,
+		{
+			Credentials: &[]Credential{},
+			IPAllowlist: &[]string{},
+			Grants:      &[]ClientTokenVaultPrivilegedGrant{},
+		}: `{"credentials":[],"ip_allowlist":[],"grants":[]}`,
+		{
+			Credentials: &[]Credential{{ID: auth0.String("cred_123")}},
+			IPAllowlist: &[]string{"10.0.0.1", "192.168.1.0/24"},
+			Grants: &[]ClientTokenVaultPrivilegedGrant{
+				{
+					Connection: auth0.String("google-oauth2"),
+					Scopes:     &[]string{"https://www.googleapis.com/auth/calendar.readonly"},
 				},
 			},
-		})
-		require.NoError(t, err)
-		assert.JSONEq(
-			t,
-			`{"token_vault_privileged_access":{
-				"credentials":[{"id":"cred_123"}],
-				"ip_allowlist":["10.0.0.1","192.168.1.0/24"],
-				"grants":[{"connection":"google-oauth2","scopes":["https://www.googleapis.com/auth/calendar.readonly"]}]
-			}}`,
-			string(payload),
-		)
-	})
-
-	t.Run("Sends the credential material accepted on create", func(t *testing.T) {
-		payload, err := json.Marshal(&Client{
-			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
-				Credentials: &[]ClientCredentialID{
-					{
-						CredentialType: auth0.String("public_key"),
-						PEM:            auth0.String("-----BEGIN PUBLIC KEY-----"),
-					},
+		}: `{"credentials":[{"id":"cred_123"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"google-oauth2","scopes":["https://www.googleapis.com/auth/calendar.readonly"]}]}`,
+		// POST /clients takes credential material inline, where PATCH takes only
+		// an ID reference.
+		{
+			Credentials: &[]Credential{
+				{
+					Name:           auth0.String("Worker Key"),
+					CredentialType: auth0.String("public_key"),
+					PEM:            auth0.String("-----BEGIN PUBLIC KEY-----"),
 				},
 			},
-		})
-		require.NoError(t, err)
-		assert.JSONEq(
-			t,
-			`{"token_vault_privileged_access":{"credentials":[{"credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----"}]}}`,
-			string(payload),
-		)
-	})
+		}: `{"credentials":[{"name":"Worker Key","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----"}]}`,
+	} {
+		payload, err := json.Marshal(access)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(payload))
+	}
 
-	t.Run("Unmarshals a stored object", func(t *testing.T) {
-		var client Client
-
-		err := json.Unmarshal([]byte(`{"token_vault_privileged_access":{
-			"credentials":[{"id":"cred_123","name":"Worker Key","credential_type":"public_key"}],
-			"ip_allowlist":["10.0.0.1"],
-			"grants":[{"connection":"slack","scopes":["chat:write","channels:read"]}]
-		}}`), &client)
-		require.NoError(t, err)
-
-		access := client.GetTokenVaultPrivilegedAccess()
-		require.NotNil(t, access)
-		assert.Equal(t, []string{"10.0.0.1"}, access.GetIPAllowlist())
-
-		credentials := access.GetCredentials()
-		require.Len(t, credentials, 1)
-		assert.Equal(t, "cred_123", credentials[0].GetID())
-		assert.Equal(t, "Worker Key", credentials[0].GetName())
-		assert.Equal(t, "public_key", credentials[0].GetCredentialType())
-
-		grants := access.GetGrants()
-		require.Len(t, grants, 1)
-		assert.Equal(t, "slack", grants[0].GetConnection())
-		assert.Equal(t, []string{"chat:write", "channels:read"}, grants[0].GetScopes())
-	})
-
-	t.Run("Nil access omits the key entirely", func(t *testing.T) {
+	t.Run("Omits the key when unset on Client", func(t *testing.T) {
 		payload, err := json.Marshal(&Client{Name: auth0.String("Test Client")})
-		require.NoError(t, err)
-		assert.NotContains(t, string(payload), "token_vault_privileged_access")
+		assert.NoError(t, err)
+		assert.Equal(t, `{"name":"Test Client"}`, string(payload))
 	})
+}
+
+func TestClientTokenVaultPrivilegedAccess_UnmarshalJSON(t *testing.T) {
+	for jsonBody, expected := range map[string]*ClientTokenVaultPrivilegedAccess{
+		`{}`: {},
+		// GET /clients/{id} returns only the ID of each attached credential.
+		`{"credentials":[{"id":"cred_123"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"slack","scopes":["chat:write","channels:read"]}]}`: {
+			Credentials: &[]Credential{{ID: auth0.String("cred_123")}},
+			IPAllowlist: &[]string{"10.0.0.1"},
+			Grants: &[]ClientTokenVaultPrivilegedGrant{
+				{
+					Connection: auth0.String("slack"),
+					Scopes:     &[]string{"chat:write", "channels:read"},
+				},
+			},
+		},
+	} {
+		var actual ClientTokenVaultPrivilegedAccess
+		err := json.Unmarshal([]byte(jsonBody), &actual)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, &actual)
+	}
 }
 
 func TestClientTokenVaultPrivilegedAccess_CleanForPatch(t *testing.T) {
 	t.Run("Reduces read-back credentials to their IDs", func(t *testing.T) {
 		client := &Client{
 			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
-				Credentials: &[]ClientCredentialID{
+				Credentials: &[]Credential{
 					{
 						ID:             auth0.String("cred_123"),
 						Name:           auth0.String("Worker Key"),
@@ -1541,7 +1501,7 @@ func TestClientTokenVaultPrivilegedAccess_CleanForPatch(t *testing.T) {
 	t.Run("Leaves credential material untouched", func(t *testing.T) {
 		client := &Client{
 			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
-				Credentials: &[]ClientCredentialID{
+				Credentials: &[]Credential{
 					{
 						CredentialType: auth0.String("public_key"),
 						PEM:            auth0.String("-----BEGIN PUBLIC KEY-----"),
@@ -1559,7 +1519,7 @@ func TestClientTokenVaultPrivilegedAccess_CleanForPatch(t *testing.T) {
 	t.Run("Preserves an empty credentials list", func(t *testing.T) {
 		client := &Client{
 			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
-				Credentials: &[]ClientCredentialID{},
+				Credentials: &[]Credential{},
 			},
 		}
 
@@ -1577,10 +1537,10 @@ func TestClient_TokenVaultPrivilegedAccess(t *testing.T) {
 	ctx := context.Background()
 
 	// Every write that sets `token_vault_privileged_access` must carry all three
-	// sub-fields. Verified against a tenant with the feature enabled: omitting any
-	// one of them is a 400, so there is no "omit preserves the stored value"
-	// behaviour at the sub-field level. Clearing is done with an empty array, and
-	// removing the whole object with a literal null.
+	// sub-fields: omitting any one of them is a 400, so there is no "omit
+	// preserves the stored value" behaviour at the sub-field level. On PATCH,
+	// clearing is done with an empty array and removing the whole object with a
+	// literal null.
 	//
 	// Credentials are referenced by ID on PATCH, so they must exist first, which
 	// needs a client ID. The object is therefore attached with a PATCH rather than
@@ -1605,7 +1565,7 @@ func TestClient_TokenVaultPrivilegedAccess(t *testing.T) {
 	// Attach the object with all three sub-fields populated. `credentials` is
 	// required whenever the object is being set, so it is echoed on every write.
 	access := &ClientTokenVaultPrivilegedAccess{
-		Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
+		Credentials: &[]Credential{{ID: auth0.String(credential.GetID())}},
 		IPAllowlist: &[]string{"10.0.0.1", "192.168.1.0/24"},
 		Grants: &[]ClientTokenVaultPrivilegedGrant{
 			{
@@ -1647,14 +1607,14 @@ func TestClient_TokenVaultPrivilegedAccess(t *testing.T) {
 		{
 			name: "grants",
 			access: &ClientTokenVaultPrivilegedAccess{
-				Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
+				Credentials: &[]Credential{{ID: auth0.String(credential.GetID())}},
 				IPAllowlist: &[]string{"10.0.0.2"},
 			},
 		},
 		{
 			name: "ip_allowlist",
 			access: &ClientTokenVaultPrivilegedAccess{
-				Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
+				Credentials: &[]Credential{{ID: auth0.String(credential.GetID())}},
 				Grants:      &[]ClientTokenVaultPrivilegedGrant{},
 			},
 		},
@@ -1673,7 +1633,7 @@ func TestClient_TokenVaultPrivilegedAccess(t *testing.T) {
 	// A populated array replaces the stored value.
 	require.NoError(t, api.Client.Update(ctx, client.GetClientID(), &Client{
 		TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
-			Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
+			Credentials: &[]Credential{{ID: auth0.String(credential.GetID())}},
 			IPAllowlist: &[]string{"10.0.0.2"},
 			Grants: &[]ClientTokenVaultPrivilegedGrant{
 				{
@@ -1693,7 +1653,7 @@ func TestClient_TokenVaultPrivilegedAccess(t *testing.T) {
 	// the whole object.
 	require.NoError(t, api.Client.Update(ctx, client.GetClientID(), &Client{
 		TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
-			Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
+			Credentials: &[]Credential{{ID: auth0.String(credential.GetID())}},
 			IPAllowlist: &[]string{"10.0.0.2"},
 			Grants:      &[]ClientTokenVaultPrivilegedGrant{},
 		},
@@ -1732,7 +1692,7 @@ func TestClient_TokenVaultPrivilegedAccessOnCreate(t *testing.T) {
 		AppType:      auth0.String("non_interactive"),
 		IsFirstParty: auth0.Bool(true),
 		TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
-			Credentials: &[]ClientCredentialID{
+			Credentials: &[]Credential{
 				{
 					Name:           auth0.String("Test Credential On Create"),
 					CredentialType: auth0.String("public_key"),
@@ -1755,25 +1715,173 @@ func TestClient_TokenVaultPrivilegedAccessOnCreate(t *testing.T) {
 		cleanupClient(t, client.GetClientID())
 	})
 
-	// The response echoes the created credential, now carrying a server-assigned ID.
+	// The response echoes the created credential with the server-assigned ID and
+	// the derived metadata. Credential carries all of it, unlike the ID-only shape
+	// that PATCH and GET return.
 	access := client.GetTokenVaultPrivilegedAccess()
 	require.NotNil(t, access)
 	require.Len(t, access.GetCredentials(), 1)
-	assert.NotEmpty(t, access.GetCredentials()[0].GetID())
-	assert.Equal(t, "public_key", access.GetCredentials()[0].GetCredentialType())
+
+	created := access.GetCredentials()[0]
+	assert.NotEmpty(t, created.GetID())
+	assert.Equal(t, "public_key", created.GetCredentialType())
+	assert.Equal(t, "Test Credential On Create", created.GetName())
+	assert.NotEmpty(t, created.GetKeyID())
+	assert.Equal(t, "RS256", created.GetAlgorithm())
+	assert.False(t, created.GetCreatedAt().IsZero())
 	assert.Equal(t, []string{"10.0.0.1"}, access.GetIPAllowlist())
 	require.Len(t, access.GetGrants(), 1)
 	assert.Equal(t, "Username-Password-Authentication", access.GetGrants()[0].GetConnection())
 
-	// Reading back reduces credentials to bare ID references.
+	// Reading back reduces credentials to bare ID references: GET returns only the
+	// ID, so the metadata above has to come from ListCredentials instead.
 	actual, err := api.Client.Read(ctx, client.GetClientID())
 	require.NoError(t, err)
 	require.Len(t, actual.GetTokenVaultPrivilegedAccess().GetCredentials(), 1)
-	assert.Equal(
-		t,
-		access.GetCredentials()[0].GetID(),
-		actual.GetTokenVaultPrivilegedAccess().GetCredentials()[0].GetID(),
-	)
+
+	readBack := actual.GetTokenVaultPrivilegedAccess().GetCredentials()[0]
+	assert.Equal(t, created.GetID(), readBack.GetID())
+	assert.Empty(t, readBack.GetCredentialType())
+	assert.Empty(t, readBack.GetKeyID())
+
+	// The attached credential is an ordinary client credential.
+	credentials, err := api.Client.ListCredentials(ctx, client.GetClientID())
+	require.NoError(t, err)
+	require.Len(t, credentials, 1)
+	assert.Equal(t, created.GetID(), credentials[0].GetID())
+	assert.Equal(t, created.GetKeyID(), credentials[0].GetKeyID())
+}
+
+func TestClient_TokenVaultPrivilegedAccessValidation(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	ctx := context.Background()
+
+	credentials := &[]Credential{
+		{
+			CredentialType: auth0.String("public_key"),
+			PEM:            auth0.String(testTokenVaultPublicKeyPEM),
+		},
+	}
+	grants := &[]ClientTokenVaultPrivilegedGrant{
+		{
+			Connection: auth0.String("Username-Password-Authentication"),
+			Scopes:     &[]string{"openid"},
+		},
+	}
+
+	// The limits and formats the API enforces on create. Each case is rejected
+	// with a 400, so no client is left behind.
+	for _, testCase := range []struct {
+		name   string
+		access *ClientTokenVaultPrivilegedAccess
+	}{
+		{
+			name: "More than 10 ip_allowlist entries",
+			access: &ClientTokenVaultPrivilegedAccess{
+				Credentials: credentials,
+				IPAllowlist: &[]string{
+					"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5", "10.0.0.6",
+					"10.0.0.7", "10.0.0.8", "10.0.0.9", "10.0.0.10", "10.0.0.11",
+				},
+				Grants: grants,
+			},
+		},
+		{
+			name: "Malformed ip_allowlist entry",
+			access: &ClientTokenVaultPrivilegedAccess{
+				Credentials: credentials,
+				IPAllowlist: &[]string{"not-an-ip"},
+				Grants:      grants,
+			},
+		},
+		{
+			name: "More than 2 credentials",
+			access: &ClientTokenVaultPrivilegedAccess{
+				Credentials: &[]Credential{
+					{CredentialType: auth0.String("public_key"), PEM: auth0.String(testTokenVaultPublicKeyPEM), KeyID: auth0.String("keyidkeyid1")},
+					{CredentialType: auth0.String("public_key"), PEM: auth0.String(testTokenVaultPublicKeyPEM), KeyID: auth0.String("keyidkeyid2")},
+					{CredentialType: auth0.String("public_key"), PEM: auth0.String(testTokenVaultPublicKeyPEM), KeyID: auth0.String("keyidkeyid3")},
+				},
+				IPAllowlist: &[]string{"10.0.0.1"},
+				Grants:      grants,
+			},
+		},
+		{
+			name: "More than 5 grants",
+			access: &ClientTokenVaultPrivilegedAccess{
+				Credentials: credentials,
+				IPAllowlist: &[]string{"10.0.0.1"},
+				Grants: &[]ClientTokenVaultPrivilegedGrant{
+					{Connection: auth0.String("c1"), Scopes: &[]string{"openid"}},
+					{Connection: auth0.String("c2"), Scopes: &[]string{"openid"}},
+					{Connection: auth0.String("c3"), Scopes: &[]string{"openid"}},
+					{Connection: auth0.String("c4"), Scopes: &[]string{"openid"}},
+					{Connection: auth0.String("c5"), Scopes: &[]string{"openid"}},
+					{Connection: auth0.String("c6"), Scopes: &[]string{"openid"}},
+				},
+			},
+		},
+		{
+			name: "More than 20 scopes across all grants",
+			access: &ClientTokenVaultPrivilegedAccess{
+				Credentials: credentials,
+				IPAllowlist: &[]string{"10.0.0.1"},
+				Grants: &[]ClientTokenVaultPrivilegedGrant{
+					{
+						Connection: auth0.String("Username-Password-Authentication"),
+						Scopes: &[]string{
+							"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11",
+							"s12", "s13", "s14", "s15", "s16", "s17", "s18", "s19", "s20", "s21",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Duplicate connections in grants",
+			access: &ClientTokenVaultPrivilegedAccess{
+				Credentials: credentials,
+				IPAllowlist: &[]string{"10.0.0.1"},
+				Grants: &[]ClientTokenVaultPrivilegedGrant{
+					{Connection: auth0.String("dup"), Scopes: &[]string{"openid"}},
+					{Connection: auth0.String("dup"), Scopes: &[]string{"profile"}},
+				},
+			},
+		},
+		{
+			name: "Empty ip_allowlist on create",
+			access: &ClientTokenVaultPrivilegedAccess{
+				Credentials: credentials,
+				IPAllowlist: &[]string{},
+				Grants:      grants,
+			},
+		},
+		{
+			name: "Empty grants on create",
+			access: &ClientTokenVaultPrivilegedAccess{
+				Credentials: credentials,
+				IPAllowlist: &[]string{"10.0.0.1"},
+				Grants:      &[]ClientTokenVaultPrivilegedGrant{},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := &Client{
+				Name:                       auth0.Stringf("Test Client TVPA Invalid (%s)", time.Now().Format(time.StampMilli)),
+				AppType:                    auth0.String("non_interactive"),
+				IsFirstParty:               auth0.Bool(true),
+				TokenVaultPrivilegedAccess: testCase.access,
+			}
+
+			err := api.Client.Create(ctx, client)
+			assert.Error(t, err)
+
+			if client.GetClientID() != "" {
+				cleanupClient(t, client.GetClientID())
+			}
+		})
+	}
 }
 
 func TestClient_CIMDFields(t *testing.T) {

--- a/management/client_test.go
+++ b/management/client_test.go
@@ -1385,6 +1385,275 @@ func cleanupCredential(t *testing.T, clientID string, credentialID string) {
 	require.NoError(t, err)
 }
 
+func TestClientTokenVaultPrivilegedAccess_MarshalJSON(t *testing.T) {
+	t.Run("Omits sub-fields that are nil, to preserve the stored value", func(t *testing.T) {
+		payload, err := json.Marshal(&Client{
+			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
+				Credentials: &[]ClientCredentialID{{ID: auth0.String("cred_123")}},
+			},
+		})
+		require.NoError(t, err)
+		assert.JSONEq(
+			t,
+			`{"token_vault_privileged_access":{"credentials":[{"id":"cred_123"}]}}`,
+			string(payload),
+		)
+	})
+
+	t.Run("Sends empty arrays that clear the stored value", func(t *testing.T) {
+		payload, err := json.Marshal(&Client{
+			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
+				Credentials: &[]ClientCredentialID{{ID: auth0.String("cred_123")}},
+				IPAllowlist: &[]string{},
+				Grants:      &[]ClientTokenVaultPrivilegedGrant{},
+			},
+		})
+		require.NoError(t, err)
+		assert.JSONEq(
+			t,
+			`{"token_vault_privileged_access":{"credentials":[{"id":"cred_123"}],"ip_allowlist":[],"grants":[]}}`,
+			string(payload),
+		)
+	})
+
+	t.Run("Sends populated arrays that replace the stored value", func(t *testing.T) {
+		payload, err := json.Marshal(&Client{
+			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
+				Credentials: &[]ClientCredentialID{{ID: auth0.String("cred_123")}},
+				IPAllowlist: &[]string{"10.0.0.1", "192.168.1.0/24"},
+				Grants: &[]ClientTokenVaultPrivilegedGrant{
+					{
+						Connection: auth0.String("google-oauth2"),
+						Scopes:     &[]string{"https://www.googleapis.com/auth/calendar.readonly"},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.JSONEq(
+			t,
+			`{"token_vault_privileged_access":{
+				"credentials":[{"id":"cred_123"}],
+				"ip_allowlist":["10.0.0.1","192.168.1.0/24"],
+				"grants":[{"connection":"google-oauth2","scopes":["https://www.googleapis.com/auth/calendar.readonly"]}]
+			}}`,
+			string(payload),
+		)
+	})
+
+	t.Run("Sends the credential material accepted on create", func(t *testing.T) {
+		payload, err := json.Marshal(&Client{
+			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
+				Credentials: &[]ClientCredentialID{
+					{
+						CredentialType: auth0.String("public_key"),
+						PEM:            auth0.String("-----BEGIN PUBLIC KEY-----"),
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.JSONEq(
+			t,
+			`{"token_vault_privileged_access":{"credentials":[{"credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----"}]}}`,
+			string(payload),
+		)
+	})
+
+	t.Run("Unmarshals a stored object", func(t *testing.T) {
+		var client Client
+
+		err := json.Unmarshal([]byte(`{"token_vault_privileged_access":{
+			"credentials":[{"id":"cred_123","name":"Worker Key","credential_type":"public_key"}],
+			"ip_allowlist":["10.0.0.1"],
+			"grants":[{"connection":"slack","scopes":["chat:write","channels:read"]}]
+		}}`), &client)
+		require.NoError(t, err)
+
+		access := client.GetTokenVaultPrivilegedAccess()
+		require.NotNil(t, access)
+		assert.Equal(t, []string{"10.0.0.1"}, access.GetIPAllowlist())
+
+		credentials := access.GetCredentials()
+		require.Len(t, credentials, 1)
+		assert.Equal(t, "cred_123", credentials[0].GetID())
+		assert.Equal(t, "Worker Key", credentials[0].GetName())
+		assert.Equal(t, "public_key", credentials[0].GetCredentialType())
+
+		grants := access.GetGrants()
+		require.Len(t, grants, 1)
+		assert.Equal(t, "slack", grants[0].GetConnection())
+		assert.Equal(t, []string{"chat:write", "channels:read"}, grants[0].GetScopes())
+	})
+
+	t.Run("Nil access omits the key entirely", func(t *testing.T) {
+		payload, err := json.Marshal(&Client{Name: auth0.String("Test Client")})
+		require.NoError(t, err)
+		assert.NotContains(t, string(payload), "token_vault_privileged_access")
+	})
+}
+
+func TestClientTokenVaultPrivilegedAccess_CleanForPatch(t *testing.T) {
+	t.Run("Reduces read-back credentials to their IDs", func(t *testing.T) {
+		client := &Client{
+			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
+				Credentials: &[]ClientCredentialID{
+					{
+						ID:             auth0.String("cred_123"),
+						Name:           auth0.String("Worker Key"),
+						CredentialType: auth0.String("public_key"),
+					},
+				},
+				IPAllowlist: &[]string{"10.0.0.1"},
+			},
+		}
+
+		client.CleanForPatch()
+
+		payload, err := json.Marshal(client)
+		require.NoError(t, err)
+		assert.JSONEq(
+			t,
+			`{"token_vault_privileged_access":{"credentials":[{"id":"cred_123"}],"ip_allowlist":["10.0.0.1"]}}`,
+			string(payload),
+		)
+	})
+
+	t.Run("Leaves credential material untouched", func(t *testing.T) {
+		client := &Client{
+			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
+				Credentials: &[]ClientCredentialID{
+					{
+						CredentialType: auth0.String("public_key"),
+						PEM:            auth0.String("-----BEGIN PUBLIC KEY-----"),
+					},
+				},
+			},
+		}
+
+		client.CleanForPatch()
+
+		assert.Equal(t, "public_key", client.GetTokenVaultPrivilegedAccess().GetCredentials()[0].GetCredentialType())
+		assert.Equal(t, "-----BEGIN PUBLIC KEY-----", client.GetTokenVaultPrivilegedAccess().GetCredentials()[0].GetPEM())
+	})
+
+	t.Run("Preserves an empty credentials list", func(t *testing.T) {
+		client := &Client{
+			TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
+				Credentials: &[]ClientCredentialID{},
+			},
+		}
+
+		client.CleanForPatch()
+
+		payload, err := json.Marshal(client)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"token_vault_privileged_access":{"credentials":[]}}`, string(payload))
+	})
+}
+
+func TestClient_TokenVaultPrivilegedAccess(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	ctx := context.Background()
+
+	// A privileged worker's credentials must exist before they can be referenced,
+	// and creating them needs a client ID, so the object is attached with a PATCH
+	// rather than being part of the initial POST.
+	client := &Client{
+		Name:         auth0.Stringf("Test Client TVPA (%s)", time.Now().Format(time.StampMilli)),
+		Description:  auth0.String("This is a test client with Token Vault privileged access."),
+		AppType:      auth0.String("non_interactive"),
+		IsFirstParty: auth0.Bool(true),
+	}
+
+	require.NoError(t, api.Client.Create(ctx, client))
+	require.NotEmpty(t, client.GetClientID())
+
+	t.Cleanup(func() {
+		cleanupClient(t, client.GetClientID())
+	})
+
+	credential := givenACredential(t, client)
+
+	// Attach the object with all three sub-fields populated. `credentials` is
+	// required whenever the object is being set, so it is echoed on every write.
+	access := &ClientTokenVaultPrivilegedAccess{
+		Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
+		IPAllowlist: &[]string{"10.0.0.1", "192.168.1.0/24"},
+		Grants: &[]ClientTokenVaultPrivilegedGrant{
+			{
+				Connection: auth0.String("Username-Password-Authentication"),
+				Scopes:     &[]string{"openid", "profile"},
+			},
+		},
+	}
+
+	require.NoError(t, api.Client.Update(ctx, client.GetClientID(), &Client{TokenVaultPrivilegedAccess: access}))
+
+	created, err := api.Client.Read(ctx, client.GetClientID())
+	require.NoError(t, err)
+	require.NotNil(t, created.GetTokenVaultPrivilegedAccess())
+	assert.ElementsMatch(t, []string{"10.0.0.1", "192.168.1.0/24"}, created.GetTokenVaultPrivilegedAccess().GetIPAllowlist())
+	require.Len(t, created.GetTokenVaultPrivilegedAccess().GetCredentials(), 1)
+	assert.Equal(t, credential.GetID(), created.GetTokenVaultPrivilegedAccess().GetCredentials()[0].GetID())
+	require.Len(t, created.GetTokenVaultPrivilegedAccess().GetGrants(), 1)
+	assert.Equal(t, "Username-Password-Authentication", created.GetTokenVaultPrivilegedAccess().GetGrants()[0].GetConnection())
+	assert.ElementsMatch(t, []string{"openid", "profile"}, created.GetTokenVaultPrivilegedAccess().GetGrants()[0].GetScopes())
+
+	// Updating an unrelated field must not clobber the stored object.
+	require.NoError(t, api.Client.Update(ctx, client.GetClientID(), &Client{
+		Description: auth0.String("Description updated without touching Token Vault."),
+	}))
+
+	preserved, err := api.Client.Read(ctx, client.GetClientID())
+	require.NoError(t, err)
+	assert.Equal(t, "Description updated without touching Token Vault.", preserved.GetDescription())
+	assert.Equal(t, created.GetTokenVaultPrivilegedAccess(), preserved.GetTokenVaultPrivilegedAccess())
+
+	// A populated array replaces the stored value; a nil sub-field is omitted and
+	// leaves its stored value alone.
+	require.NoError(t, api.Client.Update(ctx, client.GetClientID(), &Client{
+		TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
+			Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
+			IPAllowlist: &[]string{"10.0.0.2"},
+		},
+	}))
+
+	replaced, err := api.Client.Read(ctx, client.GetClientID())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.2"}, replaced.GetTokenVaultPrivilegedAccess().GetIPAllowlist())
+	assert.Len(t, replaced.GetTokenVaultPrivilegedAccess().GetGrants(), 1)
+
+	// An empty array clears the stored value, which is distinct from removing the
+	// whole object.
+	require.NoError(t, api.Client.Update(ctx, client.GetClientID(), &Client{
+		TokenVaultPrivilegedAccess: &ClientTokenVaultPrivilegedAccess{
+			Credentials: &[]ClientCredentialID{{ID: auth0.String(credential.GetID())}},
+			Grants:      &[]ClientTokenVaultPrivilegedGrant{},
+		},
+	}))
+
+	cleared, err := api.Client.Read(ctx, client.GetClientID())
+	require.NoError(t, err)
+	require.NotNil(t, cleared.GetTokenVaultPrivilegedAccess())
+	assert.Empty(t, cleared.GetTokenVaultPrivilegedAccess().GetGrants())
+	assert.Equal(t, []string{"10.0.0.2"}, cleared.GetTokenVaultPrivilegedAccess().GetIPAllowlist())
+
+	// Removing the object requires a literal null, which `omitempty` prevents the
+	// struct from emitting, so use a custom request.
+	type clientPatchNullTokenVault struct {
+		TokenVaultPrivilegedAccess *ClientTokenVaultPrivilegedAccess `json:"token_vault_privileged_access"` // no omitempty to allow null.
+	}
+
+	patch := &clientPatchNullTokenVault{TokenVaultPrivilegedAccess: nil}
+	require.NoError(t, api.Request(ctx, http.MethodPatch, api.URI("clients", client.GetClientID()), patch))
+
+	removed, err := api.Client.Read(ctx, client.GetClientID())
+	require.NoError(t, err)
+	assert.Nil(t, removed.GetTokenVaultPrivilegedAccess())
+}
+
 func TestClient_CIMDFields(t *testing.T) {
 	configureHTTPTestRecordings(t)
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2472,43 +2472,6 @@ func (c *ClientAuthenticationMethods) String() string {
 	return Stringify(c)
 }
 
-// GetCredentialType returns the CredentialType field if it's non-nil, zero value otherwise.
-func (c *ClientCredentialID) GetCredentialType() string {
-	if c == nil || c.CredentialType == nil {
-		return ""
-	}
-	return *c.CredentialType
-}
-
-// GetID returns the ID field if it's non-nil, zero value otherwise.
-func (c *ClientCredentialID) GetID() string {
-	if c == nil || c.ID == nil {
-		return ""
-	}
-	return *c.ID
-}
-
-// GetName returns the Name field if it's non-nil, zero value otherwise.
-func (c *ClientCredentialID) GetName() string {
-	if c == nil || c.Name == nil {
-		return ""
-	}
-	return *c.Name
-}
-
-// GetPEM returns the PEM field if it's non-nil, zero value otherwise.
-func (c *ClientCredentialID) GetPEM() string {
-	if c == nil || c.PEM == nil {
-		return ""
-	}
-	return *c.PEM
-}
-
-// String returns a string representation of ClientCredentialID.
-func (c *ClientCredentialID) String() string {
-	return Stringify(c)
-}
-
 // GetFlows returns the Flows field if it's non-nil, zero value otherwise.
 func (c *ClientDefaultOrganization) GetFlows() []string {
 	if c == nil || c.Flows == nil {
@@ -2900,7 +2863,7 @@ func (c *ClientTokenExchange) String() string {
 }
 
 // GetCredentials returns the Credentials field if it's non-nil, zero value otherwise.
-func (c *ClientTokenVaultPrivilegedAccess) GetCredentials() []ClientCredentialID {
+func (c *ClientTokenVaultPrivilegedAccess) GetCredentials() []Credential {
 	if c == nil || c.Credentials == nil {
 		return nil
 	}

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2185,6 +2185,14 @@ func (c *Client) GetTokenQuota() *TokenQuota {
 	return c.TokenQuota
 }
 
+// GetTokenVaultPrivilegedAccess returns the TokenVaultPrivilegedAccess field.
+func (c *Client) GetTokenVaultPrivilegedAccess() *ClientTokenVaultPrivilegedAccess {
+	if c == nil {
+		return nil
+	}
+	return c.TokenVaultPrivilegedAccess
+}
+
 // GetWebOrigins returns the WebOrigins field if it's non-nil, zero value otherwise.
 func (c *Client) GetWebOrigins() []string {
 	if c == nil || c.WebOrigins == nil {
@@ -2461,6 +2469,43 @@ func (c *ClientAuthenticationMethods) GetTLSClientAuth() *TLSClientAuth {
 
 // String returns a string representation of ClientAuthenticationMethods.
 func (c *ClientAuthenticationMethods) String() string {
+	return Stringify(c)
+}
+
+// GetCredentialType returns the CredentialType field if it's non-nil, zero value otherwise.
+func (c *ClientCredentialID) GetCredentialType() string {
+	if c == nil || c.CredentialType == nil {
+		return ""
+	}
+	return *c.CredentialType
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (c *ClientCredentialID) GetID() string {
+	if c == nil || c.ID == nil {
+		return ""
+	}
+	return *c.ID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (c *ClientCredentialID) GetName() string {
+	if c == nil || c.Name == nil {
+		return ""
+	}
+	return *c.Name
+}
+
+// GetPEM returns the PEM field if it's non-nil, zero value otherwise.
+func (c *ClientCredentialID) GetPEM() string {
+	if c == nil || c.PEM == nil {
+		return ""
+	}
+	return *c.PEM
+}
+
+// String returns a string representation of ClientCredentialID.
+func (c *ClientCredentialID) String() string {
 	return Stringify(c)
 }
 
@@ -2851,6 +2896,56 @@ func (c *ClientTokenExchange) GetAllowAnyProfileOfType() []string {
 
 // String returns a string representation of ClientTokenExchange.
 func (c *ClientTokenExchange) String() string {
+	return Stringify(c)
+}
+
+// GetCredentials returns the Credentials field if it's non-nil, zero value otherwise.
+func (c *ClientTokenVaultPrivilegedAccess) GetCredentials() []ClientCredentialID {
+	if c == nil || c.Credentials == nil {
+		return nil
+	}
+	return *c.Credentials
+}
+
+// GetGrants returns the Grants field if it's non-nil, zero value otherwise.
+func (c *ClientTokenVaultPrivilegedAccess) GetGrants() []ClientTokenVaultPrivilegedGrant {
+	if c == nil || c.Grants == nil {
+		return nil
+	}
+	return *c.Grants
+}
+
+// GetIPAllowlist returns the IPAllowlist field if it's non-nil, zero value otherwise.
+func (c *ClientTokenVaultPrivilegedAccess) GetIPAllowlist() []string {
+	if c == nil || c.IPAllowlist == nil {
+		return nil
+	}
+	return *c.IPAllowlist
+}
+
+// String returns a string representation of ClientTokenVaultPrivilegedAccess.
+func (c *ClientTokenVaultPrivilegedAccess) String() string {
+	return Stringify(c)
+}
+
+// GetConnection returns the Connection field if it's non-nil, zero value otherwise.
+func (c *ClientTokenVaultPrivilegedGrant) GetConnection() string {
+	if c == nil || c.Connection == nil {
+		return ""
+	}
+	return *c.Connection
+}
+
+// GetScopes returns the Scopes field if it's non-nil, zero value otherwise.
+func (c *ClientTokenVaultPrivilegedGrant) GetScopes() []string {
+	if c == nil || c.Scopes == nil {
+		return nil
+	}
+	return *c.Scopes
+}
+
+// String returns a string representation of ClientTokenVaultPrivilegedGrant.
+func (c *ClientTokenVaultPrivilegedGrant) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2990,54 +2990,6 @@ func TestClientAuthenticationMethods_String(t *testing.T) {
 	}
 }
 
-func TestClientCredentialID_GetCredentialType(tt *testing.T) {
-	var zeroValue string
-	c := &ClientCredentialID{CredentialType: &zeroValue}
-	c.GetCredentialType()
-	c = &ClientCredentialID{}
-	c.GetCredentialType()
-	c = nil
-	c.GetCredentialType()
-}
-
-func TestClientCredentialID_GetID(tt *testing.T) {
-	var zeroValue string
-	c := &ClientCredentialID{ID: &zeroValue}
-	c.GetID()
-	c = &ClientCredentialID{}
-	c.GetID()
-	c = nil
-	c.GetID()
-}
-
-func TestClientCredentialID_GetName(tt *testing.T) {
-	var zeroValue string
-	c := &ClientCredentialID{Name: &zeroValue}
-	c.GetName()
-	c = &ClientCredentialID{}
-	c.GetName()
-	c = nil
-	c.GetName()
-}
-
-func TestClientCredentialID_GetPEM(tt *testing.T) {
-	var zeroValue string
-	c := &ClientCredentialID{PEM: &zeroValue}
-	c.GetPEM()
-	c = &ClientCredentialID{}
-	c.GetPEM()
-	c = nil
-	c.GetPEM()
-}
-
-func TestClientCredentialID_String(t *testing.T) {
-	var rawJSON json.RawMessage
-	v := &ClientCredentialID{}
-	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
-		t.Errorf("failed to produce a valid json")
-	}
-}
-
 func TestClientDefaultOrganization_GetFlows(tt *testing.T) {
 	var zeroValue []string
 	c := &ClientDefaultOrganization{Flows: &zeroValue}
@@ -3536,7 +3488,7 @@ func TestClientTokenExchange_String(t *testing.T) {
 }
 
 func TestClientTokenVaultPrivilegedAccess_GetCredentials(tt *testing.T) {
-	var zeroValue []ClientCredentialID
+	var zeroValue []Credential
 	c := &ClientTokenVaultPrivilegedAccess{Credentials: &zeroValue}
 	c.GetCredentials()
 	c = &ClientTokenVaultPrivilegedAccess{}

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -2725,6 +2725,13 @@ func TestClient_GetTokenQuota(tt *testing.T) {
 	c.GetTokenQuota()
 }
 
+func TestClient_GetTokenVaultPrivilegedAccess(tt *testing.T) {
+	c := &Client{}
+	c.GetTokenVaultPrivilegedAccess()
+	c = nil
+	c.GetTokenVaultPrivilegedAccess()
+}
+
 func TestClient_GetWebOrigins(tt *testing.T) {
 	var zeroValue []string
 	c := &Client{WebOrigins: &zeroValue}
@@ -2978,6 +2985,54 @@ func TestClientAuthenticationMethods_GetTLSClientAuth(tt *testing.T) {
 func TestClientAuthenticationMethods_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ClientAuthenticationMethods{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestClientCredentialID_GetCredentialType(tt *testing.T) {
+	var zeroValue string
+	c := &ClientCredentialID{CredentialType: &zeroValue}
+	c.GetCredentialType()
+	c = &ClientCredentialID{}
+	c.GetCredentialType()
+	c = nil
+	c.GetCredentialType()
+}
+
+func TestClientCredentialID_GetID(tt *testing.T) {
+	var zeroValue string
+	c := &ClientCredentialID{ID: &zeroValue}
+	c.GetID()
+	c = &ClientCredentialID{}
+	c.GetID()
+	c = nil
+	c.GetID()
+}
+
+func TestClientCredentialID_GetName(tt *testing.T) {
+	var zeroValue string
+	c := &ClientCredentialID{Name: &zeroValue}
+	c.GetName()
+	c = &ClientCredentialID{}
+	c.GetName()
+	c = nil
+	c.GetName()
+}
+
+func TestClientCredentialID_GetPEM(tt *testing.T) {
+	var zeroValue string
+	c := &ClientCredentialID{PEM: &zeroValue}
+	c.GetPEM()
+	c = &ClientCredentialID{}
+	c.GetPEM()
+	c = nil
+	c.GetPEM()
+}
+
+func TestClientCredentialID_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ClientCredentialID{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}
@@ -3475,6 +3530,72 @@ func TestClientTokenExchange_GetAllowAnyProfileOfType(tt *testing.T) {
 func TestClientTokenExchange_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ClientTokenExchange{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestClientTokenVaultPrivilegedAccess_GetCredentials(tt *testing.T) {
+	var zeroValue []ClientCredentialID
+	c := &ClientTokenVaultPrivilegedAccess{Credentials: &zeroValue}
+	c.GetCredentials()
+	c = &ClientTokenVaultPrivilegedAccess{}
+	c.GetCredentials()
+	c = nil
+	c.GetCredentials()
+}
+
+func TestClientTokenVaultPrivilegedAccess_GetGrants(tt *testing.T) {
+	var zeroValue []ClientTokenVaultPrivilegedGrant
+	c := &ClientTokenVaultPrivilegedAccess{Grants: &zeroValue}
+	c.GetGrants()
+	c = &ClientTokenVaultPrivilegedAccess{}
+	c.GetGrants()
+	c = nil
+	c.GetGrants()
+}
+
+func TestClientTokenVaultPrivilegedAccess_GetIPAllowlist(tt *testing.T) {
+	var zeroValue []string
+	c := &ClientTokenVaultPrivilegedAccess{IPAllowlist: &zeroValue}
+	c.GetIPAllowlist()
+	c = &ClientTokenVaultPrivilegedAccess{}
+	c.GetIPAllowlist()
+	c = nil
+	c.GetIPAllowlist()
+}
+
+func TestClientTokenVaultPrivilegedAccess_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ClientTokenVaultPrivilegedAccess{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestClientTokenVaultPrivilegedGrant_GetConnection(tt *testing.T) {
+	var zeroValue string
+	c := &ClientTokenVaultPrivilegedGrant{Connection: &zeroValue}
+	c.GetConnection()
+	c = &ClientTokenVaultPrivilegedGrant{}
+	c.GetConnection()
+	c = nil
+	c.GetConnection()
+}
+
+func TestClientTokenVaultPrivilegedGrant_GetScopes(tt *testing.T) {
+	var zeroValue []string
+	c := &ClientTokenVaultPrivilegedGrant{Scopes: &zeroValue}
+	c.GetScopes()
+	c = &ClientTokenVaultPrivilegedGrant{}
+	c.GetScopes()
+	c = nil
+	c.GetScopes()
+}
+
+func TestClientTokenVaultPrivilegedGrant_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ClientTokenVaultPrivilegedGrant{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/test/data/recordings/TestClient_TokenVaultPrivilegedAccess.yaml
+++ b/test/data/recordings/TestClient_TokenVaultPrivilegedAccess.yaml
@@ -1,0 +1,500 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 174
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"This is a test client with Token Vault privileged access.","app_type":"non_interactive","is_first_party":true}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"This is a test client with Token Vault privileged access.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 400ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 900
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"credential_type":"public_key","name":"Test Credential (Jul 30 12:24:20.913)","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo/credentials
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3","name":"Test Credential (Jul 30 12:24:20.913)","credential_type":"public_key","kid":"QTtPEeOT2gWWuID0QDg6nHgh7foYRcWkOyJ9DhNIn_A","alg":"RS256","created_at":"2026-07-30T12:24:21.108Z","updated_at":"2026-07-30T12:24:21.108Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 400ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 224
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"This is a test client with Token Vault privileged access.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 400ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"This is a test client with Token Vault privileged access.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 400ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 67
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"description":"Description updated without touching Token Vault."}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 400ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 400ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 116
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.2"]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.2"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 400ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.2"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 400ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 100
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"grants":[]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.2"],"grants":[]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 400ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.2"],"grants":[]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 400ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 38
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"token_vault_privileged_access":null}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 400ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 400ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo/credentials/cred_2ZbXqVrM7TnKdLpWsGyHu3
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 400ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 400ms

--- a/test/data/recordings/TestClient_TokenVaultPrivilegedAccess.yaml
+++ b/test/data/recordings/TestClient_TokenVaultPrivilegedAccess.yaml
@@ -6,14 +6,14 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 174
+        content_length: 175
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"This is a test client with Token Vault privileged access.","app_type":"non_interactive","is_first_party":true}
+            {"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"This is a test client with Token Vault privileged access.","app_type":"non_interactive","is_first_party":true}
         form: {}
         headers:
             Content-Type:
@@ -30,33 +30,33 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"This is a test client with Token Vault privileged access.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"This is a test client with Token Vault privileged access.","client_id":"RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 400ms
+        duration: 1.055280375s
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 900
+        content_length: 901
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"credential_type":"public_key","name":"Test Credential (Jul 30 12:24:20.913)","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}
+            {"name":"Test Credential (Aug  3 18:32:21.086)","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo/credentials
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3/credentials
         method: POST
       response:
         proto: HTTP/2.0
@@ -64,35 +64,35 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
+        content_length: 260
         uncompressed: false
-        body: '{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3","name":"Test Credential (Jul 30 12:24:20.913)","credential_type":"public_key","kid":"QTtPEeOT2gWWuID0QDg6nHgh7foYRcWkOyJ9DhNIn_A","alg":"RS256","created_at":"2026-07-30T12:24:21.108Z","updated_at":"2026-07-30T12:24:21.108Z"}'
+        body: '{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB","credential_type":"public_key","kid":"QTtPEeOT2gWWuID0QDg6nHgh7foYRcWkOyJ9DhNIn_A","alg":"RS256","name":"Test Credential (Aug  3 18:32:21.086)","created_at":"2026-08-03T13:02:21.341Z","updated_at":"2026-08-03T13:02:21.341Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 400ms
+        duration: 328.075791ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 224
+        content_length: 225
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}
+            {"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -101,14 +101,14 @@ interactions:
         transfer_encoding: []
         trailer: {}
         content_length: -1
-        uncompressed: false
-        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"This is a test client with Token Vault privileged access.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        uncompressed: true
+        body: '{"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"This is a test client with Token Vault privileged access.","client_id":"RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400ms
+        duration: 399.907167ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -123,11 +123,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
         method: GET
       response:
         proto: HTTP/2.0
@@ -136,20 +134,20 @@ interactions:
         transfer_encoding: []
         trailer: {}
         content_length: -1
-        uncompressed: false
-        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"This is a test client with Token Vault privileged access.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        uncompressed: true
+        body: '{"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"This is a test client with Token Vault privileged access.","client_id":"RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400ms
+        duration: 286.913583ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 67
+        content_length: 68
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
@@ -163,7 +161,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -172,14 +170,14 @@ interactions:
         transfer_encoding: []
         trailer: {}
         content_length: -1
-        uncompressed: false
-        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        uncompressed: true
+        body: '{"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"Description updated without touching Token Vault.","client_id":"RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400ms
+        duration: 338.674166ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -194,11 +192,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
         method: GET
       response:
         proto: HTTP/2.0
@@ -207,34 +203,34 @@ interactions:
         transfer_encoding: []
         trailer: {}
         content_length: -1
-        uncompressed: false
-        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        uncompressed: true
+        body: '{"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"Description updated without touching Token Vault.","client_id":"RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.1","192.168.1.0/24"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400ms
+        duration: 291.824625ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 116
+        content_length: 117
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.2"]}}
+            {"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.2"]}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -242,70 +238,71 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
+        content_length: 153
         uncompressed: false
-        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.2"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 400ms
+        status: 400 Bad Request
+        code: 400
+        duration: 291.45975ms
     - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 101
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: |
+            {"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"grants":[]}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
-        method: GET
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
+        content_length: 159
         uncompressed: false
-        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.2"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 400ms
+        status: 400 Bad Request
+        code: 400
+        duration: 313.19775ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 100
+        content_length: 76
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"grants":[]}}
+            {"token_vault_privileged_access":{"ip_allowlist":["10.0.0.2"],"grants":[]}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -313,70 +310,35 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
+        content_length: 234
         uncompressed: false
-        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.2"],"grants":[]}}'
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 400ms
+        status: 400 Bad Request
+        code: 400
+        duration: 282.280166ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: go-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: false
-        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_2ZbXqVrM7TnKdLpWsGyHu3"}],"ip_allowlist":["10.0.0.2"],"grants":[]}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 400ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 38
+        content_length: 208
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"token_vault_privileged_access":null}
+            {"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.2"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -385,15 +347,15 @@ interactions:
         transfer_encoding: []
         trailer: {}
         content_length: -1
-        uncompressed: false
-        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        uncompressed: true
+        body: '{"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"Description updated without touching Token Vault.","client_id":"RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.2"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400ms
-    - id: 11
+        duration: 311.153084ms
+    - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -407,11 +369,9 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
         method: GET
       response:
         proto: HTTP/2.0
@@ -420,14 +380,50 @@ interactions:
         transfer_encoding: []
         trailer: {}
         content_length: -1
-        uncompressed: false
-        body: '{"name":"Test Client TVPA (Jul 30 12:24:19.804)","description":"Description updated without touching Token Vault.","client_id":"hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        uncompressed: true
+        body: '{"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"Description updated without touching Token Vault.","client_id":"RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.2"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid","profile"]}]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400ms
+        duration: 294.063791ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 129
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.2"],"grants":[]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"Description updated without touching Token Vault.","client_id":"RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.2"],"grants":[]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 327.701125ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -442,12 +438,10 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo/credentials/cred_2ZbXqVrM7TnKdLpWsGyHu3
-        method: DELETE
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -455,15 +449,51 @@ interactions:
         transfer_encoding: []
         trailer: {}
         content_length: -1
-        uncompressed: false
-        body: ""
+        uncompressed: true
+        body: '{"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"Description updated without touching Token Vault.","client_id":"RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_vm7vsoYsx69ZPRHMH3KCPB"}],"ip_allowlist":["10.0.0.2"],"grants":[]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 400ms
+        status: 200 OK
+        code: 200
+        duration: 283.037291ms
     - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 39
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"token_vault_privileged_access":null}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"Description updated without touching Token Vault.","client_id":"RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 298.062291ms
+    - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -477,12 +507,10 @@ interactions:
         body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
                 - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/hZ3nQdKvYtRb7WsMxPfL9CgAeJuT2iVo
-        method: DELETE
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -490,6 +518,39 @@ interactions:
         transfer_encoding: []
         trailer: {}
         content_length: -1
+        uncompressed: true
+        body: '{"name":"Test Client TVPA (Aug  3 18:32:20.029)","description":"Description updated without touching Token Vault.","client_id":"RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 305.927958ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3/credentials/cred_vm7vsoYsx69ZPRHMH3KCPB
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
         uncompressed: false
         body: ""
         headers:
@@ -497,4 +558,37 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 400ms
+        duration: 305.588125ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/RX69k1dthuv3BkMWmdVeQgKgCzhLAPh3
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 332.799ms

--- a/test/data/recordings/TestClient_TokenVaultPrivilegedAccessOnCreate.yaml
+++ b/test/data/recordings/TestClient_TokenVaultPrivilegedAccessOnCreate.yaml
@@ -13,13 +13,13 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Test Client TVPA Create (Aug  3 18:32:26.100)","app_type":"non_interactive","is_first_party":true,"token_vault_privileged_access":{"credentials":[{"name":"Test Credential On Create","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}
+            {"name":"Test Client TVPA Create (Aug  3 21:17:39.905)","app_type":"non_interactive","is_first_party":true,"token_vault_privileged_access":{"credentials":[{"name":"Test Credential On Create","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.45.0
+                - Go-Auth0/1.46.0
         url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"name":"Test Client TVPA Create (Aug  3 18:32:26.100)","client_id":"4J2yN3XOXZLj4nhrf4WTVKlrtkTfHYLj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_syrzALSanvH82zyWmiM4RZ","name":"Test Credential On Create","credential_type":"public_key"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}'
+        body: '{"name":"Test Client TVPA Create (Aug  3 21:17:39.905)","client_id":"CyfoLA0MP4c8Qwh2AcAYnpZDKWl4Qwly","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_333zA86EavsoydkdT92SKM","name":"Test Credential On Create","kid":"QTtPEeOT2gWWuID0QDg6nHgh7foYRcWkOyJ9DhNIn_A","credential_type":"public_key","alg":"RS256","created_at":"2026-08-03T15:47:40.581Z","updated_at":"2026-08-03T15:47:40.581Z"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 452.019458ms
+        duration: 854.292334ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -52,8 +52,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/4J2yN3XOXZLj4nhrf4WTVKlrtkTfHYLj
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/CyfoLA0MP4c8Qwh2AcAYnpZDKWl4Qwly
         method: GET
       response:
         proto: HTTP/2.0
@@ -63,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Test Client TVPA Create (Aug  3 18:32:26.100)","client_id":"4J2yN3XOXZLj4nhrf4WTVKlrtkTfHYLj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_syrzALSanvH82zyWmiM4RZ"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}'
+        body: '{"name":"Test Client TVPA Create (Aug  3 21:17:39.905)","client_id":"CyfoLA0MP4c8Qwh2AcAYnpZDKWl4Qwly","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_333zA86EavsoydkdT92SKM"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 289.140584ms
+        duration: 295.032584ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -85,8 +85,41 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.45.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/4J2yN3XOXZLj4nhrf4WTVKlrtkTfHYLj
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/CyfoLA0MP4c8Qwh2AcAYnpZDKWl4Qwly/credentials?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"cred_333zA86EavsoydkdT92SKM","credential_type":"public_key","kid":"QTtPEeOT2gWWuID0QDg6nHgh7foYRcWkOyJ9DhNIn_A","alg":"RS256","name":"Test Credential On Create","created_at":"2026-08-03T15:47:40.581Z","updated_at":"2026-08-03T15:47:40.581Z"}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 281.454208ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/CyfoLA0MP4c8Qwh2AcAYnpZDKWl4Qwly
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -102,4 +135,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 351.251292ms
+        duration: 412.043667ms

--- a/test/data/recordings/TestClient_TokenVaultPrivilegedAccessOnCreate.yaml
+++ b/test/data/recordings/TestClient_TokenVaultPrivilegedAccessOnCreate.yaml
@@ -1,0 +1,105 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1156
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client TVPA Create (Aug  3 18:32:26.100)","app_type":"non_interactive","is_first_party":true,"token_vault_privileged_access":{"credentials":[{"name":"Test Credential On Create","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client TVPA Create (Aug  3 18:32:26.100)","client_id":"4J2yN3XOXZLj4nhrf4WTVKlrtkTfHYLj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_syrzALSanvH82zyWmiM4RZ","name":"Test Credential On Create","credential_type":"public_key"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 452.019458ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/4J2yN3XOXZLj4nhrf4WTVKlrtkTfHYLj
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Test Client TVPA Create (Aug  3 18:32:26.100)","client_id":"4J2yN3XOXZLj4nhrf4WTVKlrtkTfHYLj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_vault_privileged_access":{"credentials":[{"id":"cred_syrzALSanvH82zyWmiM4RZ"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 289.140584ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/4J2yN3XOXZLj4nhrf4WTVKlrtkTfHYLj
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 351.251292ms

--- a/test/data/recordings/TestClient_TokenVaultPrivilegedAccessValidation.yaml
+++ b/test/data/recordings/TestClient_TokenVaultPrivilegedAccessValidation.yaml
@@ -1,0 +1,291 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1234
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client TVPA Invalid (Aug  3 21:17:41.754)","app_type":"non_interactive","is_first_party":true,"token_vault_privileged_access":{"credentials":[{"credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}],"ip_allowlist":["10.0.0.1","10.0.0.2","10.0.0.3","10.0.0.4","10.0.0.5","10.0.0.6","10.0.0.7","10.0.0.8","10.0.0.9","10.0.0.10","10.0.0.11"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 198
+        uncompressed: false
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 300.53825ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1123
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client TVPA Invalid (Aug  3 21:17:42.055)","app_type":"non_interactive","is_first_party":true,"token_vault_privileged_access":{"credentials":[{"credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}],"ip_allowlist":["not-an-ip"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 211
+        uncompressed: false
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 295.958875ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2890
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client TVPA Invalid (Aug  3 21:17:42.351)","app_type":"non_interactive","is_first_party":true,"token_vault_privileged_access":{"credentials":[{"kid":"keyidkeyid1","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"},{"kid":"keyidkeyid2","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"},{"kid":"keyidkeyid3","credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 195
+        uncompressed: false
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 302.380458ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1292
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client TVPA Invalid (Aug  3 21:17:42.654)","app_type":"non_interactive","is_first_party":true,"token_vault_privileged_access":{"credentials":[{"credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"c1","scopes":["openid"]},{"connection":"c2","scopes":["openid"]},{"connection":"c3","scopes":["openid"]},{"connection":"c4","scopes":["openid"]},{"connection":"c5","scopes":["openid"]},{"connection":"c6","scopes":["openid"]}]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 190
+        uncompressed: false
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 463.54075ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1230
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client TVPA Invalid (Aug  3 21:17:43.118)","app_type":"non_interactive","is_first_party":true,"token_vault_privileged_access":{"credentials":[{"credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"Username-Password-Authentication","scopes":["s1","s2","s3","s4","s5","s6","s7","s8","s9","s10","s11","s12","s13","s14","s15","s16","s17","s18","s19","s20","s21"]}]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 171
+        uncompressed: false
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 288.480916ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1135
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client TVPA Invalid (Aug  3 21:17:43.407)","app_type":"non_interactive","is_first_party":true,"token_vault_privileged_access":{"credentials":[{"credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}],"ip_allowlist":["10.0.0.1"],"grants":[{"connection":"dup","scopes":["openid"]},{"connection":"dup","scopes":["profile"]}]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 156
+        uncompressed: false
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 314.832833ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1112
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client TVPA Invalid (Aug  3 21:17:43.722)","app_type":"non_interactive","is_first_party":true,"token_vault_privileged_access":{"credentials":[{"credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}],"ip_allowlist":[],"grants":[{"connection":"Username-Password-Authentication","scopes":["openid"]}]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 157
+        uncompressed: false
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 296.186667ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1053
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client TVPA Invalid (Aug  3 21:17:44.019)","app_type":"non_interactive","is_first_party":true,"token_vault_privileged_access":{"credentials":[{"credential_type":"public_key","pem":"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3njxXJoHnuN4hByBhSUo\n0kIbXkJTA0wP0fig87MyVz5KgohPrPJgbRSZ7yz/MmXa4qRNHkWiClJybMS2a98M\n6ELOFG8pfDb6J7JaJqx0Kvqn6xsGInbpwsth3K582Cxrp+Y+GBNja++8wDY5IqAi\nTSKSZRNies0GO0grzQ7kj2p0+R7a0c86mdLO4JnGrHoBqEY1HcsfnJvkJkqETlGi\nyMzDQw8Wkux7P59N/3wuroAI83+HMYl1fV39ek3L/GrsLjECrNe5/CVFtblNltyb\n/va9+pAP7Ye5p6tTW2oj3fzUvdX3dYzENWEtRB7DBHXnfEHMjTaBiQeWb2yDHBCw\n++Uh1OCKw9ZLYzoE6gcDQspYf+fFU3F0kuU4c//gSoNuj/iEjaNmOEK6S3xGy8fE\nTjsC+0oF6YaokDZO9+NreL/sGxFfOAysybrKWrMoaYwa81RlpcmBGZM7H1M00zLH\nPPfCYVhGhFs5X3Qzzt6MQE+msgMt9zeGH7liJbOSW2NGSJwbmn7q35YYIfJEoXRF\n1iefT/9fJB9vhQhtYfCOe3AEpTQq6Yz5ViLhToBdsVDBbz2gmRLALs9/D91SE9T4\nXzvXjHGyxWVu0jdvS9hyhJzP4165k1cYDgx8mmg0VxR7j79LmCUDsFcvvSrAOf6y\n0zY7r4pmNyQQ0r4in/gs/wkCAwEAAQ==\n-----END PUBLIC KEY-----"}],"ip_allowlist":["10.0.0.1"],"grants":[]}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 151
+        uncompressed: false
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 312.460834ms


### PR DESCRIPTION

# feat(client): add Token Vault privileged access support

### 🔧 Changes

Adds support for configuring a client as a **Token Vault privileged worker**, which allows it to request Token Vault tokens on behalf of other users. This is an Early Access feature and must be enabled for the tenant.

**Types added**

- `ClientTokenVaultPrivilegedAccess` — the configuration object itself, with three fields:
  - `Credentials *[]ClientCredentialID` — credentials attached to the worker (max 2). Required whenever the object is being set, on both `POST /clients` and `PATCH /clients/{id}`. Sending an empty array detaches every credential and disables the worker.
  - `IPAllowlist *[]string` — permitted IPv4/IPv6 addresses or CIDR ranges the worker may request tokens from (max 10).
  - `Grants *[]ClientTokenVaultPrivilegedGrant` — pins the connections, and the scopes within them, the worker may request tokens for (max 5 grants, max 20 scopes in total).
- `ClientCredentialID` — references a client credential. On `PATCH /clients/{id}` only `ID` is accepted, referencing a credential created beforehand via `ClientManager.CreateCredential`; on `POST /clients` the credential material is supplied instead through `CredentialType` and `PEM`.
- `ClientTokenVaultPrivilegedGrant` — a `Connection` name plus the `Scopes` allowed on it.

**Fields added**

- `Client.TokenVaultPrivilegedAccess *ClientTokenVaultPrivilegedAccess` (`token_vault_privileged_access`).

**Why the sub-fields are pointers to slices**

Each sub-field is a `*[]T` so all three write semantics of the Management API can be expressed distinctly:

| Value | Sent as | Effect |
| --- | --- | --- |
| `nil` | key omitted | stored value left unchanged |
| `&[]T{}` | `[]` | stored value cleared |
| `&[]T{...}` | `[...]` | stored value replaced |

Removing the whole object is a fourth case that requires a literal `null` for `token_vault_privileged_access`, which `omitempty` on a nil `Client` field cannot emit. That case is documented on the field and needs a custom `PATCH` request:

```go
type clientPatch struct {
	TokenVaultPrivilegedAccess *ClientTokenVaultPrivilegedAccess `json:"token_vault_privileged_access"` // no omitempty
}

err := api.Request(ctx, http.MethodPatch, api.URI("clients", clientID), &clientPatch{})
```

**`CleanForPatch` behaviour**

`Client.CleanForPatch` now reduces a read-back credential list to bare IDs, since `PATCH /clients/{id}` only accepts credential references. Entries without an ID are deliberately left untouched rather than dropped — dropping them would silently detach the worker's credentials, whereas passing them through surfaces the API error. Credential material supplied for a create (`CredentialType`/`PEM`) is therefore preserved as-is, and an empty credentials list stays empty.

**Usage**

```go
credential, err := api.Client.CreateCredential(ctx, clientID, &Credential{
	Name:           auth0.String("Worker Key"),
	CredentialType: auth0.String("public_key"),
	PEM:            auth0.String(publicKeyPEM),
})

err = api.Client.Update(ctx, clientID, &management.Client{
	TokenVaultPrivilegedAccess: &management.ClientTokenVaultPrivilegedAccess{
		Credentials: &[]management.ClientCredentialID{{ID: credential.ID}},
		IPAllowlist: &[]string{"10.0.0.1", "192.168.1.0/24"},
		Grants: &[]management.ClientTokenVaultPrivilegedGrant{
			{
				Connection: auth0.String("google-oauth2"),
				Scopes:     &[]string{"https://www.googleapis.com/auth/calendar.readonly"},
			},
		},
	},
})
```

**Generated code**

Regenerated getters and generated tests in `management.gen.go` / `management.gen_test.go` for the new types and field.

### 📚 References

Auth0 Management API: `token_vault_privileged_access` on `POST /api/v2/clients` and `PATCH /api/v2/clients/{id}` (Early Access).

### 🔬 Testing

- `TestClientTokenVaultPrivilegedAccess_MarshalJSON` — unit tests over the (un)marshalling contract: nil sub-fields omitted, empty arrays emitted, populated arrays emitted, the create-time credential material shape, and unmarshalling a stored object.
- `TestClientTokenVaultPrivilegedAccess_CleanForPatch` — unit tests that read-back credentials are reduced to IDs, credential material is preserved, and an empty credentials list survives.
- `TestClient_TokenVaultPrivilegedAccess` — HTTP-recorded end-to-end test (`test/data/recordings/TestClient_TokenVaultPrivilegedAccess.yaml`) that creates a non-interactive client, creates a credential, attaches the object via `PATCH`, then asserts each write semantic in turn: an unrelated field update does not clobber the stored object, a populated array replaces while a nil sub-field is omitted, an empty array clears, and a custom `PATCH` with a literal `null` removes the object entirely.

Run against a tenant with the feature enabled:

```bash
make test-integration FILTER="TestClient_TokenVaultPrivilegedAccess"
```

Reviewers can replay the recordings without a tenant:

```bash
go test ./management/... -run 'TestClient.*TokenVaultPrivilegedAccess'
```

Not covered: server-side validation of the documented limits (2 credentials, 10 allowlist entries, 5 grants / 20 scopes) and the non-empty / no-duplicate scope rules — these are enforced by the API, not the SDK. The `POST /clients` path that inlines credential material is exercised only at the marshalling level, since the integration test must create credentials after the client exists in order to reference them.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
