### PR TITLE
feat: match_all field support in network_acl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [Unreleased]
+
+**Added**
+- feat: add `MatchAll` field (`*bool`) to `NetworkACLRule`, enabling rules that match all requests without signal-based criteria, along with a generated `GetMatchAll()` accessor
+
 ## [v1.48.0](https://github.com/auth0/go-auth0/tree/v1.48.0) (2026-08-26)
 [Full Changelog](https://github.com/auth0/go-auth0/compare/v1.47.0...v1.48.0)
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -10592,6 +10592,14 @@ func (n *NetworkACLRule) GetMatch() *NetworkACLRuleMatch {
 	return n.Match
 }
 
+// GetMatchAll returns the MatchAll field if it's non-nil, zero value otherwise.
+func (n *NetworkACLRule) GetMatchAll() bool {
+	if n == nil || n.MatchAll == nil {
+		return false
+	}
+	return *n.MatchAll
+}
+
 // GetNotMatch returns the NotMatch field.
 func (n *NetworkACLRule) GetNotMatch() *NetworkACLRuleMatch {
 	if n == nil {

--- a/management/management.gen_test.go
+++ b/management/management.gen_test.go
@@ -13240,6 +13240,16 @@ func TestNetworkACLRule_GetMatch(tt *testing.T) {
 	n.GetMatch()
 }
 
+func TestNetworkACLRule_GetMatchAll(tt *testing.T) {
+	var zeroValue bool
+	n := &NetworkACLRule{MatchAll: &zeroValue}
+	n.GetMatchAll()
+	n = &NetworkACLRule{}
+	n.GetMatchAll()
+	n = nil
+	n.GetMatchAll()
+}
+
 func TestNetworkACLRule_GetNotMatch(tt *testing.T) {
 	n := &NetworkACLRule{}
 	n.GetNotMatch()

--- a/management/network_acl.go
+++ b/management/network_acl.go
@@ -33,6 +33,8 @@ type NetworkACLRule struct {
 	NotMatch *NetworkACLRuleMatch `json:"not_match,omitempty"`
 	// The scope of the Network ACL Rule
 	Scope *string `json:"scope,omitempty"`
+	// Whether the rule matches all requests
+	MatchAll *bool `json:"match_all,omitempty"`
 }
 
 // NetworkACLRuleAction : Network ACL Rule Action.

--- a/management/network_acl_test.go
+++ b/management/network_acl_test.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -9,6 +10,54 @@ import (
 
 	"github.com/auth0/go-auth0"
 )
+
+func TestNetworkACLRule_MatchAll_Marshal(t *testing.T) {
+	t.Run("marshal match_all true omits match field", func(t *testing.T) {
+		rule := &NetworkACLRule{
+			Action:   &NetworkACLRuleAction{Block: auth0.Bool(true)},
+			Scope:    auth0.String("authentication"),
+			MatchAll: auth0.Bool(true),
+		}
+		b, err := json.Marshal(rule)
+		assert.NoError(t, err)
+		assert.Contains(t, string(b), `"match_all":true`)
+		assert.NotContains(t, string(b), `"match"`)
+	})
+
+	t.Run("marshal nil MatchAll omits match_all key", func(t *testing.T) {
+		rule := &NetworkACLRule{
+			Action: &NetworkACLRuleAction{Block: auth0.Bool(true)},
+			Match:  &NetworkACLRuleMatch{GeoCountryCodes: &[]string{"US"}},
+			Scope:  auth0.String("authentication"),
+		}
+		b, err := json.Marshal(rule)
+		assert.NoError(t, err)
+		assert.NotContains(t, string(b), `"match_all"`)
+	})
+}
+
+func TestNetworkACLRule_MatchAll_Unmarshal(t *testing.T) {
+	t.Run("unmarshal match_all true sets MatchAll pointer", func(t *testing.T) {
+		raw := `{"action":{"block":true},"scope":"authentication","match_all":true}`
+
+		var rule NetworkACLRule
+		err := json.Unmarshal([]byte(raw), &rule)
+		assert.NoError(t, err)
+		assert.NotNil(t, rule.MatchAll)
+		assert.True(t, *rule.MatchAll)
+		assert.Nil(t, rule.Match)
+	})
+
+	t.Run("unmarshal signal-based rule leaves MatchAll nil", func(t *testing.T) {
+		raw := `{"action":{"block":true},"match":{"geo_country_codes":["US"]},"scope":"authentication"}`
+
+		var rule NetworkACLRule
+		err := json.Unmarshal([]byte(raw), &rule)
+		assert.NoError(t, err)
+		assert.Nil(t, rule.MatchAll)
+		assert.NotNil(t, rule.Match)
+	})
+}
 
 func TestNetworkACLManager_Create(t *testing.T) {
 	configureHTTPTestRecordings(t)
@@ -38,6 +87,36 @@ func TestNetworkACLManager_Create(t *testing.T) {
 	actualNetworkACL, err := api.NetworkACL.Read(context.Background(), expectedNetworkACL.GetID())
 	assert.NoError(t, err)
 	assert.Equal(t, expectedNetworkACL, actualNetworkACL)
+}
+
+func TestNetworkACLManager_CreateWithMatchAll(t *testing.T) {
+	configureHTTPTestRecordings(t)
+
+	expectedNetworkACL := &NetworkACL{
+		Description: auth0.String("some-description-match-all"),
+		Active:      auth0.Bool(true),
+		Priority:    auth0.Int(1),
+		Rule: &NetworkACLRule{
+			Action: &NetworkACLRuleAction{
+				Block: auth0.Bool(true),
+			},
+			MatchAll: auth0.Bool(true),
+			Scope:    auth0.String("authentication"),
+		},
+	}
+
+	err := api.NetworkACL.Create(context.Background(), expectedNetworkACL)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, expectedNetworkACL.GetID())
+	t.Cleanup(func() {
+		cleanupNetworkACL(t, expectedNetworkACL.GetID())
+	})
+
+	actualNetworkACL, err := api.NetworkACL.Read(context.Background(), expectedNetworkACL.GetID())
+	assert.NoError(t, err)
+	assert.NotNil(t, actualNetworkACL.Rule.MatchAll)
+	assert.True(t, actualNetworkACL.Rule.GetMatchAll())
+	assert.Nil(t, actualNetworkACL.Rule.Match)
 }
 
 func TestNetworkACLManager_CreateWithAuth0Managed(t *testing.T) {

--- a/test/data/recordings/TestNetworkACLManager_CreateWithMatchAll.yaml
+++ b/test/data/recordings/TestNetworkACLManager_CreateWithMatchAll.yaml
@@ -1,0 +1,105 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 147
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"description":"some-description-match-all","active":true,"priority":1,"rule":{"action":{"block":true},"scope":"authentication","match_all":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/network-acls
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 260
+        uncompressed: false
+        body: '{"description":"some-description-match-all","active":true,"priority":1,"rule":{"scope":"authentication","action":{"block":true},"match_all":true},"created_at":"2026-09-04T09:30:17.324Z","updated_at":"2026-09-04T09:30:17.324Z","id":"acl_jf67PDExRF2gtyvcvDBA1U"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 787.877166ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/network-acls/acl_jf67PDExRF2gtyvcvDBA1U
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"tenant_id":"go-auth0-dev.eu.auth0.com","description":"some-description-match-all","active":true,"priority":1,"rule":{"scope":"authentication","action":{"block":true},"match_all":true},"created_at":"2026-09-04T09:30:17.324Z","updated_at":"2026-09-04T09:30:17.324Z","deleted_at":null,"id":"acl_jf67PDExRF2gtyvcvDBA1U"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 383.181667ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: go-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://go-auth0-dev.eu.auth0.com/api/v2/network-acls/acl_jf67PDExRF2gtyvcvDBA1U
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 24
+        uncompressed: false
+        body: '{"code":204,"object":""}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 320.784167ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds `match_all` as an optional boolean field on `NetworkACLRule`, allowing a rule to match all requests without specifying any signal-based criteria.

**Updated type:**
- `NetworkACLRule` — gains a `MatchAll` field (`*bool`, `json:"match_all,omitempty"`)

**New accessor:**
- `(*NetworkACLRule).GetMatchAll() bool` — returns the dereferenced value, or `false` if the pointer is nil

**Usage example:**

```go
rule := &management.NetworkACLRule{
    Action: &management.NetworkACLRuleAction{
        Block: auth0.Bool(true),
    },
    Scope:    auth0.String("authentication"),
    MatchAll: auth0.Bool(true),
}
```

> **Note:** When `MatchAll` is set, `Match` and `NotMatch` should be omitted — the field is mutually exclusive with signal-based matching criteria. A nil `MatchAll` serialises as absent (`omitempty`), preserving full backward compatibility.

### 🔬 Testing

- Acceptance test `TestNetworkACLManager_CreateWithMatchAll` added with a recorded VCR cassette; confirms the Management API returns `"match_all":true` and no `"match"` key in the response.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
