### PR TITLE
feat: Added support for ThirdPartyClientAccess in V1 SDK [EA Only]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [Unreleased]
+
+**Added**
+- feat: add `ThirdPartyClientAccess` support to `MyOrganizationConfiguration` on `Client`, controlling whether third-party clients can access organizations created for the client through the My Organization API (Early Access). Note that `AllowedValues` is required whenever `ThirdPartyClientAccess` is set.
+
 ## [v1.47.0](https://github.com/auth0/go-auth0/tree/v1.47.0) (2026-08-13)
 [Full Changelog](https://github.com/auth0/go-auth0/compare/v1.46.0...v1.47.0)
 

--- a/management/client.go
+++ b/management/client.go
@@ -410,6 +410,24 @@ type MyOrganizationConfiguration struct {
 	// InvitationLandingClientID is the client ID used as the invitation landing page
 	// when creating invitations through the My Organization API.
 	InvitationLandingClientID *string `json:"invitation_landing_client_id,omitempty"`
+
+	// ThirdPartyClientAccess controls whether third-party clients can access organizations
+	// created for this client through the My Organization API.
+	ThirdPartyClientAccess *MyOrganizationThirdPartyClientAccess `json:"third_party_client_access,omitempty"`
+}
+
+// MyOrganizationThirdPartyClientAccess represents the third-party client access policy for
+// organizations created through the My Organization API.
+type MyOrganizationThirdPartyClientAccess struct {
+	// DefaultValue is the default third-party client access value applied to organizations
+	// created for this client. Currently the API only accepts "block"; "allow" is rejected
+	// with a 400 error.
+	DefaultValue *string `json:"default_value,omitempty"`
+
+	// AllowedValues is the list of third-party client access values that can be set on
+	// organizations created for this client through the My Organization API.
+	// Possible values: "allow", "block". Required whenever ThirdPartyClientAccess is set.
+	AllowedValues *[]string `json:"allowed_values,omitempty"`
 }
 
 // ClientTokenExchange allows configuration for token exchange.

--- a/management/client_test.go
+++ b/management/client_test.go
@@ -2140,6 +2140,54 @@ func TestClient_MyOrganizationConfiguration(t *testing.T) {
 	assert.Equal(t, "allow", readClient.GetMyOrganizationConfiguration().GetConnectionDeletionBehavior())
 }
 
+func TestClient_MyOrganizationConfigurationThirdPartyClientAccess(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	ctx := context.Background()
+
+	// Case: Create a client with third_party_client_access set to its only allowed default value.
+	clientWith := &Client{
+		Name:        auth0.Stringf("Test Client ThirdPartyClientAccess (%s)", time.Now().Format(time.StampMilli)),
+		Description: auth0.String("Client with my_organization_configuration.third_party_client_access."),
+		MyOrganizationConfiguration: &MyOrganizationConfiguration{
+			AllowedStrategies:          &[]string{"okta"},
+			ConnectionDeletionBehavior: auth0.String("allow"),
+			ThirdPartyClientAccess: &MyOrganizationThirdPartyClientAccess{
+				DefaultValue:  auth0.String("block"),
+				AllowedValues: &[]string{"allow", "block"},
+			},
+		},
+	}
+	err := api.Client.Create(ctx, clientWith)
+	require.NoError(t, err)
+	require.NotEmpty(t, clientWith.GetClientID())
+	t.Cleanup(func() {
+		cleanupClient(t, clientWith.GetClientID())
+	})
+
+	thirdPartyClientAccess := clientWith.GetMyOrganizationConfiguration().GetThirdPartyClientAccess()
+	require.NotNil(t, thirdPartyClientAccess)
+	assert.Equal(t, "block", thirdPartyClientAccess.GetDefaultValue())
+	assert.ElementsMatch(t, []string{"allow", "block"}, thirdPartyClientAccess.GetAllowedValues())
+
+	// Case: DefaultValue "allow" is rejected by the API, which only accepts "block" (400).
+	clientWithInvalidDefault := &Client{
+		Name: auth0.Stringf("Test Client ThirdPartyClientAccess Invalid Default (%s)", time.Now().Format(time.StampMilli)),
+		MyOrganizationConfiguration: &MyOrganizationConfiguration{
+			AllowedStrategies:          &[]string{"okta"},
+			ConnectionDeletionBehavior: auth0.String("allow"),
+			ThirdPartyClientAccess: &MyOrganizationThirdPartyClientAccess{
+				DefaultValue:  auth0.String("allow"),
+				AllowedValues: &[]string{"allow", "block"},
+			},
+		},
+	}
+	err = api.Client.Create(ctx, clientWithInvalidDefault)
+	require.Error(t, err)
+	assert.Implements(t, (*Error)(nil), err)
+	assert.Equal(t, http.StatusBadRequest, err.(Error).Status())
+}
+
 func givenAnExpressConfigurationClient(t *testing.T) *Client {
 	t.Helper()
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -10473,6 +10473,14 @@ func (m *MyOrganizationConfiguration) GetInvitationLandingClientID() string {
 	return *m.InvitationLandingClientID
 }
 
+// GetThirdPartyClientAccess returns the ThirdPartyClientAccess field.
+func (m *MyOrganizationConfiguration) GetThirdPartyClientAccess() *MyOrganizationThirdPartyClientAccess {
+	if m == nil {
+		return nil
+	}
+	return m.ThirdPartyClientAccess
+}
+
 // GetUserAttributeProfileID returns the UserAttributeProfileID field if it's non-nil, zero value otherwise.
 func (m *MyOrganizationConfiguration) GetUserAttributeProfileID() string {
 	if m == nil || m.UserAttributeProfileID == nil {
@@ -10483,6 +10491,27 @@ func (m *MyOrganizationConfiguration) GetUserAttributeProfileID() string {
 
 // String returns a string representation of MyOrganizationConfiguration.
 func (m *MyOrganizationConfiguration) String() string {
+	return Stringify(m)
+}
+
+// GetAllowedValues returns the AllowedValues field if it's non-nil, zero value otherwise.
+func (m *MyOrganizationThirdPartyClientAccess) GetAllowedValues() []string {
+	if m == nil || m.AllowedValues == nil {
+		return nil
+	}
+	return *m.AllowedValues
+}
+
+// GetDefaultValue returns the DefaultValue field if it's non-nil, zero value otherwise.
+func (m *MyOrganizationThirdPartyClientAccess) GetDefaultValue() string {
+	if m == nil || m.DefaultValue == nil {
+		return ""
+	}
+	return *m.DefaultValue
+}
+
+// String returns a string representation of MyOrganizationThirdPartyClientAccess.
+func (m *MyOrganizationThirdPartyClientAccess) String() string {
 	return Stringify(m)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -13098,6 +13098,13 @@ func TestMyOrganizationConfiguration_GetInvitationLandingClientID(tt *testing.T)
 	m.GetInvitationLandingClientID()
 }
 
+func TestMyOrganizationConfiguration_GetThirdPartyClientAccess(tt *testing.T) {
+	m := &MyOrganizationConfiguration{}
+	m.GetThirdPartyClientAccess()
+	m = nil
+	m.GetThirdPartyClientAccess()
+}
+
 func TestMyOrganizationConfiguration_GetUserAttributeProfileID(tt *testing.T) {
 	var zeroValue string
 	m := &MyOrganizationConfiguration{UserAttributeProfileID: &zeroValue}
@@ -13111,6 +13118,34 @@ func TestMyOrganizationConfiguration_GetUserAttributeProfileID(tt *testing.T) {
 func TestMyOrganizationConfiguration_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &MyOrganizationConfiguration{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestMyOrganizationThirdPartyClientAccess_GetAllowedValues(tt *testing.T) {
+	var zeroValue []string
+	m := &MyOrganizationThirdPartyClientAccess{AllowedValues: &zeroValue}
+	m.GetAllowedValues()
+	m = &MyOrganizationThirdPartyClientAccess{}
+	m.GetAllowedValues()
+	m = nil
+	m.GetAllowedValues()
+}
+
+func TestMyOrganizationThirdPartyClientAccess_GetDefaultValue(tt *testing.T) {
+	var zeroValue string
+	m := &MyOrganizationThirdPartyClientAccess{DefaultValue: &zeroValue}
+	m.GetDefaultValue()
+	m = &MyOrganizationThirdPartyClientAccess{}
+	m.GetDefaultValue()
+	m = nil
+	m.GetDefaultValue()
+}
+
+func TestMyOrganizationThirdPartyClientAccess_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &MyOrganizationThirdPartyClientAccess{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}

--- a/test/data/recordings/TestClient_MyOrganizationConfigurationThirdPartyClientAccess.yaml
+++ b/test/data/recordings/TestClient_MyOrganizationConfigurationThirdPartyClientAccess.yaml
@@ -1,0 +1,108 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 345
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client ThirdPartyClientAccess (Aug 26 17:32:29.453)","description":"Client with my_organization_configuration.third_party_client_access.","my_organization_configuration":{"allowed_strategies":["okta"],"connection_deletion_behavior":"allow","third_party_client_access":{"default_value":"block","allowed_values":["allow","block"]}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Test Client ThirdPartyClientAccess (Aug 26 17:32:29.453)","description":"Client with my_organization_configuration.third_party_client_access.","client_id":"I7EwZ84QCNypGQGzjqHG3QK0SD8Yhkln","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"my_organization_configuration":{"allowed_strategies":["okta"],"connection_deletion_behavior":"allow","third_party_client_access":{"default_value":"block","allowed_values":["allow","block"]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1.125675417s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 276
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Test Client ThirdPartyClientAccess Invalid Default (Aug 26 17:32:30.585)","my_organization_configuration":{"allowed_strategies":["okta"],"connection_deletion_behavior":"allow","third_party_client_access":{"default_value":"allow","allowed_values":["allow","block"]}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 298
+        uncompressed: false
+        body: '{"client_secret":"[REDACTED]","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 345.031583ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/clients/I7EwZ84QCNypGQGzjqHG3QK0SD8Yhkln
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 379.318625ms


### PR DESCRIPTION

# feat: add ThirdPartyClientAccess support to My Organization API (EA)

### 🔧 Changes

- Add `ThirdPartyClientAccess *MyOrganizationThirdPartyClientAccess` field to `MyOrganizationConfiguration` on `Client`, controlling whether third-party clients can access organizations created for the client through the My Organization API (Early Access).
- Add new `MyOrganizationThirdPartyClientAccess` type with `DefaultValue *string` and `AllowedValues *[]string`. `AllowedValues` is required whenever `ThirdPartyClientAccess` is set. Currently the API only accepts `"block"` for `DefaultValue`; `"allow"` is rejected with a 400.
- Add generated getters (`GetThirdPartyClientAccess`, `GetAllowedValues`, `GetDefaultValue`) and `String()` for the new type.

### 🔬 Testing

- Added `TestClient_MyOrganizationConfigurationThirdPartyClientAccess`, covering creating a client with a valid `ThirdPartyClientAccess` config and asserting the API rejects `DefaultValue: "allow"` with a 400.
- Added generated getter tests (`TestMyOrganizationConfiguration_GetThirdPartyClientAccess`, `TestMyOrganizationThirdPartyClientAccess_GetAllowedValues`, `TestMyOrganizationThirdPartyClientAccess_GetDefaultValue`, `TestMyOrganizationThirdPartyClientAccess_String`).
- New HTTP test recording added for the integration test.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)