### PR TITLE
fix: apply default query params when a paginated List receives a nil request

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -6,6 +6,10 @@ management/client/management_test.go
 management/core/request_option.go
 management/core/request_option_test.go
 management/option/request_option.go
+# preserve manual enablement of the applyQueryDefaultsOnNilRequest generator option (older generator does not emit these)
+management/internal/query.go
+management/internal/query_test.go
+management/internal/query_defaults_on_nil.go
 # preserve manual fix to broken test (caused by optional request body being an alias of an optional type)
 auth0.go
 auth0_test.go

--- a/management/internal/query.go
+++ b/management/internal/query.go
@@ -67,6 +67,11 @@ func QueryValues(v interface{}) (url.Values, error) {
 	return values, err
 }
 
+// applyQueryDefaultsOnNilRequest reports whether query parameter defaults are applied when the
+// request is nil. It is enabled by the applyQueryDefaultsOnNilRequest generator option, which
+// emits an init function that sets it to true.
+var applyQueryDefaultsOnNilRequest = false
+
 // QueryValuesWithDefaults encodes url.Values from request objects
 // and default values, merging the defaults into the request.
 // It's expected that the values of defaults are wire names.
@@ -76,6 +81,12 @@ func QueryValuesWithDefaults(v interface{}, defaults map[string]interface{}) (ur
 		return values, err
 	}
 	if !val.IsValid() {
+		if applyQueryDefaultsOnNilRequest {
+			// A nil request carries no explicit values, so every default applies.
+			for wireName, defaultVal := range defaults {
+				values.Set(wireName, valueString(reflect.ValueOf(defaultVal), tagOptions{}, reflect.StructField{}))
+			}
+		}
 		return values, nil
 	}
 

--- a/management/internal/query_defaults_on_nil.go
+++ b/management/internal/query_defaults_on_nil.go
@@ -1,0 +1,5 @@
+package internal
+
+func init() {
+	applyQueryDefaultsOnNilRequest = true
+}

--- a/management/internal/query_test.go
+++ b/management/internal/query_test.go
@@ -373,6 +373,8 @@ func TestQueryValuesWithDefaults(t *testing.T) {
 	})
 
 	t.Run("nil input returns empty values", func(t *testing.T) {
+		defer setApplyQueryDefaultsOnNilRequest(false)()
+
 		defaults := map[string]any{
 			"name": "default-name",
 			"age":  25,
@@ -392,4 +394,72 @@ func TestQueryValuesWithDefaults(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, values)
 	})
+
+	t.Run("nil input applies defaults when enabled", func(t *testing.T) {
+		defer setApplyQueryDefaultsOnNilRequest(true)()
+
+		defaults := map[string]any{
+			"name": "default-name",
+			"age":  25,
+		}
+
+		// Test with nil
+		values, err := QueryValuesWithDefaults(nil, defaults)
+		require.NoError(t, err)
+		assert.Equal(t, "age=25&name=default-name", values.Encode())
+
+		// Test with nil pointer
+		type example struct {
+			Name string `json:"name" url:"name"`
+		}
+		var nilPtr *example
+		values, err = QueryValuesWithDefaults(nilPtr, defaults)
+		require.NoError(t, err)
+		assert.Equal(t, "age=25&name=default-name", values.Encode())
+	})
+
+	t.Run("nil input without defaults returns empty values when enabled", func(t *testing.T) {
+		defer setApplyQueryDefaultsOnNilRequest(true)()
+
+		type example struct {
+			Name string `json:"name" url:"name"`
+		}
+		var nilPtr *example
+
+		values, err := QueryValuesWithDefaults(nilPtr, nil)
+		require.NoError(t, err)
+		assert.Empty(t, values)
+	})
+
+	t.Run("nil input matches zero-value struct when enabled", func(t *testing.T) {
+		defer setApplyQueryDefaultsOnNilRequest(true)()
+
+		type example struct {
+			IncludeTotals *bool `json:"include_totals,omitempty" url:"include_totals,omitempty"`
+		}
+		defaults := map[string]any{
+			"include_totals": true,
+		}
+
+		var nilPtr *example
+		nilValues, err := QueryValuesWithDefaults(nilPtr, defaults)
+		require.NoError(t, err)
+
+		zeroValues, err := QueryValuesWithDefaults(&example{}, defaults)
+		require.NoError(t, err)
+
+		assert.Equal(t, "include_totals=true", nilValues.Encode())
+		assert.Equal(t, zeroValues.Encode(), nilValues.Encode())
+	})
+}
+
+// setApplyQueryDefaultsOnNilRequest sets the flag emitted by the
+// applyQueryDefaultsOnNilRequest generator option, and returns a
+// function that restores its previous value.
+func setApplyQueryDefaultsOnNilRequest(value bool) func() {
+	previous := applyQueryDefaultsOnNilRequest
+	applyQueryDefaultsOnNilRequest = value
+	return func() {
+		applyQueryDefaultsOnNilRequest = previous
+	}
 }


### PR DESCRIPTION
### 🔧 Changes

Addresses [#826](https://github.com/auth0/go-auth0/issues/826), where calling a paginated `List` method with a `nil` request pointer failed to decode with:

```
json: cannot unmarshal array into Go value of type management.unmarshaler
```

When the request is `nil`, `internal.QueryValuesWithDefaults` returned early before applying its defaults, so `include_totals` was never sent. The Auth0 API defaults `include_totals` to `false` and returns a bare JSON array instead of the totals-wrapped object, and the generated paginated response type can only decode the object shape, so unmarshaling failed. This affected every paginated `List` that relies on default query parameters (the 27 endpoints that default `include_totals: true`, plus `page`/`per_page` defaults on the others).

Now a `nil` request applies the client's default query parameters (notably `include_totals=true`), so the object-shaped response is returned and decodes successfully, matching the behavior of passing an empty request struct.

This mirrors the upstream Fern `applyQueryDefaultsOnNilRequest` generator option (fern-api/fern#17256):

- `management/internal/query.go`: adds the `applyQueryDefaultsOnNilRequest` flag and applies defaults on a nil request when it is enabled.
- `management/internal/query_defaults_on_nil.go`: enables the flag via an `init` function. Newer generator versions emit this file automatically; it is added manually here because this SDK is built with an older generator.
- `management/internal/query_test.go`: adds coverage for the nil-request behavior with the flag enabled and disabled.
- `.fernignore`: preserves the above files across regeneration.

### 📚 References

- https://github.com/auth0/go-auth0/issues/826
- fern-api/fern#17256

### 🔬 Testing

Covered by the added cases in `management/internal/query_test.go`. `go build ./...`, `go vet ./management/...`, and `go test ./management/internal/...` all pass.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
