### PR TITLE
feat: add OTP settings to connection options

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -540,11 +540,37 @@ type ConnectionOptions struct {
 
 	// The action to be triggered for Universal Custom Password
 	CustomPasswordHash *CustomPasswordHash `json:"custom_password_hash,omitempty"`
+
+	// OTPSettings configures one-time password settings per delivery channel.
+	// Only available for auth0 (database) strategy connections.
+	OTPSettings *ConnectionOptionsOTPSettings `json:"otp_settings,omitempty"`
 }
 
 // CustomPasswordHash defines the structure of custom password hash options.
 type CustomPasswordHash struct {
 	ActionID *string `json:"action_id,omitempty"`
+}
+
+// ConnectionOptionsOTPSettings configures one-time password settings for a
+// database (auth0 strategy) connection, per delivery channel.
+type ConnectionOptionsOTPSettings struct {
+	// Email holds the OTP settings for the email delivery channel.
+	Email *ConnectionOptionsOTPChannelSettings `json:"email,omitempty"`
+
+	// Phone holds the OTP settings for the phone delivery channel.
+	Phone *ConnectionOptionsOTPChannelSettings `json:"phone,omitempty"`
+}
+
+// ConnectionOptionsOTPChannelSettings configures the one-time password settings
+// for a single delivery channel of a ConnectionOptionsOTPSettings.
+type ConnectionOptionsOTPChannelSettings struct {
+	// OTPLength is the number of digits in the generated one-time password
+	// (min 4, max 48; defaults to 6 when unset).
+	OTPLength *int `json:"otp_length,omitempty"`
+
+	// OTPExpiry is the number of seconds before the one-time password expires
+	// (min 60, max 86400; defaults to 900 when unset).
+	OTPExpiry *int `json:"otp_expiry,omitempty"`
 }
 
 // ConnectionOptionsAttributes defines the structure for attribute configurations.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3341,6 +3341,14 @@ func (c *ConnectionOptions) GetNonPersistentAttrs() []string {
 	return *c.NonPersistentAttrs
 }
 
+// GetOTPSettings returns the OTPSettings field.
+func (c *ConnectionOptions) GetOTPSettings() *ConnectionOptionsOTPSettings {
+	if c == nil {
+		return nil
+	}
+	return c.OTPSettings
+}
+
 // GetPasskeyOptions returns the PasskeyOptions field.
 func (c *ConnectionOptions) GetPasskeyOptions() *PasskeyOptions {
 	if c == nil {
@@ -6217,6 +6225,48 @@ func (c *ConnectionOptionsOTP) GetTimeStep() int {
 
 // String returns a string representation of ConnectionOptionsOTP.
 func (c *ConnectionOptionsOTP) String() string {
+	return Stringify(c)
+}
+
+// GetOTPExpiry returns the OTPExpiry field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOTPChannelSettings) GetOTPExpiry() int {
+	if c == nil || c.OTPExpiry == nil {
+		return 0
+	}
+	return *c.OTPExpiry
+}
+
+// GetOTPLength returns the OTPLength field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOTPChannelSettings) GetOTPLength() int {
+	if c == nil || c.OTPLength == nil {
+		return 0
+	}
+	return *c.OTPLength
+}
+
+// String returns a string representation of ConnectionOptionsOTPChannelSettings.
+func (c *ConnectionOptionsOTPChannelSettings) String() string {
+	return Stringify(c)
+}
+
+// GetEmail returns the Email field.
+func (c *ConnectionOptionsOTPSettings) GetEmail() *ConnectionOptionsOTPChannelSettings {
+	if c == nil {
+		return nil
+	}
+	return c.Email
+}
+
+// GetPhone returns the Phone field.
+func (c *ConnectionOptionsOTPSettings) GetPhone() *ConnectionOptionsOTPChannelSettings {
+	if c == nil {
+		return nil
+	}
+	return c.Phone
+}
+
+// String returns a string representation of ConnectionOptionsOTPSettings.
+func (c *ConnectionOptionsOTPSettings) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -4084,6 +4084,13 @@ func TestConnectionOptions_GetNonPersistentAttrs(tt *testing.T) {
 	c.GetNonPersistentAttrs()
 }
 
+func TestConnectionOptions_GetOTPSettings(tt *testing.T) {
+	c := &ConnectionOptions{}
+	c.GetOTPSettings()
+	c = nil
+	c.GetOTPSettings()
+}
+
 func TestConnectionOptions_GetPasskeyOptions(tt *testing.T) {
 	c := &ConnectionOptions{}
 	c.GetPasskeyOptions()
@@ -7674,6 +7681,56 @@ func TestConnectionOptionsOTP_GetTimeStep(tt *testing.T) {
 func TestConnectionOptionsOTP_String(t *testing.T) {
 	var rawJSON json.RawMessage
 	v := &ConnectionOptionsOTP{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsOTPChannelSettings_GetOTPExpiry(tt *testing.T) {
+	var zeroValue int
+	c := &ConnectionOptionsOTPChannelSettings{OTPExpiry: &zeroValue}
+	c.GetOTPExpiry()
+	c = &ConnectionOptionsOTPChannelSettings{}
+	c.GetOTPExpiry()
+	c = nil
+	c.GetOTPExpiry()
+}
+
+func TestConnectionOptionsOTPChannelSettings_GetOTPLength(tt *testing.T) {
+	var zeroValue int
+	c := &ConnectionOptionsOTPChannelSettings{OTPLength: &zeroValue}
+	c.GetOTPLength()
+	c = &ConnectionOptionsOTPChannelSettings{}
+	c.GetOTPLength()
+	c = nil
+	c.GetOTPLength()
+}
+
+func TestConnectionOptionsOTPChannelSettings_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsOTPChannelSettings{}
+	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
+		t.Errorf("failed to produce a valid json")
+	}
+}
+
+func TestConnectionOptionsOTPSettings_GetEmail(tt *testing.T) {
+	c := &ConnectionOptionsOTPSettings{}
+	c.GetEmail()
+	c = nil
+	c.GetEmail()
+}
+
+func TestConnectionOptionsOTPSettings_GetPhone(tt *testing.T) {
+	c := &ConnectionOptionsOTPSettings{}
+	c.GetPhone()
+	c = nil
+	c.GetPhone()
+}
+
+func TestConnectionOptionsOTPSettings_String(t *testing.T) {
+	var rawJSON json.RawMessage
+	v := &ConnectionOptionsOTPSettings{}
 	if err := json.Unmarshal([]byte(v.String()), &rawJSON); err != nil {
 		t.Errorf("failed to produce a valid json")
 	}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds per-channel one-time password configuration to database (auth0 strategy) connection options.

- Adds `OTPSettings` to connection options, with separate `Email` and `Phone` delivery channels.
- Each channel exposes `OTPLength` and `OTPExpiry`.

```go
conn := &management.Connection{
	Name:     auth0.String("my-db-connection"),
	Strategy: auth0.String("auth0"),
	Options: &management.ConnectionOptions{
		OTPSettings: &management.ConnectionOptionsOTPSettings{
			Email: &management.ConnectionOptionsOTPChannelSettings{
				OTPLength: auth0.Int(8),
				OTPExpiry: auth0.Int(600),
			},
		},
	},
}
```

### 📚 References

### 🔬 Testing

- Adds generated unit tests covering the new accessor and `String` helpers.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
