### PR TITLE
feat: add HTTP message signature signal to Network ACL rule match (EA only)

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -10576,6 +10576,24 @@ func (n *NetworkACL) String() string {
 	return Stringify(n)
 }
 
+// String returns a string representation of NetworkACLHTTPMessageSignature.
+func (n *NetworkACLHTTPMessageSignature) String() string {
+	return Stringify(n)
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (n *NetworkACLHTTPMessageSignatureKey) GetID() string {
+	if n == nil || n.ID == nil {
+		return ""
+	}
+	return *n.ID
+}
+
+// String returns a string representation of NetworkACLHTTPMessageSignatureKey.
+func (n *NetworkACLHTTPMessageSignatureKey) String() string {
+	return Stringify(n)
+}
+
 // GetAction returns the Action field.
 func (n *NetworkACLRule) GetAction() *NetworkACLRuleAction {
 	if n == nil {
@@ -10712,6 +10730,14 @@ func (n *NetworkACLRuleMatch) GetHostnames() []string {
 		return nil
 	}
 	return *n.Hostnames
+}
+
+// GetHTTPMessageSignature returns the HTTPMessageSignature field.
+func (n *NetworkACLRuleMatch) GetHTTPMessageSignature() *NetworkACLHTTPMessageSignature {
+	if n == nil {
+		return nil
+	}
+	return n.HTTPMessageSignature
 }
 
 // GetIPv4Cidrs returns the IPv4Cidrs field if it's non-nil, zero value otherwise.

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -13226,6 +13226,32 @@ func TestNetworkACL_String(t *testing.T) {
 	}
 }
 
+func TestNetworkACLHTTPMessageSignature_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &NetworkACLHTTPMessageSignature{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestNetworkACLHTTPMessageSignatureKey_GetID(tt *testing.T) {
+	var zeroValue string
+	n := &NetworkACLHTTPMessageSignatureKey{ID: &zeroValue}
+	n.GetID()
+	n = &NetworkACLHTTPMessageSignatureKey{}
+	n.GetID()
+	n = nil
+	n.GetID()
+}
+
+func TestNetworkACLHTTPMessageSignatureKey_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &NetworkACLHTTPMessageSignatureKey{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
 func TestNetworkACLRule_GetAction(tt *testing.T) {
 	n := &NetworkACLRule{}
 	n.GetAction()
@@ -13391,6 +13417,13 @@ func TestNetworkACLRuleMatch_GetHostnames(tt *testing.T) {
 	n.GetHostnames()
 	n = nil
 	n.GetHostnames()
+}
+
+func TestNetworkACLRuleMatch_GetHTTPMessageSignature(tt *testing.T) {
+	n := &NetworkACLRuleMatch{}
+	n.GetHTTPMessageSignature()
+	n = nil
+	n.GetHTTPMessageSignature()
 }
 
 func TestNetworkACLRuleMatch_GetIPv4Cidrs(tt *testing.T) {

--- a/management/network_acl.go
+++ b/management/network_acl.go
@@ -77,6 +77,20 @@ type NetworkACLRuleMatch struct {
 	ConnectingIPv4Cidrs *[]string `json:"connecting_ipv4_cidrs,omitempty"`
 	// Connecting IPv6 CIDRs
 	ConnectingIPv6Cidrs *[]string `json:"connecting_ipv6_cidrs,omitempty"`
+	// HTTP Message Signature
+	HTTPMessageSignature *NetworkACLHTTPMessageSignature `json:"http_message_signature,omitempty"`
+}
+
+// NetworkACLHTTPMessageSignature : the http_message_signature signal of a Network ACL Rule Match.
+type NetworkACLHTTPMessageSignature struct {
+	// The keys whose signatures satisfy the rule.
+	Keys []*NetworkACLHTTPMessageSignatureKey `json:"keys,omitempty"`
+}
+
+// NetworkACLHTTPMessageSignatureKey : a reference to a Network ACL key by id.
+type NetworkACLHTTPMessageSignatureKey struct {
+	// The id of the referenced Network ACL key.
+	ID *string `json:"id,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds `http_message_signature` as a signal type in Network ACL rule matching.

**Updated type:**
- `NetworkACLRuleMatch` — gains an `HTTPMessageSignature` field

**New types:**
- `NetworkACLHTTPMessageSignature` — holds the list of keys whose signatures satisfy the rule
- `NetworkACLHTTPMessageSignatureKey` — references a Network ACL key by ID

**Usage example:**

```go
Rules: &[]*management.NetworkACLRule{
    {
        Match: &management.NetworkACLRuleMatch{
            HTTPMessageSignature: &management.NetworkACLHTTPMessageSignature{
                Keys: []*management.NetworkACLHTTPMessageSignatureKey{
                    {ID: auth0.String("key-id")},
                },
            },
        },
    },
}
```

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Unit tests added for all new generated accessor methods and `String()` implementations in `management/management.gen_test.go`.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
