### PR TITLE
feat: Add support for managing Org level roles

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -12337,6 +12337,22 @@ func (r *Role) GetName() string {
 	return *r.Name
 }
 
+// GetOwnerID returns the OwnerID field if it's non-nil, zero value otherwise.
+func (r *Role) GetOwnerID() string {
+	if r == nil || r.OwnerID == nil {
+		return ""
+	}
+	return *r.OwnerID
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (r *Role) GetType() string {
+	if r == nil || r.Type == nil {
+		return ""
+	}
+	return *r.Type
+}
+
 // String returns a string representation of Role.
 func (r *Role) String() string {
 	return Stringify(r)

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -15462,6 +15462,26 @@ func TestRole_GetName(tt *testing.T) {
 	r.GetName()
 }
 
+func TestRole_GetOwnerID(tt *testing.T) {
+	var zeroValue string
+	r := &Role{OwnerID: &zeroValue}
+	r.GetOwnerID()
+	r = &Role{}
+	r.GetOwnerID()
+	r = nil
+	r.GetOwnerID()
+}
+
+func TestRole_GetType(tt *testing.T) {
+	var zeroValue string
+	r := &Role{Type: &zeroValue}
+	r.GetType()
+	r = &Role{}
+	r.GetType()
+	r = nil
+	r.GetType()
+}
+
 func TestRole_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &Role{}

--- a/management/role.go
+++ b/management/role.go
@@ -12,6 +12,15 @@ type Role struct {
 
 	// A description of the role created.
 	Description *string `json:"description,omitempty"`
+
+	// The type of the role. Can be either "tenant" for tenant-level roles,
+	// which is the default, or "organization" for organization-level roles.
+	Type *string `json:"type,omitempty"`
+
+	// References the owning entity of the role. This is only non-null when the
+	// role was created as an organization-level role, in which case it holds a
+	// valid organization ID.
+	OwnerID *string `json:"owner_id,omitempty"`
 }
 
 // RoleList holds a list of Roles.

--- a/management/role.go
+++ b/management/role.go
@@ -23,6 +23,20 @@ type Role struct {
 	OwnerID *string `json:"owner_id,omitempty"`
 }
 
+// cleanForPatch keeps only the fields PATCH /roles/{id} accepts. The endpoint
+// rejects everything else with a 400 "Additional properties not allowed",
+// including ID and including Type and OwnerID when their values are unchanged,
+// so a Read followed by an Update would otherwise always fail.
+//
+// The struct is reset in place so the response can still be decoded back into
+// it, which is what repopulates the read-only fields for the caller.
+func (r *Role) cleanForPatch() {
+	*r = Role{
+		Name:        r.Name,
+		Description: r.Description,
+	}
+}
+
 // RoleList holds a list of Roles.
 type RoleList struct {
 	List
@@ -70,8 +84,16 @@ func (m *RoleManager) Read(ctx context.Context, id string, opts ...RequestOption
 
 // Update a role.
 //
+// Only Name and Description can be updated. Type and OwnerID are set when the
+// role is created and are stripped from the request, as the endpoint rejects
+// them outright.
+//
 // See: https://auth0.com/docs/api/management/v2#!/Roles/patch_roles_by_id
 func (m *RoleManager) Update(ctx context.Context, id string, r *Role, opts ...RequestOption) (err error) {
+	if r != nil {
+		r.cleanForPatch()
+	}
+
 	return m.management.Request(ctx, "PATCH", m.management.URI("roles", id), r, opts...)
 }
 

--- a/management/role_test.go
+++ b/management/role_test.go
@@ -57,6 +57,42 @@ func TestRoleManager_Update(t *testing.T) {
 	assert.Equal(t, expectedRole.GetName(), updatedRole.GetName())
 }
 
+func TestRoleManager_UpdateStripsReadOnlyFields(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	ctx := context.Background()
+
+	org := givenAnOrganization(t)
+
+	role := &Role{
+		Name:        auth0.String(fmt.Sprintf("test-org-role%d", rand.Intn(999))),
+		Description: auth0.String("Test Organization Role"),
+		Type:        auth0.String("organization"),
+		OwnerID:     org.ID,
+	}
+	require.NoError(t, api.Role.Create(ctx, role))
+
+	t.Cleanup(func() {
+		cleanupRole(t, role.GetID())
+	})
+
+	// PATCH /roles/{id} accepts only name and description, so handing it a role
+	// read straight back from the API has to work: ID, Type and OwnerID are
+	// stripped before the request is sent.
+	readRole, err := api.Role.Read(ctx, role.GetID())
+	require.NoError(t, err)
+
+	readRole.Description = auth0.String("The Organization Administrator")
+	require.NoError(t, api.Role.Update(ctx, role.GetID(), readRole))
+
+	assert.Equal(t, "The Organization Administrator", readRole.GetDescription())
+
+	// The response repopulates the read-only fields that were stripped.
+	assert.Equal(t, role.GetID(), readRole.GetID())
+	assert.Equal(t, "organization", readRole.GetType())
+	assert.Equal(t, org.GetID(), readRole.GetOwnerID())
+}
+
 func TestRoleManager_Delete(t *testing.T) {
 	configureHTTPTestRecordings(t)
 
@@ -181,7 +217,7 @@ func TestRoleManager_OrganizationLevelRole(t *testing.T) {
 	assert.Equal(t, org.GetID(), role.GetOwnerID())
 
 	// Both fields are echoed on read and on update, even though neither can be
-	// changed after creation.
+	// sent to the update endpoint. See TestRoleManager_UpdateStripsReadOnlyFields.
 	readRole, err := api.Role.Read(ctx, role.GetID())
 	assert.NoError(t, err)
 	assert.Equal(t, "organization", readRole.GetType())

--- a/management/role_test.go
+++ b/management/role_test.go
@@ -154,6 +154,63 @@ func TestRoleManager_Permissions(t *testing.T) {
 	assert.Len(t, permissionList.Permissions, 0)
 }
 
+func TestRoleManager_OrganizationLevelRole(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	ctx := context.Background()
+
+	org := givenAnOrganization(t)
+
+	// An organization-level role is created by pointing OwnerID at the owning
+	// organization. Type is what distinguishes it from a tenant-level role, which
+	// is what the API defaults to when both fields are omitted.
+	role := &Role{
+		Name:        auth0.String(fmt.Sprintf("test-org-role%d", rand.Intn(999))),
+		Description: auth0.String("Test Organization Role"),
+		Type:        auth0.String("organization"),
+		OwnerID:     org.ID,
+	}
+
+	require.NoError(t, api.Role.Create(ctx, role))
+
+	t.Cleanup(func() {
+		cleanupRole(t, role.GetID())
+	})
+
+	assert.Equal(t, "organization", role.GetType())
+	assert.Equal(t, org.GetID(), role.GetOwnerID())
+
+	// Both fields are echoed on read and on update, even though neither can be
+	// changed after creation.
+	readRole, err := api.Role.Read(ctx, role.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, "organization", readRole.GetType())
+	assert.Equal(t, org.GetID(), readRole.GetOwnerID())
+
+	updatedRole := &Role{
+		Description: auth0.String("The Organization Administrator"),
+	}
+	err = api.Role.Update(ctx, role.GetID(), updatedRole)
+	assert.NoError(t, err)
+	assert.Equal(t, "The Organization Administrator", updatedRole.GetDescription())
+	assert.Equal(t, "organization", updatedRole.GetType())
+	assert.Equal(t, org.GetID(), updatedRole.GetOwnerID())
+
+	// The list endpoint can be filtered down to the roles owned by a single
+	// organization.
+	roleList, err := api.Role.List(ctx, Parameter("type", "organization"), Parameter("owner_id", org.GetID()))
+	assert.NoError(t, err)
+	assert.Len(t, roleList.Roles, 1)
+	assert.Equal(t, role.GetID(), roleList.Roles[0].GetID())
+	assert.Equal(t, "organization", roleList.Roles[0].GetType())
+	assert.Equal(t, org.GetID(), roleList.Roles[0].GetOwnerID())
+
+	// A role created without either field is a tenant-level role with no owner.
+	tenantRole := givenARole(t)
+	assert.Equal(t, "tenant", tenantRole.GetType())
+	assert.Empty(t, tenantRole.GetOwnerID())
+}
+
 func givenARole(t *testing.T) *Role {
 	t.Helper()
 

--- a/test/data/recordings/TestRoleManager_OrganizationLevelRole.yaml
+++ b/test/data/recordings/TestRoleManager_OrganizationLevelRole.yaml
@@ -1,0 +1,318 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 122
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"test-organization651","display_name":"Test Organization","branding":{"logo_url":"https://example.com/logo.gif"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/organizations
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 219
+        uncompressed: false
+        body: '{"id":"org_WfFAWGaizGXAbYTv","display_name":"Test Organization","name":"test-organization651","branding":{"logo_url":"https://example.com/logo.gif"},"third_party_client_access":"block","is_app_entitlement_active":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 941.977042ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 123
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"test-org-role885","description":"Test Organization Role","type":"organization","owner_id":"org_WfFAWGaizGXAbYTv"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"rol_K4K9YIu435Msh9Rg","name":"test-org-role885","description":"Test Organization Role","type":"organization","owner_id":"org_WfFAWGaizGXAbYTv"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 317.940875ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles/rol_K4K9YIu435Msh9Rg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"rol_K4K9YIu435Msh9Rg","name":"test-org-role885","description":"Test Organization Role","type":"organization","owner_id":"org_WfFAWGaizGXAbYTv"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 328.977292ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 49
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"description":"The Organization Administrator"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles/rol_K4K9YIu435Msh9Rg
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"rol_K4K9YIu435Msh9Rg","name":"test-org-role885","description":"The Organization Administrator","type":"organization","owner_id":"org_WfFAWGaizGXAbYTv"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 284.440791ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles?include_totals=true&owner_id=org_WfFAWGaizGXAbYTv&per_page=50&type=organization
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"roles":[{"id":"rol_K4K9YIu435Msh9Rg","name":"test-org-role885","description":"The Organization Administrator","type":"organization","owner_id":"org_WfFAWGaizGXAbYTv"}],"start":0,"limit":50,"total":1}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 316.929334ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 50
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"test-role768","description":"Test Role"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"rol_qRSVWjAeO72rd7j9","name":"test-role768","description":"Test Role","type":"tenant"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 283.687458ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 3
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles/rol_qRSVWjAeO72rd7j9
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '{}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 305.790875ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 3
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles/rol_K4K9YIu435Msh9Rg
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '{}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 323.743375ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/organizations/org_WfFAWGaizGXAbYTv
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 404.714292ms

--- a/test/data/recordings/TestRoleManager_UpdateStripsReadOnlyFields.yaml
+++ b/test/data/recordings/TestRoleManager_UpdateStripsReadOnlyFields.yaml
@@ -13,7 +13,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"test-organization609","display_name":"Test Organization","branding":{"logo_url":"https://example.com/logo.gif"}}
+            {"name":"test-organization520","display_name":"Test Organization","branding":{"logo_url":"https://example.com/logo.gif"}}
         form: {}
         headers:
             Content-Type:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: 219
         uncompressed: false
-        body: '{"id":"org_qffM9T64INcqaeuQ","display_name":"Test Organization","name":"test-organization609","branding":{"logo_url":"https://example.com/logo.gif"},"third_party_client_access":"block","is_app_entitlement_active":false}'
+        body: '{"id":"org_FDGR33kfSquyzUdW","display_name":"Test Organization","name":"test-organization520","branding":{"logo_url":"https://example.com/logo.gif"},"third_party_client_access":"block","is_app_entitlement_active":false}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 1.057219042s
+        duration: 897.036209ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -49,7 +49,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"test-org-role310","description":"Test Organization Role","type":"organization","owner_id":"org_qffM9T64INcqaeuQ"}
+            {"name":"test-org-role134","description":"Test Organization Role","type":"organization","owner_id":"org_FDGR33kfSquyzUdW"}
         form: {}
         headers:
             Content-Type:
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"rol_dLpIgkpQTWSH9gYj","name":"test-org-role310","description":"Test Organization Role","type":"organization","owner_id":"org_qffM9T64INcqaeuQ"}'
+        body: '{"id":"rol_2G9fDeDtV8iU6jaV","name":"test-org-role134","description":"Test Organization Role","type":"organization","owner_id":"org_FDGR33kfSquyzUdW"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.836166ms
+        duration: 367.6435ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -89,7 +89,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles/rol_dLpIgkpQTWSH9gYj
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles/rol_2G9fDeDtV8iU6jaV
         method: GET
       response:
         proto: HTTP/2.0
@@ -99,33 +99,33 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"rol_dLpIgkpQTWSH9gYj","name":"test-org-role310","description":"Test Organization Role","type":"organization","owner_id":"org_qffM9T64INcqaeuQ"}'
+        body: '{"id":"rol_2G9fDeDtV8iU6jaV","name":"test-org-role134","description":"Test Organization Role","type":"organization","owner_id":"org_FDGR33kfSquyzUdW"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.866166ms
+        duration: 319.74175ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 49
+        content_length: 75
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"description":"The Organization Administrator"}
+            {"name":"test-org-role134","description":"The Organization Administrator"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles/rol_dLpIgkpQTWSH9gYj
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles/rol_2G9fDeDtV8iU6jaV
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -135,159 +135,54 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"rol_dLpIgkpQTWSH9gYj","name":"test-org-role310","description":"The Organization Administrator","type":"organization","owner_id":"org_qffM9T64INcqaeuQ"}'
+        body: '{"id":"rol_2G9fDeDtV8iU6jaV","name":"test-org-role134","description":"The Organization Administrator","type":"organization","owner_id":"org_FDGR33kfSquyzUdW"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 398.502708ms
+        duration: 324.697375ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 3
         transfer_encoding: []
         trailer: {}
         host: go-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: |
+            {}
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles?include_totals=true&owner_id=org_qffM9T64INcqaeuQ&per_page=50&type=organization
-        method: GET
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles/rol_2G9fDeDtV8iU6jaV
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"roles":[{"id":"rol_dLpIgkpQTWSH9gYj","name":"test-org-role310","description":"The Organization Administrator","type":"organization","owner_id":"org_qffM9T64INcqaeuQ"}],"start":0,"limit":50,"total":1}'
+        content_length: 2
+        uncompressed: false
+        body: '{}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 317.766167ms
+        duration: 335.620292ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 50
-        transfer_encoding: []
-        trailer: {}
-        host: go-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"name":"test-role650","description":"Test Role"}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.46.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"rol_c70jcER7EesouWLf","name":"test-role650","description":"Test Role","type":"tenant"}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 320.198334ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 3
-        transfer_encoding: []
-        trailer: {}
-        host: go-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.46.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles/rol_c70jcER7EesouWLf
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2
-        uncompressed: false
-        body: '{}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 404.412333ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 3
-        transfer_encoding: []
-        trailer: {}
-        host: go-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.46.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/roles/rol_dLpIgkpQTWSH9gYj
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2
-        uncompressed: false
-        body: '{}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 314.146ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
         content_length: 0
         transfer_encoding: []
         trailer: {}
@@ -299,7 +194,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://go-auth0-dev.eu.auth0.com/api/v2/organizations/org_qffM9T64INcqaeuQ
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/organizations/org_FDGR33kfSquyzUdW
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -315,4 +210,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 322.478292ms
+        duration: 318.324375ms


### PR DESCRIPTION
Adds organization-level role support to the `/api/v2/roles` endpoints (EA only)

### 🔧 Changes

| Field | JSON | Notes |
| --- | --- | --- |
| `Type *string` | `type,omitempty` | `tenant` (default) or `organization` |
| `OwnerID *string` | `owner_id,omitempty` | Owning organization ID; null for tenant-level roles |

Both fields flow through `Create`, `Read`, `Update`, and `List` with no manager-method changes. The new `type`/`owner_id` list filters work via the existing `Parameter(...)` option, and checkpoint pagination (`from`/`take`/`next`) is already covered by `Take`/`From` and the embedded `List` struct.

The two new organization endpoints in the spec (`.../roles/{role_id}/members` and `.../groups`) are intentionally out of scope here and will land in v2.
### 🔬 Testing

- `TestRoleManager_OrganizationLevelRole` covers all  changed endpoints. Recordings added.


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
