### PR TITLE
fix: preserve Auth0-Client and User-Agent headers when a custom HTTP client is used

### DIFF
--- a/management/client/management.go
+++ b/management/client/management.go
@@ -34,16 +34,32 @@ func New(domain string, options ...option.RequestOption) (*Management, error) {
 		MaxRetries: 3,
 	}
 
-	// Extract NoAuth0ClientInfo and Auth0ClientEnv options in a single loop
+	// Extract NoAuth0ClientInfo, Auth0ClientEnv and any caller supplied HTTP
+	// client in a single loop
 	var noAuth0ClientInfo bool
 	var envOnlyOptions []option.RequestOption
+	var callerHTTPClient core.HTTPClient
+
+	passthroughOptions := make([]option.RequestOption, 0, len(options))
+
 	for _, opt := range options {
-		switch opt.(type) {
+		switch opt := opt.(type) {
 		case *core.NoAuth0ClientInfoOption:
 			noAuth0ClientInfo = true
 		case *core.Auth0ClientEnvEntryOption:
 			envOnlyOptions = append(envOnlyOptions, opt)
+		case *core.HTTPClientOption:
+			// Keep the client so the transports below can be layered onto it,
+			// and drop the option itself. Options are applied in order, so
+			// passing it through would replace the wrapped client built here
+			// and with it the User-Agent, Auth0-Client and custom domain
+			// headers.
+			callerHTTPClient = opt.HTTPClient
+
+			continue
 		}
+
+		passthroughOptions = append(passthroughOptions, opt)
 	}
 
 	// Build the base options that will be passed to NewWithOptions
@@ -52,11 +68,13 @@ func New(domain string, options ...option.RequestOption) (*Management, error) {
 		option.WithMaxAttempts(uint(retryOptions.MaxRetries)),
 	}
 
-	// Clone DefaultClient to avoid modifying the global client
-	httpClient := *http.DefaultClient
+	// Start from the caller's client when one was given, so its timeout, proxy
+	// and transport settings are kept, and fall back to a clone of
+	// DefaultClient otherwise
+	httpClient := baseHTTPClient(callerHTTPClient)
 
 	// Apply transports in order: UserAgent, Auth0-Client (if needed), then CustomDomain
-	httpClient.Transport = internal.UserAgentTransport(http.DefaultClient.Transport, internal.UserAgent)
+	httpClient.Transport = internal.UserAgentTransport(httpClient.Transport, internal.UserAgent)
 
 	// Only add Auth0-Client header transport if NoAuth0ClientInfo is not set
 	if !noAuth0ClientInfo {
@@ -91,9 +109,35 @@ func New(domain string, options ...option.RequestOption) (*Management, error) {
 	// Apply CustomDomainHeaderTransport last (pass empty string for client-level domain; request-level will use the hint header)
 	httpClient.Transport = internal.CustomDomainHeaderTransport(httpClient.Transport, "")
 
-	baseOptions = append(baseOptions, option.WithHTTPClient(&httpClient))
+	baseOptions = append(baseOptions, option.WithHTTPClient(httpClient))
 
-	m := NewWithOptions(append(baseOptions, options...)...)
+	m := NewWithOptions(append(baseOptions, passthroughOptions...)...)
 
 	return m, nil
+}
+
+// baseHTTPClient returns the client that the SDK transports are layered onto.
+//
+// Callers can supply any core.HTTPClient, so a client that is not an
+// *http.Client is delegated to through a round tripper, which keeps the SDK
+// headers on the requests it issues. Clients are cloned rather than used
+// directly, so that wrapping their transport does not modify the caller's copy.
+func baseHTTPClient(callerHTTPClient core.HTTPClient) *http.Client {
+	switch client := callerHTTPClient.(type) {
+	case nil:
+	case *http.Client:
+		if client != nil {
+			clone := *client
+
+			return &clone
+		}
+	default:
+		return &http.Client{
+			Transport: internal.RoundTripFunc(client.Do),
+		}
+	}
+
+	clone := *http.DefaultClient
+
+	return &clone
 }

--- a/management/client/management_test.go
+++ b/management/client/management_test.go
@@ -1,10 +1,20 @@
 package client
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	internal "github.com/auth0/go-auth0/v3/internal/client"
+	"github.com/auth0/go-auth0/v3/management/option"
 )
 
 func TestNewBaseURL(t *testing.T) {
@@ -25,4 +35,167 @@ func TestNewBaseURL(t *testing.T) {
 			assert.Equal(t, tt.expectedURL, m.baseURL)
 		})
 	}
