### PR TITLE
feat: add `AcceptClientIDOnCreation` flag to TenantFlags

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -14370,6 +14370,14 @@ func (t *TenantErrorPage) String() string {
 	return Stringify(t)
 }
 
+// GetAcceptClientIDOnCreation returns the AcceptClientIDOnCreation field if it's non-nil, zero value otherwise.
+func (t *TenantFlags) GetAcceptClientIDOnCreation() bool {
+	if t == nil || t.AcceptClientIDOnCreation == nil {
+		return false
+	}
+	return *t.AcceptClientIDOnCreation
+}
+
 // GetAllowChangingEnableSSO returns the AllowChangingEnableSSO field if it's non-nil, zero value otherwise.
 func (t *TenantFlags) GetAllowChangingEnableSSO() bool {
 	if t == nil || t.AllowChangingEnableSSO == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -18006,6 +18006,16 @@ func TestTenantErrorPage_String(t *testing.T) {
 	}
 }
 
+func TestTenantFlags_GetAcceptClientIDOnCreation(tt *testing.T) {
+	var zeroValue bool
+	t := &TenantFlags{AcceptClientIDOnCreation: &zeroValue}
+	t.GetAcceptClientIDOnCreation()
+	t = &TenantFlags{}
+	t.GetAcceptClientIDOnCreation()
+	t = nil
+	t.GetAcceptClientIDOnCreation()
+}
+
 func TestTenantFlags_GetAllowChangingEnableSSO(tt *testing.T) {
 	var zeroValue bool
 	t := &TenantFlags{AllowChangingEnableSSO: &zeroValue}

--- a/management/tenant.go
+++ b/management/tenant.go
@@ -424,6 +424,10 @@ type TenantFlags struct {
 
 	// Removes alg property from jwks .well-known endpoint
 	RemoveAlgFromJWKS *bool `json:"remove_alg_from_jwks,omitempty"`
+
+	// If enabled, allows passing a client_id in the POST body when creating a
+	// client. Intended for migration and tenant-copy scenarios.
+	AcceptClientIDOnCreation *bool `json:"accept_client_id_on_creation,omitempty"`
 }
 
 // TenantUniversalLogin holds universal login settings.


### PR DESCRIPTION
## Summary

Adds the `accept_client_id_on_creation` tenant flag to the `TenantFlags` struct.

### Change

```go
// If enabled, allows passing a client_id in the POST body when creating a client.
// Used for migration and tenant-copy scenarios.
AcceptClientIDOnCreation *bool `json:"accept_client_id_on_creation,omitempty"`
```

### 📚 References
The Auth0 Management API supports an `accept_client_id_on_creation` tenant flag that, when enabled, allows consumers to specify a `client_id` in the POST `/api/v2/clients` payload. The returned client will have exactly that ID rather than an auto generated one.