+}
+
+// doerHTTPClient is a core.HTTPClient that is not an *http.Client.
+type doerHTTPClient struct {
+	called bool
+}
+
+func (d *doerHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	d.called = true
+
+	return http.DefaultClient.Do(req)
+}
+
+// markerTransport identifies the transport a client was created with.
+type markerTransport struct{}
+
+func (m *markerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// headerRecorder serves requests and keeps the headers of the last one.
+type headerRecorder struct {
+	server *httptest.Server
+	header http.Header
+}
+
+func newHeaderRecorder(t *testing.T) *headerRecorder {
+	t.Helper()
+
+	recorder := &headerRecorder{}
+	recorder.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorder.header = r.Header.Clone()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"clients":[]}`))
+	}))
+
+	t.Cleanup(recorder.server.Close)
+
+	return recorder
+}
+
+// domain returns the host of the test server, which New expects without a scheme.
+func (h *headerRecorder) domain() string {
+	return strings.TrimPrefix(h.server.URL, "http://")
+}
+
+// auth0Client decodes the "Auth0-Client" header of the recorded request.
+func (h *headerRecorder) auth0Client(t *testing.T) *internal.Auth0ClientInfo {
+	t.Helper()
+
+	encoded := h.header.Get("Auth0-Client")
+	require.NotEmpty(t, encoded, `expected an "Auth0-Client" header`)
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+
+	var clientInfo internal.Auth0ClientInfo
+	require.NoError(t, json.Unmarshal(decoded, &clientInfo))
+
+	return &clientInfo
+}
+
+// listClients issues a request so that the headers set by the transports can be asserted.
+func listClients(t *testing.T, recorder *headerRecorder, options ...option.RequestOption) {
+	t.Helper()
+
+	m, err := New(
+		recorder.domain(),
+		append([]option.RequestOption{option.WithInsecure(), option.WithToken("token")}, options...)...,
+	)
+	require.NoError(t, err)
+
+	_, err = m.Clients.List(t.Context(), nil)
+	require.NoError(t, err)
+}
+
+func TestNewSendsClientInfo(t *testing.T) {
+	recorder := newHeaderRecorder(t)
+
+	listClients(t, recorder)
+
+	assert.Equal(t, internal.UserAgent, recorder.header.Get("User-Agent"))
+	assert.Equal(t, internal.DefaultAuth0ClientInfo.Name, recorder.auth0Client(t).Name)
+}
+
+func TestNewSendsClientInfoWithCustomHTTPClient(t *testing.T) {
+	recorder := newHeaderRecorder(t)
+
+	listClients(t, recorder, option.WithHTTPClient(&http.Client{}))
+
+	assert.Equal(t, internal.UserAgent, recorder.header.Get("User-Agent"))
+	assert.Equal(t, internal.DefaultAuth0ClientInfo.Name, recorder.auth0Client(t).Name)
+}
+
+func TestNewSendsClientInfoWithCustomHTTPClientImplementation(t *testing.T) {
+	recorder := newHeaderRecorder(t)
+
+	httpClient := &doerHTTPClient{}
+	listClients(t, recorder, option.WithHTTPClient(httpClient))
+
+	assert.True(t, httpClient.called, "expected the custom client to issue the request")
+	assert.Equal(t, internal.UserAgent, recorder.header.Get("User-Agent"))
+	assert.Equal(t, internal.DefaultAuth0ClientInfo.Name, recorder.auth0Client(t).Name)
+}
+
+func TestNewSendsClientInfoEnvEntriesWithCustomHTTPClient(t *testing.T) {
+	recorder := newHeaderRecorder(t)
+
+	listClients(
+		t,
+		recorder,
+		option.WithHTTPClient(&http.Client{}),
+		option.WithAuth0ClientEnvEntry("terraform-provider-auth0", "1.0.0"),
+	)
+
+	assert.Equal(t, "1.0.0", recorder.auth0Client(t).Env["terraform-provider-auth0"])
+}
+
+func TestNewOmitsClientInfoWithCustomHTTPClient(t *testing.T) {
+	recorder := newHeaderRecorder(t)
+
+	listClients(t, recorder, option.WithHTTPClient(&http.Client{}), option.WithNoAuth0ClientInfo())
+
+	assert.Empty(t, recorder.header.Get("Auth0-Client"))
+	assert.Equal(t, internal.UserAgent, recorder.header.Get("User-Agent"))
+}
+
+func TestNewKeepsCustomHTTPClientTransport(t *testing.T) {
+	recorder := newHeaderRecorder(t)
+
+	httpClient := &http.Client{
+		Transport: internal.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			req.Header.Set("X-Custom-Transport", "called")
+
+			return http.DefaultTransport.RoundTrip(req)
+		}),
+	}
+
+	listClients(t, recorder, option.WithHTTPClient(httpClient))
+
+	assert.Equal(t, "called", recorder.header.Get("X-Custom-Transport"))
+	assert.Equal(t, internal.DefaultAuth0ClientInfo.Name, recorder.auth0Client(t).Name)
+}
+
+func TestNewDoesNotModifyCustomHTTPClient(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: &markerTransport{},
+		Timeout:   42 * time.Second,
+	}
+
+	m, err := New("example.com", option.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+
+	// The transports are layered onto a clone, so the caller's client is left alone.
+	assert.IsType(t, &markerTransport{}, httpClient.Transport)
+
+	// The clone keeps the settings of the client it was made from.
+	usedClient, ok := m.options.HTTPClient.(*http.Client)
+	require.True(t, ok, "expected an *http.Client to be used")
+	assert.Equal(t, 42*time.Second, usedClient.Timeout)
+	assert.NotSame(t, httpClient, usedClient)
+	assert.NotEqual(t, "*client.markerTransport", fmt.Sprintf("%T", usedClient.Transport))
 }


### PR DESCRIPTION
### 🔧 Changes

Passing a custom HTTP client to `client.New` silently dropped the SDK's telemetry headers. `Auth0-Client` was not sent at all, and `User-Agent` fell back to Go's default `Go-http-client/1.1` instead of `Go-Auth0/vX.Y.Z`. The custom domain header transport was dropped along with them.

The cause is option ordering. `New` built a wrapped `http.Client`, passed it as `option.WithHTTPClient(...)` in its base options, and then appended the caller's options after it. Since `HTTPClientOption` assigns rather than composes, a caller-supplied `WithHTTPClient` replaced the wrapped client and every transport layered onto it.

`New` now uses the caller's client as the base that the transports are layered onto:

- The caller's `WithHTTPClient` is taken out of the option list and used to build the base client, so it can no longer replace the wrapped client.
- The client is cloned before its transport is wrapped, so the caller's instance is not modified, and its `Timeout`, proxy, redirect, and transport settings are all preserved.
- The caller's own transport stays in the chain, with the SDK transports wrapped around it.
- A `core.HTTPClient` that is not an `*http.Client` is delegated to through a round tripper, so any `Do` implementation keeps the headers too.
- `WithNoAuth0ClientInfo` and `WithAuth0ClientEnvEntry` continue to work when combined with a custom client.

Also fixes a related detail in the same function: the `User-Agent` transport wrapped `http.DefaultClient.Transport` rather than the transport of the client being configured, so a base client's own transport was bypassed.

Behavior with no custom client is unchanged, and there are no public API changes.

```go
// Both the caller's transport and the SDK headers are now applied.
httpClient := &http.Client{Timeout: 10 * time.Second, Transport: myTracingTransport}

api, err := client.New(domain, option.WithHTTPClient(httpClient), option.WithToken(token))
```

### 🔬 Testing

Six unit tests were added in `management/client/management_test.go`, each asserting the headers a `httptest` server actually receives:

- `Auth0-Client` and `User-Agent` are sent with a custom `*http.Client`.
- The same holds for a `core.HTTPClient` that is not an `*http.Client`, and that client is the one issuing the request.
- `WithAuth0ClientEnvEntry` values appear in the decoded `Auth0-Client` payload alongside a custom client.
- `WithNoAuth0ClientInfo` suppresses only `Auth0-Client` and leaves `User-Agent` in place.
- A custom transport still runs, and the SDK headers are applied around it.
- The caller's client is not mutated, and the clone keeps its `Timeout`.

All six fail on `main` and pass with this change. `go build ./...` and `go vet` are clean, and the `management`, `management/client`, `management/internal`, `internal/...`, and root package tests pass.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
